### PR TITLE
fix: cidocument test issue

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
@@ -8,7 +8,9 @@ import {
   getByLabelText as globalGetByLabelText,
   BoundFunction,
   GetAllBy,
-  GetByText
+  GetByText,
+  FindByText,
+  cleanup
 } from '@testing-library/react';
 import 'components/CIDocument/utils/test/createRange.mock';
 import CIDocument from '../CIDocument';
@@ -18,28 +20,18 @@ describe('<CIDocument />', () => {
   let getAllByRole: BoundFunction<GetAllBy<any[]>>,
     getByTestId: BoundFunction<GetByText>,
     getByText: BoundFunction<GetByText>,
-    getByTitle: BoundFunction<GetByText>;
+    getByTitle: BoundFunction<GetByText>,
+    findByText: BoundFunction<FindByText>;
 
   beforeEach(() => {
     act(() => {
-      ({ getAllByRole, getByTestId, getByText, getByTitle } = render(
+      ({ getAllByRole, getByTestId, getByText, getByTitle, findByText } = render(
         <CIDocument document={contract} overrideDocWidth={400} overrideDocHeight={600} />
       ));
     });
   });
 
-  it('renders without crashing', async () => {
-    jest.setTimeout(10000);
-    await waitForElement(() =>
-      // check for (partial) document text
-      getByText('On 22 December 2008 ART EFFECTS LIMITED and Customer', { exact: false })
-    );
-    // check for file name
-    getByText('Art Effects Koya Creative Base TSA 2008.pdf');
-    // check for a filter name
-    const filters = getByTestId('Filters');
-    globalGetByText(filters, 'Amendments');
-  });
+  afterEach(cleanup);
 
   it('filters and navigates forward through the list of elements', async () => {
     const filterCheckbox = await waitForElement(() => {
@@ -77,5 +69,15 @@ describe('<CIDocument />', () => {
 
     fireEvent.click(previousButton);
     globalGetByText(nav, '95 / 96');
+  });
+
+  it('renders without crashing', async () => {
+    // check for (partial) document text
+    findByText('On 22 December 2008 ART EFFECTS LIMITED and Customer', { exact: false });
+    // check for file name
+    getByText('Art Effects Koya Creative Base TSA 2008.pdf');
+    // check for a filter name
+    const filters = getByTestId('Filters');
+    globalGetByText(filters, 'Amendments');
   });
 });

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
@@ -9,8 +9,7 @@ import {
   BoundFunction,
   GetAllBy,
   GetByText,
-  FindByText,
-  cleanup
+  FindByText
 } from '@testing-library/react';
 import 'components/CIDocument/utils/test/createRange.mock';
 import CIDocument from '../CIDocument';
@@ -30,8 +29,6 @@ describe('<CIDocument />', () => {
       ));
     });
   });
-
-  afterEach(cleanup);
 
   it('filters and navigates forward through the list of elements', async () => {
     const filterCheckbox = await waitForElement(() => {


### PR DESCRIPTION
#### What do these changes do/fix?

Fixes the CIDocument test to account for future dependency changes

#### How do you test/verify these changes?

In discovery-react-components:
 run `yarn test` and see that all tests pass
