### PR TITLE
chore: update version in discovery-search-app

### DIFF
--- a/examples/discovery-search-app/package.json
+++ b/examples/discovery-search-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "discovery-search-app",
-  "version": "5.0.0",
+  "version": "1.0.0",
   "description": "Discovery components example application used to showcase components in a full application",
   "license": "Apache-2.0",
   "author": "IBM Corp.",


### PR DESCRIPTION
#### What do these changes do/fix?

accidentally got up to `5.0.0` for some reason in the `discovery-search-app`

#### How do you test/verify these changes?

`npx lerna version` should no longer generate major version changes in the example app

#### Are there any breaking changes included in this pull request?

no
