### PR TITLE
chore: add new code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @maniax89 @noah-eigenfeld @kabeaty @Steven-Gassert @ChrisGillin
+* @maniax89 @noah-eigenfeld @kabeaty @Steven-Gassert @ChrisGillin @jhpedemonte @ColbyJohnIBM
 
-/packages/discovery-components-react/src/components/DocumentPreview/ @jhpedemonte @ColbyJohnIBM @JuanNicolasGarcia @broulaye @anibapat
-/packages/discovery-components-react/src/components/CIDocument/ @jhpedemonte @ColbyJohnIBM @JuanNicolasGarcia @broulaye @anibapat
+/packages/discovery-components-react/src/components/DocumentPreview/ @JuanNicolasGarcia @broulaye @anibapat
+/packages/discovery-components-react/src/components/CIDocument/ @JuanNicolasGarcia @broulaye @anibapat


### PR DESCRIPTION
- Add Javier Pedemonte and John Colby as code owners in order to improve code review efficiency