### PR TITLE
fix: endless fetch loop caused by eslint

### DIFF
--- a/packages/discovery-react-components/src/components/StructuredQuery/StructuredQuery.tsx
+++ b/packages/discovery-react-components/src/components/StructuredQuery/StructuredQuery.tsx
@@ -37,7 +37,8 @@ const StructuredQuery: FC<StructuredQueryProps> = ({ messages = defaultMessages 
   const { fetchFields } = useContext(SearchApi);
   useEffect(() => {
     fetchFields();
-  }, [fetchFields]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className={structuredQueryClass}>


### PR DESCRIPTION
#### What do these changes do/fix?
This fixes the bug that was previously merged due to our ESLint rules automatically adding `fetchFields` as a dependency to the useEffect hook which is in charge of calling it. This previously caused us to be in a loop of indefinitely calling `fetchFields`
<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
- Load up storybook and open the `StructuredQuery` component. Notice that `fetchFields` only gets called once
#### Have you documented your changes (if necessary)?
n/a
#### Are there any breaking changes included in this pull request?
no
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
