### PR TITLE
docs: update to use 'master' instead of 'develop'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ deploy:
     script: npx lerna publish -y --conventional-prerelease --no-changelog --preid beta --dist-tag beta
     skip_cleanup: true
     on:
-      branch: develop
+      branch: master
   # do release candidate releases
   - provider: script
     script: npx lerna publish -y --conventional-prerelease --no-changelog --preid rc --dist-tag rc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discovery Components
 
-[![Build Status](https://travis-ci.org/watson-developer-cloud/discovery-components.svg?branch=develop)](https://travis-ci.org/watson-developer-cloud/discovery-components)
+[![Build Status](https://travis-ci.org/watson-developer-cloud/discovery-components.svg?branch=master)](https://travis-ci.org/watson-developer-cloud/discovery-components)
 [![Apache-2.0 license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/watson-developer-cloud/discovery-components/blob/master/LICENSE)
 [![Lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/watson-developer-cloud/discovery-components/blob/master/.github/CONTRIBUTING.md)
@@ -58,6 +58,7 @@ The `runExampleApp.sh` script provides prompts to help configure and run the exa
 1. Ask you if you'd like to start the example application
 
 Run the following command from the project root directory
+
 ```
 ./runExampleApp.sh
 ```
@@ -108,12 +109,13 @@ yarn workspace discovery-search-app run start
    4. `CLUSTER_PORT` defaults to `443` unless configured otherwise
    5. `CLUSTER_HOST` the base URL of your CP4D cluster (ex. `example.com`)
 
-    #### Windows Only
-    On Windows, the default `SASS_PATH` environmnt variable must be updated. Append the following to the `.env.local` file:
+   #### Windows Only
 
-    ```
-    SASS_PATH="./node_modules;./src"
-    ```
+   On Windows, the default `SASS_PATH` environmnt variable must be updated. Append the following to the `.env.local` file:
+
+   ```
+   SASS_PATH="./node_modules;./src"
+   ```
 
 5. Build the React components:
 
@@ -422,25 +424,20 @@ Steps in the automation can be set in `.travis.yml`, located in the root directo
 
 ### Branching and Releasing
 
-We are adopting a ["oneflow" branching strategy](https://www.endoflineblog.com/oneflow-a-git-branching-model-and-workflow) where:
-
-- `develop` is an eternal branch - bleeding edge, reviewed but not necessarily released code
-- `master` is another eternal _pointer_ branch to the latest released production tag. we advance this branch after a successful release with `git checkout master && git merge --ff-only @ibm-watson/discovery-react-components@x.x.x` where `x.x.x` is the latest released production tag. example steps:
-  - `git checkout master`
-  - `git merge --ff-only @ibm-watson/discovery-react-components@1.0.1`
-- `release/x.x.x` is a temporary branch created for beginning a production release. this contains all the features needed for the release and will only receive bugfixes. Once the release is complete, this branch is tagged and merged back into `develop`. example steps:
+- `master` is an eternal branch - bleeding edge, reviewed but not necessarily released code
+- `release/x.x.x` is a temporary branch created for beginning a production release. this contains all the features needed for the release and will only receive bugfixes. Once the release is complete, this branch is tagged and merged back into `master`. example steps:
   - `git checkout release/2.3.0`
   - if we want to publish a release candidate (not final build):
     - `npx lerna publish --conventional-prerelease --preid rc --dist-tag rc`
     - (after we find out the `rc` is good to go) `npx lerna publish --create-release github --conventional-graduate` [docs](https://github.com/lerna/lerna/blob/master/commands/version/README.md#--conventional-graduate)
   - otherwise for the official release:
     - `npx lerna publish --create-release github`
-  - `git checkout develop`
+  - `git checkout master`
   - `git merge release/2.3.0`
-  - `git push --tags origin develop`
+  - `git push --tags origin master`
   - `git branch -d release/2.3.0`
 
-The only branches permitted for release are `release/*`, `hotfix/*`, and `develop`
+The only branches permitted for release are `release/*`, `hotfix/*`, and `master`
 
 More information about the `lerna publish` command can be found in the README for [lerna publish](https://github.com/lerna/lerna/tree/master/commands/publish)
 


### PR DESCRIPTION
#### What do these changes do/fix?

Updates documentation around using `master` for ongoing development and removing `develop`. There will be follow-up issues to:
- add compatibility tables between releases of Watson Discovery on CP4D and this component library
- switch lerna config to use single-version increments (instead of independent)
- publish docs to `gh_pages` branch instead of `master /docs`

#### How do you test/verify these changes?

Make sure that merging to `master` still triggers `beta`-style releases

#### Have you documented your changes (if necessary)?

Yes

#### Are there any breaking changes included in this pull request?

`develop` branch no longer exists
