### PR TITLE
fix: add name and about YAML to ISSUE_TEMPLATEs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,7 +4,6 @@ about: Create a report to help us improve
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,12 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!--
 Use this template if you want to report a bug or problem.
 

--- a/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-or-enhancement.md
@@ -1,3 +1,12 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
 <!--
 Use this template if you want to request a new feature, or a change to an existing feature.
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -4,7 +4,6 @@ about: Ask a question or start a discussion about this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 <!--

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,4 +1,15 @@
-Please use this template to ask a question about Discovery Components and its usage.
+---
+name: Question
+about: Ask a question or start a discussion about this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+Use this template to ask a question or start a discussion about Discovery Components and its usage.
+-->
 
 #### Description of question
 


### PR DESCRIPTION
#### What do these changes do/fix?
This adds `name` and `about` to our ISSUE_TEMPLATEs so that they will show up as options when new issues are created.

#### How do you test/verify these changes?
See that this is the requirement specified here: https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No
