### PR TITLE
fix(SearchResults): title fallback and footerbar value max length

### DIFF
--- a/packages/discovery-react-components/src/components/SearchResults/__fixtures__/searchResults.ts
+++ b/packages/discovery-react-components/src/components/SearchResults/__fixtures__/searchResults.ts
@@ -12,7 +12,7 @@ const searchResults: DiscoveryV2.QueryResponse = {
       result_metadata: {
         collection_id: COLLECTION_ID_1
       },
-      title: 'alternate title',
+      title: 'Alternate title',
       document_passages: [
         {
           passage_text:
@@ -28,7 +28,7 @@ const searchResults: DiscoveryV2.QueryResponse = {
       result_metadata: {
         collection_id: COLLECTION_ID_1
       },
-      title: 'alternate title',
+      title: 'Alternate title',
       document_passages: [
         {
           passage_text:
@@ -47,7 +47,7 @@ const searchResults: DiscoveryV2.QueryResponse = {
       extracted_metadata: {
         title: 'IBM_Analytics_Machine_Learning.pdf'
       },
-      title: 'alternate title',
+      title: 'Alternate title',
       text:
         '<em>Machine learning</em> trains a model from patterns in your data, exploring a space of possible models defined by parameters. If your parameter space is too big, you’ll overfit to your training data and train a model that doesn’t generalize beyond it. A detailed explanation requires more math, but as a rule you should keep your models as simple as possible.'
     },
@@ -56,7 +56,7 @@ const searchResults: DiscoveryV2.QueryResponse = {
       result_metadata: {
         collection_id: COLLECTION_ID_1
       },
-      title: 'alternate title',
+      title: 'Alternate title',
       extracted_metadata: {
         title: 'IBM_Analytics_Machine_Learning.pdf'
       }

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -113,6 +113,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
   if (result) {
     documentId = result.document_id;
   }
+
   const title = get(result, resultTitleField);
   const filename: string | undefined = get(result, 'extracted_metadata.filename');
 

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -109,13 +109,12 @@ export const Result: React.FunctionComponent<ResultProps> = ({
   const hasText = displayedText && !showTablesOnlyResults;
   const emptyResultContent = !(hasText || tableHtml);
 
-  let documentId;
-  if (result) {
-    documentId = result.document_id;
-  }
-
-  const title = get(result, resultTitleField);
+  const documentId: string | undefined = get(result, 'document_id');
   const filename: string | undefined = get(result, 'extracted_metadata.filename');
+  const userSelectedTitle: string | undefined = get(result, resultTitleField);
+  const title: string | undefined = userSelectedTitle
+    ? userSelectedTitle
+    : get(result, 'extracted_metadata.title') || filename || documentId;
 
   const searchResultClasses = [searchResultClass];
   if (isEqual(result, selectedResult.document)) {
@@ -194,11 +193,13 @@ export const Result: React.FunctionComponent<ResultProps> = ({
             <SkeletonText width={'30%'} data-testid="result-title-skeleton" />
           ) : (
             result && (
-              <div className={searchResultFooterTitleClass}>{title || filename || documentId}</div>
+              <div className={searchResultFooterTitleClass} title={title}>
+                {title}
+              </div>
             )
           )}
           {collectionName && (
-            <div className={searchResultFooterCollectionNameClass}>
+            <div className={searchResultFooterCollectionNameClass} title={collectionName}>
               {messages.collectionLabel} {collectionName}
             </div>
           )}

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
@@ -478,9 +478,13 @@ describe('<Result />', () => {
           result_metadata: {
             collection_id: '1'
           },
-          url: {
+          url1: {
             firstPart: 'ibm',
             secondPart: 'com'
+          },
+          url2: {
+            firstPart: 'cloud',
+            secondPart: 'ibm'
           }
         };
         const api = {
@@ -550,6 +554,78 @@ describe('<Result />', () => {
         wrapWithContext(<SearchResults resultTitleField="myTitle" />, api, context)
       );
       expect(getByText('my title')).toBeInTheDocument();
+    });
+
+    describe('but resultTitleField does not map to a value on the result object', () => {
+      describe('and we have a value at extracted_metadata.title', () => {
+        test('we display the value at extracted_metadata.title', () => {
+          (context.searchResponseStore!.data as DiscoveryV2.QueryResponse).results = [
+            {
+              document_id: 'some document_id',
+              result_metadata: {
+                collection_id: '1'
+              },
+              extracted_metadata: {
+                title: 'some title',
+                filename: 'some file name'
+              },
+              myTitle: 'my title'
+            }
+          ];
+          const api = {
+            setSelectedResult: jest.fn()
+          };
+          const { getByText } = render(
+            wrapWithContext(<SearchResults resultTitleField="doesNotExist" />, api, context)
+          );
+          expect(getByText('some title')).toBeInTheDocument();
+        });
+      });
+
+      describe('and we have a value only for filename and document_id', () => {
+        test('we display the filename', () => {
+          (context.searchResponseStore!.data as DiscoveryV2.QueryResponse).results = [
+            {
+              document_id: 'some document_id',
+              result_metadata: {
+                collection_id: '1'
+              },
+              extracted_metadata: {
+                filename: 'my file name'
+              },
+              myTitle: 'my title'
+            }
+          ];
+          const api = {
+            setSelectedResult: jest.fn()
+          };
+          const { getByText } = render(
+            wrapWithContext(<SearchResults resultTitleField="doesNotExist" />, api, context)
+          );
+          expect(getByText('my file name')).toBeInTheDocument();
+        });
+      });
+
+      describe('and we have a value only for document_id', () => {
+        test('we display document_id', () => {
+          (context.searchResponseStore!.data as DiscoveryV2.QueryResponse).results = [
+            {
+              document_id: 'some document_id',
+              result_metadata: {
+                collection_id: '1'
+              },
+              myTitle: 'my title'
+            }
+          ];
+          const api = {
+            setSelectedResult: jest.fn()
+          };
+          const { getByText } = render(
+            wrapWithContext(<SearchResults resultTitleField="doesNotExist" />, api, context)
+          );
+          expect(getByText('some document_id')).toBeInTheDocument();
+        });
+      });
     });
   });
 

--- a/packages/discovery-react-components/src/components/SearchResults/utils/getDisplaySettings.ts
+++ b/packages/discovery-react-components/src/components/SearchResults/utils/getDisplaySettings.ts
@@ -7,9 +7,7 @@ export const getDisplaySettings = (
   componentSettings: DiscoveryV2.ComponentSettingsResponse | null = null
 ): Required<Pick<SearchResultsProps, 'resultTitleField' | 'bodyField' | 'usePassages'>> => {
   return {
-    resultTitleField:
-      params.resultTitleField ||
-      get(componentSettings, 'fields_shown.title.field', 'extracted_metadata.title'),
+    resultTitleField: params.resultTitleField || get(componentSettings, 'fields_shown.title.field'),
     bodyField: params.bodyField || get(componentSettings, 'fields_shown.body.field', 'text'),
     usePassages:
       params.usePassages === undefined

--- a/packages/discovery-styles/scss/components/search-results/_search-results.scss
+++ b/packages/discovery-styles/scss/components/search-results/_search-results.scss
@@ -171,15 +171,28 @@ $result-table-fade-offset: calc(#{$result-element-max-height} - #{$result-table-
   color: $gray-60;
   font-size: $spacing-sm;
   display: flex;
-  align-items: center;
   justify-content: space-between;
 }
 
 .#{$prefix}--search-result__footer__title {
-  align-items: center;
-  display: flex;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  margin-right: $spacing-05;
 
-  svg {
-    margin-right: $spacing-03;
+  &:hover {
+    overflow: visible;
+    white-space: normal;
+  }
+}
+
+.#{$prefix}--search-result__footer__collection-name {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  &:hover {
+    overflow: visible;
+    white-space: normal;
   }
 }


### PR DESCRIPTION
#### What do these changes do/fix?
This changes the result title fallback. Also this will make it so that result titles and collection names will be cut off with `...` if they begin to overflow. See this gif

![hover-title](https://user-images.githubusercontent.com/10775718/70186910-f1856200-16ba-11ea-9f12-7aafc2087114.gif)

<!--
If there's a related issue, please add a link to the issue here.
-->
related to issue: https://github.ibm.com/Watson-Discovery/disco-widgets/issues/423 and https://github.ibm.com/Watson-Discovery/wd-issues/issues/1180

#### How do you test/verify these changes?
You can test this by starting storybook and changing the value of `title` to be any large value inside of `packages/discovery-react-components/src/components/SearchResults/__fixtures__/searchResults.ts`. Next open the SearchResults component and change the value of `resultTitleField` to be `title`. The title being displayed should be cutoff and `...` should be appended. You can do the same with `name` inside of `collectionsResponse.ts`

Also see the description of https://github.ibm.com/Watson-Discovery/wd-issues/issues/1180
and the new unit tests added to confirm new fallback functionality

#### Have you documented your changes (if necessary)?
I figured in-depth documentation like this for components will live in the storybook docs add-on

#### Are there any breaking changes included in this pull request?
No

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
