### PR TITLE
fix: better JSON doc handling for DocumentPreview

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -8,7 +8,7 @@ import SimpleDocument from './components/SimpleDocument/SimpleDocument';
 import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBoundary';
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
-import get from 'lodash/get';
+import { getDocumentType } from './utils/documentData';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -117,8 +117,8 @@ function PreviewDocument({
   highlight
 }: PreviewDocumentProps): ReactElement | null {
   if (document) {
-    const isJsonType = get(document, 'extracted_metadata.file_type') === 'json';
-    const isCsvType = get(document, 'extracted_metadata.file_type') === 'csv';
+    const isJsonType = getDocumentType(document) === 'json';
+    const isCsvType = getDocumentType(document) === 'csv';
     if (document.html && !isJsonType && !isCsvType) {
       return (
         <HtmlView

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -8,7 +8,7 @@ import SimpleDocument from './components/SimpleDocument/SimpleDocument';
 import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBoundary';
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
-import { getDocumentType } from './utils/documentData';
+import { getDocumentType, JSON_FILE, CSV_FILE } from './utils/documentData';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -117,8 +117,8 @@ function PreviewDocument({
   highlight
 }: PreviewDocumentProps): ReactElement | null {
   if (document) {
-    const isJsonType = getDocumentType(document) === 'json';
-    const isCsvType = getDocumentType(document) === 'csv';
+    const isJsonType = getDocumentType(document) === JSON_FILE;
+    const isCsvType = getDocumentType(document) === CSV_FILE;
     if (document.html && !isJsonType && !isCsvType) {
       return (
         <HtmlView

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -8,6 +8,7 @@ import SimpleDocument from './components/SimpleDocument/SimpleDocument';
 import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBoundary';
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
+import get from 'lodash/get';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -116,7 +117,9 @@ function PreviewDocument({
   highlight
 }: PreviewDocumentProps): ReactElement | null {
   if (document) {
-    if (document.html) {
+    const isJsonType = get(document, 'extracted_metadata.file_type') === 'json';
+    const isCsvType = get(document, 'extracted_metadata.file_type') === 'csv';
+    if (document.html && !isJsonType && !isCsvType) {
       return (
         <HtmlView
           document={document}

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -8,7 +8,7 @@ import SimpleDocument from './components/SimpleDocument/SimpleDocument';
 import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBoundary';
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
-import { getDocumentType, JSON_FILE, CSV_FILE } from './utils/documentData';
+import { getDocumentType, DOCUMENT_TYPES } from './utils/documentData';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -117,8 +117,8 @@ function PreviewDocument({
   highlight
 }: PreviewDocumentProps): ReactElement | null {
   if (document) {
-    const isJsonType = getDocumentType(document) === JSON_FILE;
-    const isCsvType = getDocumentType(document) === CSV_FILE;
+    const isJsonType = getDocumentType(document) === DOCUMENT_TYPES.JSON_FILE;
+    const isCsvType = getDocumentType(document) === DOCUMENT_TYPES.CSV_FILE;
     if (document.html && !isJsonType && !isCsvType) {
       return (
         <HtmlView

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -8,7 +8,7 @@ import SimpleDocument from './components/SimpleDocument/SimpleDocument';
 import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBoundary';
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
-import { getDocumentType, DOCUMENT_TYPES } from './utils/documentData';
+import { isCsvFile, isJsonFile } from './utils/documentData';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -117,8 +117,8 @@ function PreviewDocument({
   highlight
 }: PreviewDocumentProps): ReactElement | null {
   if (document) {
-    const isJsonType = getDocumentType(document) === DOCUMENT_TYPES.JSON_FILE;
-    const isCsvType = getDocumentType(document) === DOCUMENT_TYPES.CSV_FILE;
+    const isJsonType = isJsonFile(document);
+    const isCsvType = isCsvFile(document);
     if (document.html && !isJsonType && !isCsvType) {
       return (
         <HtmlView

--- a/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
@@ -52,7 +52,9 @@ describe('DocumentPreview', () => {
       return mockedBbox;
     };
     // This is added since the context needs to be reset to defaults for renders not wrappedWithContext
-    context.componentSettings = undefined;
+    if (context.componentSettings) {
+      context.componentSettings.fields_shown!.body = undefined;
+    }
   });
 
   afterEach(() => ((SVGElement.prototype as SVGTextElement).getBBox = originalGetBBox));
@@ -237,9 +239,15 @@ describe('DocumentPreview', () => {
     body_field: 'I am a specified "body" field.'
   };
 
-  // TODO: All of these currently fail since DocumentPreview defaults to HtmlView if a HTML field is present.
-  // TODO: Also fails because SimpleDocument will not show a JSON document without a passage highlight.
-  describe.skip('with JSON files', () => {
+  describe('with JSON files', () => {
+    it('should show an error if no text field exists and no "body" field or passage has been specified', () => {
+      act(() => {
+        ({ getByText } = render(<DocumentPreview document={omit(jsonDoc, 'text', 'html')} />));
+      });
+
+      getByText('Cannot preview document');
+    });
+
     it('should render text field for JSON files', () => {
       act(() => {
         ({ getByText } = render(<DocumentPreview document={jsonDoc} />));

--- a/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
@@ -241,8 +241,9 @@ describe('DocumentPreview', () => {
 
   describe('with JSON files', () => {
     it('should show an error if no text field exists and no "body" field or passage has been specified', () => {
+      const errorJsonDoc = omit(jsonDoc, 'html', 'text');
       act(() => {
-        ({ getByText } = render(<DocumentPreview document={omit(jsonDoc, 'text', 'html')} />));
+        ({ getByText } = render(<DocumentPreview document={errorJsonDoc} />));
       });
 
       getByText('Cannot preview document');

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -7,7 +7,7 @@ import { clearNodeChildren } from 'utils/dom';
 import { findOffsetInDOM, createFieldRects } from 'utils/document/documentUtils';
 import { isPassage } from '../Highlight/passages';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
-import { getDocumentType, JSON_FILE } from '../../utils/documentData';
+import { getDocumentType, DOCUMENT_TYPES } from '../../utils/documentData';
 
 interface Props {
   /**
@@ -43,7 +43,7 @@ export const SimpleDocument: FC<Props> = ({
   if (document) {
     // JSON files will default to displaying the specified body field, `text` field, or passage highlighting field,
     // Otherwise an error is shown
-    const isJsonType = getDocumentType(document) === JSON_FILE;
+    const isJsonType = getDocumentType(document) === DOCUMENT_TYPES.JSON_FILE;
     let field = get(componentSettings, 'fields_shown.body.field', 'text');
     if (isJsonType && (!highlight || !isPassage(highlight)) && document[field] === undefined) {
       html = `<p>${cannotPreviewMessage}</p>`;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -40,13 +40,13 @@ export const SimpleDocument: FC<Props> = ({
   let html,
     passage: QueryResultPassage | null = null;
   if (document) {
-    //Json object usually don't have enough info to allow us to determine which field to display
-    //Unless there is passage pointing to a specific field.
+    // JSON objects will default to displaying the specfied body field, text field, or passage highlighting field,
+    // Otherwise an error is shown
     const isJsonType = get(document, 'extracted_metadata.file_type') === 'json';
-    if (isJsonType && (!highlight || !isPassage(highlight))) {
+    let field = get(componentSettings, 'fields_shown.body.field', 'text');
+    if (isJsonType && (!highlight || !isPassage(highlight)) && document[field] === undefined) {
       html = `<p>${cannotPreviewMessage}</p>`;
     } else {
-      let field;
       // if there is a passage highlight, use text values from field specified in passage
       if (highlight && isPassage(highlight)) {
         passage = highlight as QueryResultPassage;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -7,7 +7,7 @@ import { clearNodeChildren } from 'utils/dom';
 import { findOffsetInDOM, createFieldRects } from 'utils/document/documentUtils';
 import { isPassage } from '../Highlight/passages';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
-import { getDocumentType, DOCUMENT_TYPES } from '../../utils/documentData';
+import { isJsonFile } from '../../utils/documentData';
 
 interface Props {
   /**
@@ -43,7 +43,7 @@ export const SimpleDocument: FC<Props> = ({
   if (document) {
     // JSON files will default to displaying the specified body field, `text` field, or passage highlighting field,
     // Otherwise an error is shown
-    const isJsonType = getDocumentType(document) === DOCUMENT_TYPES.JSON_FILE;
+    const isJsonType = isJsonFile(document);
     let field = get(componentSettings, 'fields_shown.body.field', 'text');
     if (isJsonType && (!highlight || !isPassage(highlight)) && document[field] === undefined) {
       html = `<p>${cannotPreviewMessage}</p>`;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -7,6 +7,7 @@ import { clearNodeChildren } from 'utils/dom';
 import { findOffsetInDOM, createFieldRects } from 'utils/document/documentUtils';
 import { isPassage } from '../Highlight/passages';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
+import { getDocumentType } from '../../utils/documentData';
 
 interface Props {
   /**
@@ -40,9 +41,9 @@ export const SimpleDocument: FC<Props> = ({
   let html,
     passage: QueryResultPassage | null = null;
   if (document) {
-    // JSON objects will default to displaying the specfied body field, text field, or passage highlighting field,
+    // JSON files will default to displaying the specified body field, `text` field, or passage highlighting field,
     // Otherwise an error is shown
-    const isJsonType = get(document, 'extracted_metadata.file_type') === 'json';
+    const isJsonType = getDocumentType(document) === 'json';
     let field = get(componentSettings, 'fields_shown.body.field', 'text');
     if (isJsonType && (!highlight || !isPassage(highlight)) && document[field] === undefined) {
       html = `<p>${cannotPreviewMessage}</p>`;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -7,7 +7,7 @@ import { clearNodeChildren } from 'utils/dom';
 import { findOffsetInDOM, createFieldRects } from 'utils/document/documentUtils';
 import { isPassage } from '../Highlight/passages';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
-import { getDocumentType } from '../../utils/documentData';
+import { getDocumentType, JSON_FILE } from '../../utils/documentData';
 
 interface Props {
   /**
@@ -43,7 +43,7 @@ export const SimpleDocument: FC<Props> = ({
   if (document) {
     // JSON files will default to displaying the specified body field, `text` field, or passage highlighting field,
     // Otherwise an error is shown
-    const isJsonType = getDocumentType(document) === 'json';
+    const isJsonType = getDocumentType(document) === JSON_FILE;
     let field = get(componentSettings, 'fields_shown.body.field', 'text');
     if (isJsonType && (!highlight || !isPassage(highlight)) && document[field] === undefined) {
       html = `<p>${cannotPreviewMessage}</p>`;

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -1,11 +1,11 @@
 import { getTextMappings, isCsvFile, isJsonFile } from '../documentData';
 import jsonDoc from '../../__fixtures__/Art Effects Koya Creative Base TSA 2008.pdf.json';
 
-const noMetadata = {
-  extracted_metadata: {}
-};
-
 describe('documentData', () => {
+  const noMetadata = {
+    extracted_metadata: {}
+  };
+
   let consoleError: jest.SpyInstance<any, any>;
 
   beforeAll(() => {

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -1,35 +1,8 @@
-import { getTextMappings, getDocumentType } from '../documentData';
+import { getTextMappings, isCsvFile, isJsonFile } from '../documentData';
 import jsonDoc from '../../__fixtures__/Art Effects Koya Creative Base TSA 2008.pdf.json';
-
-const correctTextMapping = {
-  extracted_metadata: {
-    file_type: 'json',
-    text_mappings:
-      '{"text_mappings":[{"page":{"page_number":1,"bbox":[54.0,89.32704162597656,558.0890502929688,175.20001363754272]},"field":{"name":"text","index":0,"span":[0,757]}}],"pages":[{"page_number":0,"height":792.0,"width":612.0,"origin":"TopLeft"}]}'
-  }
-};
 
 const noMetadata = {
   extracted_metadata: {}
-};
-
-const invalidStringTextMapping = {
-  extracted_metadata: {
-    text_mappings:
-      'I have replaced to usual text mapping string here for a test. This should give an error.'
-  }
-};
-
-const noStringFileType = {
-  extracted_metadata: {
-    file_type: 12
-  }
-};
-
-const noStringTextMapping = {
-  extracted_metadata: {
-    text_mappings: 1
-  }
 };
 
 describe('documentData', () => {
@@ -49,6 +22,12 @@ describe('documentData', () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  const correctTextMapping = {
+    extracted_metadata: {
+      text_mappings:
+        '{"text_mappings":[{"page":{"page_number":1,"bbox":[54.0,89.32704162597656,558.0890502929688,175.20001363754272]},"field":{"name":"text","index":0,"span":[0,757]}}],"pages":[{"page_number":0,"height":792.0,"width":612.0,"origin":"TopLeft"}]}'
+    }
+  };
   it('returns correct text mapping data', () => {
     const mappings = getTextMappings(correctTextMapping)!;
     expect(mappings).not.toEqual(null);
@@ -67,30 +46,61 @@ describe('documentData', () => {
     expect(consoleError).not.toHaveBeenCalled();
   });
 
+  const invalidStringTextMapping = {
+    extracted_metadata: {
+      text_mappings:
+        'I have replaced to usual text mapping string here for a test. This should give an error.'
+    }
+  };
   it('fails gracefully if text mappings cannot be parsed', () => {
     const mappings = getTextMappings(invalidStringTextMapping);
     expect(mappings).toEqual(null);
     expect(consoleError).toHaveBeenCalled();
   });
 
+  const noStringTextMapping = {
+    extracted_metadata: {
+      text_mappings: 1
+    }
+  };
   it('fails gracefully if text mappings is not a string', () => {
     const mappings = getTextMappings(noStringTextMapping);
     expect(mappings).toEqual(null);
     expect(consoleError).toHaveBeenCalled();
   });
 
-  it('returns the correct document type', () => {
-    const docType = getDocumentType(correctTextMapping);
-    expect(docType).toEqual('json');
+  const jsonFileType = {
+    extracted_metadata: {
+      file_type: 'json'
+    }
+  };
+  it('returns true if the document is a JSON file', () => {
+    const docTypeJson = isJsonFile(jsonFileType);
+    expect(docTypeJson).toEqual(true);
   });
 
-  it('returns null if the file type provided is not a string', () => {
-    const docType = getDocumentType(noStringFileType);
-    expect(docType).toEqual(null);
+  const csvFileType = {
+    extracted_metadata: {
+      file_type: 'csv'
+    }
+  };
+  it('returns true if the document is a CSV file', () => {
+    const docTypeJson = isCsvFile(csvFileType);
+    expect(docTypeJson).toEqual(true);
   });
 
-  it('returns null if there is no file type provided', () => {
-    const docType = getDocumentType(noMetadata);
-    expect(docType).toEqual(null);
+  const noStringFileType = {
+    extracted_metadata: {
+      file_type: true
+    }
+  };
+  it('returns false if the file type provided is not a string', () => {
+    const falseDocType = isJsonFile(noStringFileType);
+    expect(falseDocType).toEqual(false);
+  });
+
+  it('returns false if there is no file type provided', () => {
+    const falseDocType = isCsvFile(noMetadata);
+    expect(falseDocType).toEqual(false);
   });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -1,14 +1,15 @@
-import { getTextMappings } from '../documentData';
+import { getTextMappings, getDocumentType } from '../documentData';
 import jsonDoc from '../../__fixtures__/Art Effects Koya Creative Base TSA 2008.pdf.json';
 
 const correctTextMapping = {
   extracted_metadata: {
+    file_type: 'json',
     text_mappings:
       '{"text_mappings":[{"page":{"page_number":1,"bbox":[54.0,89.32704162597656,558.0890502929688,175.20001363754272]},"field":{"name":"text","index":0,"span":[0,757]}}],"pages":[{"page_number":0,"height":792.0,"width":612.0,"origin":"TopLeft"}]}'
   }
 };
 
-const noTextMapping = {
+const noMetadata = {
   extracted_metadata: {}
 };
 
@@ -16,6 +17,12 @@ const invalidStringTextMapping = {
   extracted_metadata: {
     text_mappings:
       'I have replaced to usual text mapping string here for a test. This should give an error.'
+  }
+};
+
+const noStringFileType = {
+  extracted_metadata: {
+    file_type: 12
   }
 };
 
@@ -55,7 +62,7 @@ describe('documentData', () => {
   });
 
   it('fails gracefully if text mappings does not exist', () => {
-    const mappings = getTextMappings(noTextMapping);
+    const mappings = getTextMappings(noMetadata);
     expect(mappings).toEqual(null);
     expect(consoleError).not.toHaveBeenCalled();
   });
@@ -70,5 +77,20 @@ describe('documentData', () => {
     const mappings = getTextMappings(noStringTextMapping);
     expect(mappings).toEqual(null);
     expect(consoleError).toHaveBeenCalled();
+  });
+
+  it('returns the correct document type', () => {
+    const docType = getDocumentType(correctTextMapping);
+    expect(docType).toEqual('json');
+  });
+
+  it('returns null if the file type provided is not a string', () => {
+    const docType = getDocumentType(noStringFileType);
+    expect(docType).toEqual(null);
+  });
+
+  it('returns null if there is no file type provided', () => {
+    const docType = getDocumentType(noMetadata);
+    expect(docType).toEqual(null);
   });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -24,3 +24,16 @@ export function getTextMappings(
   }
   return mappings;
 }
+
+/**
+ * Get `file_type` document property as a string. Usually, this
+ * prop is stored as a JSON string.
+ */
+export function getDocumentType(doc: QueryResult | null | undefined): string | null {
+  let docType = get(doc, 'extracted_metadata.file_type');
+  if (docType && typeof docType === 'string') {
+    return docType;
+  } else {
+    return null;
+  }
+}

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -2,12 +2,6 @@ import get from 'lodash/get';
 import { QueryResult } from 'ibm-watson/discovery/v2';
 import { TextMappings } from '../types';
 
-// document types
-export const DOCUMENT_TYPES = {
-  CSV_FILE: 'csv',
-  JSON_FILE: 'json'
-};
-
 /**
  * Get `text_mappings` document property as an object. Usually, this
  * prop is stored as a JSON string; if so, parse and return as object.
@@ -32,13 +26,15 @@ export function getTextMappings(
 }
 
 /**
- * Get `file_type` document property as a string. Usually, this
- * prop is stored as a JSON string.
+ * Returns true if the `file_type` is CSV
  */
-export function getDocumentType(doc: QueryResult | null | undefined): string | null {
-  let docType = get(doc, 'extracted_metadata.file_type');
-  if (docType && typeof docType === 'string') {
-    return docType;
-  }
-  return null;
+export function isCsvFile(doc: QueryResult | null | undefined): boolean {
+  return get(doc, 'extracted_metadata.file_type') === 'csv';
+}
+
+/**
+ * Returns true if the `file_type` is JSON
+ */
+export function isJsonFile(doc: QueryResult | null | undefined): boolean {
+  return get(doc, 'extracted_metadata.file_type') === 'json';
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -2,6 +2,10 @@ import get from 'lodash/get';
 import { QueryResult } from 'ibm-watson/discovery/v2';
 import { TextMappings } from '../types';
 
+// document types
+export const CSV_FILE = 'csv';
+export const JSON_FILE = 'json';
+
 /**
  * Get `text_mappings` document property as an object. Usually, this
  * prop is stored as a JSON string; if so, parse and return as object.
@@ -33,7 +37,6 @@ export function getDocumentType(doc: QueryResult | null | undefined): string | n
   let docType = get(doc, 'extracted_metadata.file_type');
   if (docType && typeof docType === 'string') {
     return docType;
-  } else {
-    return null;
   }
+  return null;
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -3,8 +3,10 @@ import { QueryResult } from 'ibm-watson/discovery/v2';
 import { TextMappings } from '../types';
 
 // document types
-export const CSV_FILE = 'csv';
-export const JSON_FILE = 'json';
+export const DOCUMENT_TYPES = {
+  CSV_FILE: 'csv',
+  JSON_FILE: 'json'
+};
 
 /**
  * Get `text_mappings` document property as an object. Usually, this


### PR DESCRIPTION
#### What do these changes do/fix?
When displaying the text for a uploaded JSON file, the selected field from DocumentPreview no longer defaults to HTML. It now will check for passage highlighting, then a specified body field, then a text field. If none of those are present, the error message appears. 

**This covers two issues:**
https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1189
https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1193

**Previously**, HTML would be the default view for processed JSON files, but the HTML field would not be rendered.
<img width="1914" alt="Screen Shot 2020-02-21 at 2 04 05 PM" src="https://user-images.githubusercontent.com/59846843/75067638-18ca1f00-54b3-11ea-9aed-6ed27823edc0.png">
**Previously**, a specified body field would default to HTML view instead.
<img width="1916" alt="Screen Shot 2020-02-21 at 2 13 10 PM" src="https://user-images.githubusercontent.com/59846843/75068194-4fed0000-54b4-11ea-91fb-4b81b58eef34.png">
**Now**, the same document will default to the `text` field and display that text.
<img width="1914" alt="Screen Shot 2020-02-21 at 2 02 16 PM" src="https://user-images.githubusercontent.com/59846843/75067530-daccfb00-54b2-11ea-971b-397f98c2df5b.png">
**Now**, the same document will also display a specified body field.
<img width="1915" alt="Screen Shot 2020-02-21 at 2 10 46 PM" src="https://user-images.githubusercontent.com/59846843/75068095-20d68e80-54b4-11ea-85aa-aedb587e0a96.png">

#### How do you test/verify these changes?
Run `yarn test:watch DocumentPreview.test` and see that previously skipped tests pass now that the bug was been corrected.

Can also verify by linking components and tooling and uploading the following test document on a cluster:
```
{
    "id": '1234567890',
    "extracted_metadata": {
      "filename": 'i_am_a_json_file.json',
      "file_type": 'json'
    },
    "html": '<p>This is a <em>HTML</em> string.</p>',
    "text": 'This is simple text.',
    "body_field": 'I am a specified "body" field.'
}
```
#### Are there any breaking changes included in this pull request?
No