### PR TITLE
chore: add test ids for use in discovery-tooling integration tests

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -406,7 +406,9 @@ const CIDocument: FC<CIDocumentProps> = ({
   return (
     <div className={base}>
       <nav className={`${base}__toolbar`} aria-label={messages.navigationToolbarLabel}>
-        <div className={`${base}__title`}>{filename}</div>
+        <div className={`${base}__title`} data-testid="CIDocument_title">
+          {filename}
+        </div>
         {highlightedList.length > 0 && (
           <>
             <NavigationToolbar
@@ -495,6 +497,7 @@ function renderFilterPanel(
       messages={messages}
       onFilterChange={onFilterChange({ currentFilter, setCurrentFilter })}
       onFilterClear={resetStates}
+      data-testid="CIDocument_filterPanel"
     />
   );
 }

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/CIDocument.tsx
@@ -497,7 +497,6 @@ function renderFilterPanel(
       messages={messages}
       onFilterChange={onFilterChange({ currentFilter, setCurrentFilter })}
       onFilterClear={resetStates}
-      data-testid="CIDocument_filterPanel"
     />
   );
 }

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
@@ -54,7 +54,7 @@ describe('<CIDocument />', () => {
       // check for file name
       getByText('invoice.pdf');
       // check for a filter name
-      const filters = getByTestId('Filters');
+      const filters = getByTestId('CIDocument_filterPanel');
       globalGetByText(filters, 'Currency');
     });
 
@@ -68,7 +68,7 @@ describe('<CIDocument />', () => {
       expect(queryByTestId('metadata-tab')).toBeNull();
 
       // If an attribute is selected, DetailsPane type value is the same as the selected attribute
-      const filters = await findByTestId('Filters');
+      const filters = await findByTestId('CIDocument_filterPanel');
       const currencyButton = globalGetByLabelText(filters, 'Currency(2)');
       fireEvent.click(currencyButton);
 
@@ -80,7 +80,7 @@ describe('<CIDocument />', () => {
       const relationsTab = getByTestId('relations-tab');
       fireEvent.click(relationsTab);
 
-      const filters = await findByTestId('Filters');
+      const filters = await findByTestId('CIDocument_filterPanel');
       const invoiceButton = globalGetByLabelText(filters, 'Invoice parts(5)');
       fireEvent.click(invoiceButton);
 
@@ -108,13 +108,13 @@ describe('<CIDocument />', () => {
       // check for file name
       getByText('purchase_orders.pdf');
       // check for a filter name
-      const filters = getByTestId('Filters');
+      const filters = getByTestId('CIDocument_filterPanel');
       globalGetByText(filters, 'Currency');
     });
 
     it('filters and navigates forward through the list of elements', async () => {
       const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('Filters');
+        const filters = getByTestId('CIDocument_filterPanel');
         return globalGetByLabelText(filters, 'Currency(2)');
       });
       fireEvent.click(filterCheckbox);
@@ -133,7 +133,7 @@ describe('<CIDocument />', () => {
 
     it('filters and navigates backward through the list of elements', async () => {
       const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('Filters');
+        const filters = getByTestId('CIDocument_filterPanel');
         return globalGetByLabelText(filters, 'Currency(2)');
       });
       fireEvent.click(filterCheckbox);
@@ -152,12 +152,12 @@ describe('<CIDocument />', () => {
 
     it('selects a filter and then resets filters', async () => {
       const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('Filters');
+        const filters = getByTestId('CIDocument_filterPanel');
         return globalGetByLabelText(filters, 'Suppliers(1)');
       });
       fireEvent.click(filterCheckbox);
 
-      const filters = getByTestId('Filters');
+      const filters = getByTestId('CIDocument_filterPanel');
       const resetButton = globalGetByText(filters, 'Reset filters');
       fireEvent.click(resetButton);
 
@@ -190,7 +190,7 @@ describe('<CIDocument />', () => {
       // check for file name
       getByText('Art Effects Koya Creative Base TSA 2008.pdf');
       // check for a filter name
-      const filters = getByTestId('Filters');
+      const filters = getByTestId('CIDocument_filterPanel');
       globalGetByText(filters, 'Intellectual Property');
     });
 
@@ -204,7 +204,7 @@ describe('<CIDocument />', () => {
       expect(queryByTestId('relations-tab')).toBeNull();
 
       // Once a filter is selected, DetailsPane has Categories, Types, and Attributes sections
-      const filters = await findByTestId('Filters');
+      const filters = await findByTestId('CIDocument_filterPanel');
       const categoryCheckbox = globalGetByLabelText(filters, 'Intellectual Property(1)');
       fireEvent.click(categoryCheckbox);
 
@@ -233,7 +233,7 @@ describe('<CIDocument />', () => {
     });
 
     it('correctly filters contract elements', async () => {
-      const filters = await findByTestId('Filters');
+      const filters = await findByTestId('CIDocument_filterPanel');
 
       const categoryCheckbox = globalGetByLabelText(filters, 'Intellectual Property(1)');
       fireEvent.click(categoryCheckbox);

--- a/packages/discovery-react-components/src/components/CIDocument/components/FilterPanel/FilterPanel.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/FilterPanel/FilterPanel.tsx
@@ -46,7 +46,7 @@ const FilterPanel: FC<FilterPanelProps> = ({
       className={cx(base, className, {
         skeletons: loading
       })}
-      data-testid="Filters"
+      data-testid="CIDocument_filterPanel"
     >
       {loading ? (
         <SkeletonText paragraph={true} lineCount={6} />

--- a/packages/discovery-react-components/src/components/CIDocument/components/NavigationToolbar/NavigationToolbar.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/NavigationToolbar/NavigationToolbar.tsx
@@ -35,8 +35,9 @@ const NavigationToolbar: FC<NavigationToolbarProps> = ({
         aria-label={messages.previousLabel}
         iconDescription={messages.previousLabel}
         onClick={handleChange(onChange, index, max, -1)}
+        data-testid="NavigationToolbar_previous"
       />
-      <span className="text">
+      <span className="text" data-testid="NavigationToolbar_counter">
         {messages
           .counterPattern!.replace('{index}', index > 0 ? String(index) : '-')
           .replace('{max}', String(max))}
@@ -50,6 +51,7 @@ const NavigationToolbar: FC<NavigationToolbarProps> = ({
         renderIcon={ChevronRight16}
         iconDescription={messages.nextLabel}
         onClick={handleChange(onChange, index, max, 1)}
+        data-testid="NavigationToolbar_next"
       />
     </nav>
   );

--- a/packages/discovery-react-components/src/utils/document/documentUtils.ts
+++ b/packages/discovery-react-components/src/utils/document/documentUtils.ts
@@ -154,6 +154,7 @@ export function createFieldRects({
   fieldNode.className = 'field';
   fieldNode.dataset.fieldType = fieldType;
   fieldNode.dataset.fieldId = fieldId;
+  fieldNode.setAttribute('data-testid', `field-${fieldId}`);
   fragment.appendChild(fieldNode);
 
   // create highlight rect(s) inside of a field


### PR DESCRIPTION
- Add `data-testid` attributes to items that are used in document details integration tests