### PR TITLE
fix: use react-scripts to run with code-coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,10 +290,10 @@ See the following for [more info about Lerna](https://github.com/lerna/lerna) or
 | `yarn build`                   | uses `rollup` to create a production build of component library    |
 | `yarn test`                    | runs the unit/integration tests for the component library          |
 | `yarn test:watch`              | runs the unit/integration tests in watch mode                      |
+| `yarn test:coverage`           | runs the unit/integration tests code coverage report               |
 | `yarn circular`                | runs `madge` to identify any circular dependencies                 |
 | `yarn eslint`                  | runs `eslint` on `src` and `.storybook`                            |
 | `yarn lint`                    | runs both `eslint` and `circular` commands                         |
-| `yarn code-coverage`           | runs the unit/integration tests code coverage report               |
 | `yarn storybook`               | runs storybook on http://localhost:9002                            |
 | `yarn storybook:build`         | builds storybook artifacts locally (primarily for testing build)   |
 | `yarn storybook:build:release` | builds storybook artifacts and outputs into `/docs`                |

--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -9,10 +9,10 @@
   "module": "dist/index.es.js",
   "scripts": {
     "test": "cross-env CI=1 react-scripts test",
+    "test:coverage": "cross-env CI=1 react-scripts test --coverage",
     "test:watch": "react-scripts test --watch",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
     "circular": "madge --circular src/*",
-    "code-coverage": "jest --collectCoverage",
     "build": "rollup -c",
     "eslint": "eslint --resolve-plugins-relative-to '../../node_modules/react-scripts/node_modules' './{src,.storybook}/**/*.{js,jsx,ts,tsx}' --quiet",
     "lint": "yarn run eslint && yarn run circular",


### PR DESCRIPTION
#### What do these changes do/fix?

Existing `yarn code-coverage` command doesn't work since it directly uses `jest`. Instead, we need to go through `react-scripts` to properly set the environment. Add a `yarn test:coverage` command to handle this.

#### How do you test/verify these changes?

Run `yarn test:coverage`

#### Have you documented your changes (if necessary)?

Yes

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
