### PR TITLE
bug: search facet tag text wrapping

### DIFF
--- a/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
+++ b/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
@@ -11,6 +11,11 @@
 .#{$prefix}--search-facet {
   margin-bottom: $spacing-md;
   word-break: break-word;
+
+  // To prevent tags text from breaking inside of search facet
+  .#{$prefix}--tag--filter {
+    word-break: normal;
+  }
 }
 
 .#{$prefix}--search-facet__facet__label-and-selection-container {


### PR DESCRIPTION
#### What do these changes do/fix?
Fixes the text wrapping in search facet tags. 

**Before:**
<img width="273" alt="Screen Shot 2020-03-06 at 3 31 02 PM" src="https://user-images.githubusercontent.com/59846843/76124104-974cb380-5fbf-11ea-81aa-2fb699b1bd18.png">
**After:**
<img width="273" alt="Screen Shot 2020-03-06 at 3 17 15 PM" src="https://user-images.githubusercontent.com/59846843/76124017-72584080-5fbf-11ea-9d31-e1143afe9d85.png">
<img width="272" alt="Screen Shot 2020-03-06 at 3 29 55 PM" src="https://user-images.githubusercontent.com/59846843/76124018-72f0d700-5fbf-11ea-9bf6-9233b7025c8e.png">

https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1245

#### How do you test/verify these changes?
1. Link components and tooling by running `yarn link-components` in tooling.
2. Link components-styles by running `yarn link` there and `yarn link @ibm-watson/discovery-styles` in tooling.
3. Select 10+ search filters in the Search Facets Panel

#### Are there any breaking changes included in this pull request?
No