### PR TITLE
feat: implement fields api and use it in StructuredQuery

### DIFF
--- a/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
@@ -5,12 +5,12 @@ import DiscoverySearch, {
   SearchApi,
   SearchContext
 } from '../DiscoverySearch';
-import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import { createDummyResponsePromise } from 'utils/testingUtils';
+import { SearchClient } from '../types';
 interface Setup {
   fullTree: JSX.Element;
   result: RenderResult;
-  searchClient: Pick<DiscoveryV2, 'query' | 'getAutocompletion' | 'listCollections'>;
+  searchClient: SearchClient;
 }
 
 const setup = (props: Partial<DiscoverySearchProps>, children: JSX.Element): Setup => {
@@ -25,6 +25,9 @@ const setup = (props: Partial<DiscoverySearchProps>, children: JSX.Element): Set
       return createDummyResponsePromise({});
     }
     getComponentSettings() {
+      return createDummyResponsePromise({});
+    }
+    listFields() {
       return createDummyResponsePromise({});
     }
   }
@@ -316,6 +319,26 @@ describe('DiscoverySearch', () => {
         projectId: '',
         prefix: 'foo',
         count: 1
+      });
+    });
+
+    it('can call fetchFields', async () => {
+      const tree = (
+        <SearchApi.Consumer>
+          {({ fetchFields }) => <button onClick={() => fetchFields()}>Action</button>}
+        </SearchApi.Consumer>
+      );
+      const {
+        result: { getByText },
+        searchClient
+      } = setup({}, tree);
+      const spy = jest.spyOn(searchClient, 'listFields');
+      expect(spy).not.toHaveBeenCalled();
+      act(() => {
+        fireEvent.click(getByText('Action'));
+      });
+      expect(spy).toHaveBeenCalledWith({
+        projectId: ''
       });
     });
   });

--- a/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
@@ -2,5 +2,5 @@ import DiscoveryV2 from 'ibm-watson/discovery/v2';
 
 export type SearchClient = Pick<
   DiscoveryV2,
-  'query' | 'getAutocompletion' | 'listCollections' | 'getComponentSettings'
+  'query' | 'getAutocompletion' | 'listCollections' | 'getComponentSettings' | 'listFields'
 >;

--- a/packages/discovery-react-components/src/components/StructuredQuery/StructuredQuery.tsx
+++ b/packages/discovery-react-components/src/components/StructuredQuery/StructuredQuery.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useState, useContext, useEffect } from 'react';
 import { RuleGroup } from './components/RuleGroup/RuleGroup';
 import { AddRuleRowButton } from './components/AddRuleRowButton/AddRuleRowButton';
 import { AddRuleGroupButton } from './components/AddRuleGroupButton/AddRuleGroupButton';
@@ -9,6 +9,7 @@ import { StructuredQuerySelection } from './utils/structuredQueryInterfaces';
 import { withErrorBoundary } from 'react-error-boundary';
 import { FallbackComponent } from 'utils/FallbackComponent';
 import onErrorCallback from 'utils/onErrorCallback';
+import { SearchApi } from 'components/DiscoverySearch/DiscoverySearch';
 
 export interface StructuredQueryProps {
   /**
@@ -32,6 +33,11 @@ const StructuredQuery: FC<StructuredQueryProps> = ({ messages = defaultMessages 
     structuredQuerySelection.groups[0].rows.length < MAX_NUM_SIBLING_RULE_ROWS;
   const showAddRuleGroupButton =
     Object.keys(structuredQuerySelection.groups).length - 1 < MAX_NUM_NESTED_RULE_GROUPS;
+
+  const { fetchFields } = useContext(SearchApi);
+  useEffect(() => {
+    fetchFields();
+  }, [fetchFields]);
 
   return (
     <div className={structuredQueryClass}>

--- a/packages/discovery-react-components/src/components/StructuredQuery/__stories__/StructuredQuery.stories.tsx
+++ b/packages/discovery-react-components/src/components/StructuredQuery/__stories__/StructuredQuery.stories.tsx
@@ -7,13 +7,25 @@ import StructuredQuery from '../StructuredQuery';
 import { defaultMessages } from '../messages';
 import marked from 'marked';
 import defaultReadme from './default.md';
+import { createDummyResponsePromise } from 'utils/testingUtils';
+import DiscoveryV2 from 'ibm-watson/discovery/v2';
+import { action } from '@storybook/addon-actions';
 
 const props = () => ({
   messages: object("Default messages for the component's text strings", defaultMessages)
 });
 
+class DummySearchClientReturnsFields extends DummySearchClient {
+  public async listFields(fetchFieldsParams: DiscoveryV2.ListFieldsParams): Promise<any> {
+    action('listFields')(fetchFieldsParams);
+    return createDummyResponsePromise({
+      fields: [{ field: 'field name 1' }, { field: 'field name 2' }]
+    });
+  }
+}
+
 const discoverySearchProps = (): DiscoverySearchProps => ({
-  searchClient: new DummySearchClient(),
+  searchClient: new DummySearchClientReturnsFields(),
   projectId: text('Project ID', 'project-id')
 });
 

--- a/packages/discovery-react-components/src/components/StructuredQuery/components/RuleRow/RuleRow.tsx
+++ b/packages/discovery-react-components/src/components/StructuredQuery/components/RuleRow/RuleRow.tsx
@@ -1,9 +1,11 @@
-import React, { FC, Dispatch, SetStateAction } from 'react';
+import React, { FC, Dispatch, SetStateAction, useContext } from 'react';
 import { ComboBox, TextInput } from 'carbon-components-react';
 import { RemoveRuleRowButton } from '../RemoveRuleRowButton/RemoveRuleRowButton';
 import { Messages } from 'components/StructuredQuery/messages';
 import { structuredQueryRulesClass } from 'components/StructuredQuery/cssClasses';
 import { StructuredQuerySelection } from 'components/StructuredQuery/utils/structuredQueryInterfaces';
+import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
+import { getFieldNames } from 'components/StructuredQuery/utils/getFieldNames';
 
 export interface RuleRowProps {
   /**
@@ -35,6 +37,11 @@ export const RuleRow: FC<RuleRowProps> = ({
   structuredQuerySelection,
   setStructuredQuerySelection
 }) => {
+  const {
+    fieldsStore: { data: fieldsResponse, isLoading: fieldStoreLoading, isError: fieldStoreError }
+  } = useContext(SearchContext);
+  const projectFields: string[] = getFieldNames(fieldsResponse);
+
   const operatorDropdownItems = [
     { label: messages.operatorDropdownIsOptionText, value: '::' },
     { label: messages.operatorDropdownIsNotOptionText, value: '::!' },
@@ -45,15 +52,24 @@ export const RuleRow: FC<RuleRowProps> = ({
   const showRemoveRuleRowButton =
     structuredQuerySelection.groups[groupId].rows.length > 1 || !isTopLevelGroup;
 
+  let placeholderText: string;
+  if (fieldStoreLoading) {
+    placeholderText = messages.fieldDropdownLoadingText;
+  } else if (fieldStoreError) {
+    placeholderText = messages.fieldDropdownErrorText;
+  } else {
+    placeholderText = messages.fieldDropdownPlaceholderText;
+  }
+
   return (
     <div className={structuredQueryRulesClass} data-testid={`rule-row-${groupId}`}>
       <ComboBox
         id={`structured-query-rules-field-${groupId}`}
-        // TODO: Items is empty for now as it's a required field and retrieving fields for the dropdown
-        // and adding them as items will be addressed in a future issue
-        items={[]}
-        placeholder={messages.fieldDropdownPlaceholderText}
+        items={projectFields}
+        placeholder={placeholderText}
         titleText={messages.fieldDropdownTitleText}
+        disabled={fieldStoreLoading || fieldStoreError}
+        onChange={() => {}} // TODO make use of this param as well as 'selectedItem' to make this component controlled and start assembling queries with the dropdown selections
       />
       <ComboBox
         id={`structured-query-rules-operator-${groupId}`}

--- a/packages/discovery-react-components/src/components/StructuredQuery/messages.ts
+++ b/packages/discovery-react-components/src/components/StructuredQuery/messages.ts
@@ -25,6 +25,14 @@ export interface Messages {
    */
   fieldDropdownTitleText: string;
   /**
+   * override the default text to display when projectFields are being fetched
+   */
+  fieldDropdownLoadingText: string;
+  /**
+   * override the default text to display when there was an error loading project fields
+   */
+  fieldDropdownErrorText: string;
+  /**
    * override the default placeholder text for the Operator dropdown
    */
   operatorDropdownPlaceholderText: string;
@@ -77,6 +85,8 @@ export const defaultMessages: Messages = {
   ruleGroupDropdownLabelText: 'Choose whether to satisfy all or any of the following rules',
   fieldDropdownPlaceholderText: 'Select field',
   fieldDropdownTitleText: 'Field',
+  fieldDropdownLoadingText: 'Loading project fields',
+  fieldDropdownErrorText: 'Error loading project fields',
   operatorDropdownIsOptionText: 'is',
   operatorDropdownIsNotOptionText: 'is not',
   operatorDropdownContainsOptionText: 'contains',

--- a/packages/discovery-react-components/src/components/StructuredQuery/utils/__tests__/getFieldNames.test.ts
+++ b/packages/discovery-react-components/src/components/StructuredQuery/utils/__tests__/getFieldNames.test.ts
@@ -1,0 +1,39 @@
+import { getFieldNames } from '../getFieldNames';
+
+function matchingArrays(array1: string[], array2: string[]): boolean {
+  return array1.toString() === array2.toString();
+}
+
+describe('getFieldNames', () => {
+  describe('when given non nested fields', () => {
+    it('returns the correct field names', () => {
+      const fields = { fields: [{ field: 'fieldname 1' }, { field: 'fieldname 2' }] };
+      const fieldNames = getFieldNames(fields);
+      expect(matchingArrays(fieldNames, ['fieldname 1', 'fieldname 2'])).toBe(true);
+    });
+  });
+
+  describe('when given fields that are of type nested', () => {
+    it('does not return the nested fields', () => {
+      const fields = {
+        fields: [
+          { field: 'fieldname 1' },
+          { field: 'fieldname 2' },
+          { field: 'fieldname 3', type: 'nested' }
+        ]
+      };
+      const fieldNames = getFieldNames(fields);
+      expect(matchingArrays(fieldNames, ['fieldname 1', 'fieldname 2'])).toBe(true);
+    });
+  });
+
+  describe('when given an array of fields containing duplicate field names', () => {
+    it('returns a deduplicated array of field names', () => {
+      const fields = {
+        fields: [{ field: 'fieldname 1' }, { field: 'fieldname 2' }, { field: 'fieldname 2' }]
+      };
+      const fieldNames = getFieldNames(fields);
+      expect(matchingArrays(fieldNames, ['fieldname 1', 'fieldname 2'])).toBe(true);
+    });
+  });
+});

--- a/packages/discovery-react-components/src/components/StructuredQuery/utils/getFieldNames.ts
+++ b/packages/discovery-react-components/src/components/StructuredQuery/utils/getFieldNames.ts
@@ -1,0 +1,17 @@
+import DiscoveryV2 from 'ibm-watson/discovery/v2';
+
+export const getFieldNames = (response: DiscoveryV2.ListFieldsResponse | null): string[] => {
+  if (response && response.fields) {
+    const fieldObjects = response.fields;
+    const fieldNames = fieldObjects.reduce((namesArray: string[], fieldObject) => {
+      if (fieldObject.type === 'nested') {
+        return namesArray;
+      } else if (fieldObject.field && !namesArray.includes(fieldObject.field)) {
+        namesArray.push(fieldObject.field);
+      }
+      return namesArray;
+    }, []);
+    return fieldNames;
+  }
+  return [];
+};

--- a/packages/discovery-react-components/src/utils/storybookUtils.tsx
+++ b/packages/discovery-react-components/src/utils/storybookUtils.tsx
@@ -52,4 +52,9 @@ export class DummySearchClient {
     action('getComponentSettings')(getComponentSettingsParams);
     return createDummyResponsePromise({});
   }
+
+  public async listFields(listFieldsParams: DiscoveryV2.ListFieldsParams): Promise<any> {
+    action('listFields')(listFieldsParams);
+    return createDummyResponsePromise({});
+  }
 }


### PR DESCRIPTION
#### What do these changes do/fix?
This implements the `useFieldsApi` in order to fetch project fields and display them in our StructuredQuery component.
<!--
If there's a related issue, please add a link to the issue here.
-->
https://github.ibm.com/Watson-Discovery/disco-widgets/issues/184

#### How do you test/verify these changes?
You can verify this change by
1) Making sure the new unit tests added to `useDataApi.test.tsx`, `StructuredQuery.test.tsx`, and `DiscoverySearch.test.tsx` all pass and capture the intended functionality.
2) Making sure that the fields dropdown in storybook works as expected.
3) adding `StructuredQuery` to our example app (haven't added it yet since it's functionality is not complete) and checking that fields populate in the **Fields** dropdown menu

#### Have you documented your changes (if necessary)?
I've added this component to our storybook
#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
