### PR TITLE
fix: cidocument test quickfix

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
@@ -29,6 +29,7 @@ describe('<CIDocument />', () => {
   });
 
   it('renders without crashing', async () => {
+    jest.setTimeout(10000);
     await waitForElement(() =>
       // check for (partial) document text
       getByText('On 22 December 2008 ART EFFECTS LIMITED and Customer', { exact: false })


### PR DESCRIPTION
#### What do these changes do/fix?

This is a quick fix change to the CIDocument test, to prevent it from failing.  The default timeout for jest is 5000, which doesn't seem to be enough time to pass the test consistently.  This changes the timeout to 10000

#### How do you test/verify these changes?

Run `yarn test` and see that the CIDocument test `renders without crashing` passes.

