### PR TITLE
fix: pr to add PR13 into janFixpack branch

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -34,10 +34,18 @@ import {
 } from '../../../../utils/document/nonContractUtils';
 import { withErrorBoundary, WithErrorBoundaryProps } from '../../../../utils/hoc/withErrorBoundary';
 import { Filter, FilterGroup, FilterChangeArgs } from '../FilterPanel/types';
-import { EnrichedHtml, Contract } from '../../types';
-import { MetadataData, Address, Mention } from '../MetadataPane/types';
+import {
+  Metadata,
+  MetadataData,
+  EnrichedHtml,
+  Contract,
+  Item,
+  Field,
+  Attributes,
+  Relations
+} from 'components/CIDocument/types';
+import { Address, Mention } from '../MetadataPane/types';
 import { Items } from '../DetailsPane/types';
-import { Item, Field } from '../../types';
 import { defaultTheme, Theme } from '../../../../utils/theme';
 import {
   defaultMessages as detailsPaneDefaultMsgs,
@@ -82,6 +90,9 @@ interface State {
     byItem: any;
     bySection: any;
   };
+  metadata: Metadata[];
+  attributes: Attributes[];
+  relations: Relations[];
 }
 
 enum ActionType {
@@ -99,7 +110,10 @@ const INITIAL_STATE: State = {
   isError: false,
   styles: [],
   sections: [],
-  itemMap: { byItem: {}, bySection: {} }
+  itemMap: { byItem: {}, bySection: {} },
+  metadata: [],
+  attributes: [],
+  relations: []
 };
 
 const RELATIONS = 'relations';
@@ -161,11 +175,11 @@ const CIDocument: FC<CIDocumentProps> = ({
   const [selectedContractFilter, setSelectedContractFilter] = useState(FILTERS);
 
   const enrichment = get(enrichedHtml, enrichmentName, {});
-  const { elements = [], metadata = [], parties = [] }: Contract = enrichment;
+  const { elements = [], parties = [] }: Contract = enrichment;
 
   let itemList = elements;
   if (isInvoiceOrPurchaseOrder(enrichmentName)) {
-    itemList = get(enrichment, selectedType, []);
+    itemList = state[selectedType] || [];
   }
 
   const resetTabs = (): void => {
@@ -190,7 +204,14 @@ const CIDocument: FC<CIDocumentProps> = ({
           const doc = await processDoc(document, { sections: true, itemMap: true });
           dispatch({
             type: ActionType.SET,
-            data: { styles: doc.styles, sections: doc.sections, itemMap: doc.itemMap }
+            data: {
+              styles: doc.styles,
+              sections: doc.sections,
+              itemMap: doc.itemMap,
+              metadata: doc.metadata,
+              attributes: doc.attributes,
+              relations: doc.relations
+            }
           });
         } catch (err) {
           dispatch({ type: ActionType.ERROR, data: err });
@@ -343,7 +364,7 @@ const CIDocument: FC<CIDocumentProps> = ({
             <Tab tabIndex={0} label={messages.metadataTabLabel}>
               {!hasError && (
                 <MetadataPane
-                  metadata={metadata}
+                  metadata={state.metadata}
                   activeMetadataId={activeMetadataIds[0]}
                   parties={parties}
                   messages={messages}

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -43,7 +43,7 @@ import {
   Field,
   Attributes,
   Relations
-} from 'components/CIDocument/types';
+} from '../../types';
 import { Address, Mention } from '../MetadataPane/types';
 import { Items } from '../DetailsPane/types';
 import { defaultTheme, Theme } from '../../../../utils/theme';

--- a/packages/discovery-react-components/src/components/CIDocument/types.ts
+++ b/packages/discovery-react-components/src/components/CIDocument/types.ts
@@ -1,4 +1,14 @@
-import { Metadata, MetadataData } from '../CIDocument/components/MetadataPane/types';
+export interface Metadata {
+  metadataType: string;
+  data: MetadataData[];
+}
+
+export interface MetadataData extends Item {
+  text: string;
+  text_normalized: string;
+  confidence_level: 'High' | 'Medium' | 'Low';
+  metadataType?: string;
+}
 
 export interface Location {
   begin: number;

--- a/packages/discovery-react-components/src/utils/document/__tests__/processDoc.spec.tsx
+++ b/packages/discovery-react-components/src/utils/document/__tests__/processDoc.spec.tsx
@@ -5,6 +5,10 @@ import parser from 'fast-xml-parser';
 import processDoc, { ProcessedDoc } from '../processDoc';
 import contractData from '../__fixtures__/contract.json';
 import escapedCharData from '../__fixtures__/escaped_char_document.json';
+import invoiceData from 'components/CIDocument/components/CIDocument/__fixtures__/invoice-index_op.json';
+import get from 'lodash/get';
+import cloneDeep from 'lodash/cloneDeep';
+import isEqual from 'lodash/isEqual';
 
 expect.extend({
   toBeValidXml(received): any {
@@ -110,5 +114,27 @@ describe('processDoc', () => {
 
       getByText(test, { exact: false });
     });
+  });
+});
+
+describe('processDoc', () => {
+  const clonedData = cloneDeep(contractData.results[0]);
+
+  beforeAll(async () => {
+    // parse doc for use in tests
+    await processDoc(clonedData, { sections: true });
+  });
+
+  it('does not mutate the passed contracts data and metadata is not be present in original data', () => {
+    expect(isEqual(clonedData, contractData.results[0])).toBeTruthy();
+    expect(get(contractData.results[0], 'enriched_html[0].contract.metadata')).toBeUndefined();
+  });
+
+  it('does not mutate the passed document data and attributes and relations properties are not present in the original data', async () => {
+    const clonedInvoiceData = cloneDeep(invoiceData);
+    await processDoc(clonedInvoiceData, { sections: true });
+    expect(isEqual(clonedInvoiceData, invoiceData)).toBeTruthy();
+    expect(get(invoiceData, 'enriched_html[0].invoice.attributes')).toBeUndefined();
+    expect(get(invoiceData, 'enriched_html[0].invoice.relations')).toBeUndefined();
   });
 });

--- a/packages/discovery-react-components/src/utils/document/__tests__/processDoc.spec.tsx
+++ b/packages/discovery-react-components/src/utils/document/__tests__/processDoc.spec.tsx
@@ -5,7 +5,7 @@ import parser from 'fast-xml-parser';
 import processDoc, { ProcessedDoc } from '../processDoc';
 import contractData from '../__fixtures__/contract.json';
 import escapedCharData from '../__fixtures__/escaped_char_document.json';
-import invoiceData from 'components/CIDocument/components/CIDocument/__fixtures__/invoice-index_op.json';
+import invoiceData from '../../../components/CIDocument/components/CIDocument/__fixtures__/invoice-index_op.json';
 import get from 'lodash/get';
 import cloneDeep from 'lodash/cloneDeep';
 import isEqual from 'lodash/isEqual';


### PR DESCRIPTION
#### What do these changes do/fix?

No longer add any data to the document input JSON object. - Duplicate of PR 13 
https://github.com/watson-developer-cloud/discovery-components/pull/13  - to add that in januaryfixpack branch. 

https://github.ibm.com/Watson-Discovery/docviz-squad-issue-tracker/issues/195
https://github.ibm.com/Watson-Discovery/wd-issues/issues/1365

#### How do you test/verify these changes?

Linked this repo up to `discovery-tooling` and saw that these changes fixed the issue noted above (and in the linked issues).

#### Have you documented your changes (if necessary)?

N/A

#### Are there any breaking changes included in this pull request?

No
