### PR TITLE
chore: fix postversion command

### DIFF
--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -23,7 +23,7 @@
     "analyze": "source-map-explorer 'dist/index.js'",
     "prepublish": "yarn run build",
     "preversion": "yarn run storybook:build:release",
-    "postversion": "git add ../../docs && git commit --amend --no-edit"
+    "version": "git add ../../docs"
   },
   "files": [
     "dist"


### PR DESCRIPTION
#### What do these changes do/fix?

we weren't getting tags published due to a `git commit --amend` in the `postversion` lifecycle hook. this throws off the tagging branch and discards the tags.

this SO explains the problem https://stackoverflow.com/questions/34891663/how-to-update-the-git-tag-automatically-when-i-do-a-commit-amend/34892535#34892535

instead we should just `git add` files from the storybook build into the `version` lifecycle hook so that we don't delete tags

#### How do you test/verify these changes?

```
npx lerna version --conventional-prerelease --preid beta --dist-tag beta --no-push
```
^ adding `--no-push` let's you test the command without pushing to the repo accidentally

this should add tags to the repo again

#### Have you documented your changes (if necessary)?

N/A

#### Are there any breaking changes included in this pull request?

No