### PR TITLE
fix: show attribute details when click on clickable attribute within element

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -633,7 +633,7 @@ function getActiveIndex(activeIds: string[], highlightedList: any[]): number {
 function getActiveElement(activeIds: string[], itemList: any[]): any {
   return itemList.find(item => {
     if ('allAttributeIds' in item) {
-      return isEqualId(item.allAttributeIds, activeIds);
+      return isEqual(item.allAttributeIds.sort(), activeIds.sort());
     } else if (isEqualId(item, activeIds)) {
       return true;
     } else if ('attributes' in item) {

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -308,7 +308,7 @@ const CIDocument: FC<CIDocumentProps> = ({
   // This can be removed once hover/click ability on attributes in sections is removed.
   const [clickedItemType, setClickedItemType] = useState<string>('');
   if (clickedItemType === ATTRIBUTES && !isInvoiceOrPurchaseOrder(enrichmentName)) {
-    activeDetails = getDetailsForAttribute(activeElement, activeIds);
+    activeDetails = getAttributeDetails(activeElement, activeIds);
   }
 
   let highlightedIds = [];
@@ -633,13 +633,13 @@ function getActiveIndex(activeIds: string[], highlightedList: any[]): number {
 function getActiveElement(activeIds: string[], itemList: any[]): any {
   return itemList.find(item => {
     if ('allAttributeIds' in item) {
-      return isEqual(item.allAttributeIds.sort(), activeIds.sort());
+      return isEqualId(item.allAttributeIds, activeIds);
     } else if (isEqualId(item, activeIds)) {
       return true;
     } else if ('attributes' in item) {
       return item.attributes.find((attribute: any) => isEqualId(attribute, activeIds));
     }
-    return isEqual([getId(item)].sort(), activeIds.sort());
+    return false;
   });
 }
 
@@ -656,7 +656,7 @@ function getAllClickableIds(itemList: any[]): string[] {
 }
 
 //Special case where user clicks on an attribute within contract element.
-function getDetailsForAttribute(activeElement: any, activeIds: string[]): any[] {
+function getAttributeDetails(activeElement: any, activeIds: string[]): any[] {
   if (activeElement && activeElement.attributes) {
     const attribute = activeElement.attributes.find((attr: any) => isEqualId(attr, activeIds));
     return [

--- a/packages/discovery-react-components/src/components/CIDocument/components/DetailsPane/__tests__/DetailsPane.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/DetailsPane/__tests__/DetailsPane.spec.tsx
@@ -3,6 +3,10 @@ import { render, BoundFunction, GetByText, AllByText, fireEvent } from '@testing
 import DetailsPane from '../DetailsPane';
 import { Items, OnActiveLinkChangeFn } from '../types';
 
+let getByText: BoundFunction<GetByText>,
+  getAllByText: BoundFunction<AllByText>,
+  onActiveLinkChange: OnActiveLinkChangeFn;
+
 describe('<DetailsPane />', () => {
   const dummyData: Items[] = [
     {
@@ -22,10 +26,6 @@ describe('<DetailsPane />', () => {
       ]
     }
   ];
-
-  let getByText: BoundFunction<GetByText>,
-    getAllByText: BoundFunction<AllByText>,
-    onActiveLinkChange: OnActiveLinkChangeFn;
 
   beforeEach(() => {
     onActiveLinkChange = jest.fn();
@@ -58,5 +58,21 @@ describe('<DetailsPane />', () => {
       sectionTitle: 'attributes',
       type: 'Number'
     });
+  });
+});
+
+describe('<DetailsPane /> - When attribute is clicked within element', () => {
+  const contractAttributeData: Items[] = [
+    {
+      heading: 'attributes',
+      items: ['DateTime']
+    }
+  ];
+  it('shows attribute type when clicked on attribute within element', () => {
+    ({ getByText, getAllByText } = render(
+      <DetailsPane items={contractAttributeData} onActiveLinkChange={onActiveLinkChange} />
+    ));
+    getByText('Attributes');
+    getByText('DateTime');
   });
 });


### PR DESCRIPTION
#### What do these changes do/fix?
Capability to show attribute details when attribute is clicked within element.

Duplicate of closed PR: https://github.ibm.com/Watson-Discovery/disco-widgets/pull/349
implements: https://github.ibm.com/Watson-Discovery/docviz-squad-issue-tracker/issues/145

#### How do you test/verify these changes?

`yarn storybook` -> CIDocument -> click on any attribute within element and should see details of the attribute.

#### Have you documented your changes (if necessary)?
No

#### Are there any breaking changes included in this pull request?
No
