### PR TITLE
fix: add result count to search facets

### DIFF
--- a/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
@@ -34,20 +34,20 @@ describe('Dynamic Facets', () => {
         .as('naiveBayesFilter');
     });
 
-    it('available dynamic facets are listed on the side', () => {
+    it('shows available dynamic facets listed on the side', () => {
       cy.get('@regressionFilter').should('exist');
       cy.get('@classificationFilter').should('exist');
       cy.get('@naiveBayesFilter').should('exist');
     });
 
-    it('dynamic facets are displayed as checkboxes', () => {
+    it('has dynamic facets displayed as checkboxes', () => {
       cy.get('@dynamicFacets')
         .find('.bx--checkbox')
         .should('have.length', 3);
     });
 
     // TODO: update this test once API supports a result count for dynamic facets
-    it('dynamic facets do not have matching results count', () => {
+    it('does not show dynamic facet matching result count', () => {
       cy.get('@dynamicFacets')
         .find('.bx--search-facet__facet__option-label')
         .first()
@@ -72,7 +72,7 @@ describe('Dynamic Facets', () => {
           .should('eq', '"regression"');
       });
 
-      it('the bubble next to dynamic facets says 1', () => {
+      it('shows the bubble next to dynamic facets saying 1', () => {
         cy.get('.bx--list-box__selection')
           .contains('1')
           .should('exist');
@@ -96,7 +96,7 @@ describe('Dynamic Facets', () => {
             .should('eq', '"regression","classification"');
         });
 
-        it('the bubble next to dynamic facets says 2', () => {
+        it('shows the bubble next to dynamic facets saying 2', () => {
           cy.get('.bx--list-box__selection')
             .contains('2')
             .should('exist');
@@ -119,7 +119,7 @@ describe('Dynamic Facets', () => {
             .should('eq', '');
         });
 
-        it('the "Clear all" button disappears', () => {
+        it('has the "Clear all" button disappear', () => {
           cy.findByText('Dynamic Facets').should('exist'); // make sure this test doesn't pass when the page is blank
           cy.get('button')
             .contains('Clear all')

--- a/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
@@ -46,6 +46,14 @@ describe('Dynamic Facets', () => {
         .should('have.length', 3);
     });
 
+    // TODO: update this test once API supports a result count for dynamic facets
+    it('dynamic facets do not have matching results count', () => {
+      cy.get('@dynamicFacets')
+        .find('.bx--search-facet__facet__option-label')
+        .first()
+        .should('have.text', 'regression');
+    });
+
     describe('and a dynamic facet filter is selected', () => {
       beforeEach(() => {
         cy.route('POST', '**/query?version=2019-01-01', '@facetsQuerySingleRefinementJSON').as(

--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -29,7 +29,7 @@ describe('Multi-Select Facets', () => {
         .as('priceFacet');
     });
 
-    it('available facets are listed on the side', () => {
+    it('shows available facets listed on the side', () => {
       cy.get('.bx--search-facet')
         .as('allFacets')
         .should('have.length', 4);
@@ -38,7 +38,7 @@ describe('Multi-Select Facets', () => {
       cy.get('@priceFacet').should('exist');
     });
 
-    it('facets are displayed as checkboxes', () => {
+    it('has facets displayed as checkboxes', () => {
       cy.get('@cityFacet')
         .find('.bx--checkbox')
         .should('have.length', 5);
@@ -50,7 +50,7 @@ describe('Multi-Select Facets', () => {
         .should('have.length', 3);
     });
 
-    it('facets have matching results count', () => {
+    it('shows the facet matching results count', () => {
       cy.get('@cityFacet')
         .contains('Boston, MA (30000)')
         .should('exist');
@@ -74,7 +74,7 @@ describe('Multi-Select Facets', () => {
           .should('eq', 'location:"Ames, IA"');
       });
 
-      it('the bubble next to that facet says 1', () => {
+      it('changes the bubble next to that facet to say 1', () => {
         cy.get('.bx--list-box__selection')
           .contains('1')
           .should('exist');
@@ -98,7 +98,7 @@ describe('Multi-Select Facets', () => {
             .should('eq', 'location:"Pittsburgh, PA"|"Ames, IA"');
         });
 
-        it('the bubble next to that facet says 2', () => {
+        it('changes the bubble next to that facet to say 2', () => {
           cy.get('.bx--list-box__selection')
             .contains('2')
             .should('exist');
@@ -121,7 +121,7 @@ describe('Multi-Select Facets', () => {
             .should('eq', '');
         });
 
-        it('the "Clear all" button disappears', () => {
+        it('has the "Clear all" button disappear', () => {
           cy.get('button')
             .contains('Clear all')
             .should('not.exist');
@@ -174,7 +174,7 @@ describe('Multi-Select Facets', () => {
             cy.wait('@postQueryFacetsAmes').as('amesFilterQueryObject');
           });
 
-          it('the filters from only that facet are cleared', () => {
+          it('has the filters from only that facet clear', () => {
             cy.get('@amesFilterQueryObject')
               //@ts-ignore TODO: we'll need to handle typings for `cy.its` at some point, but for now, we'll ignore the error on the parameter string
               .its('requestBody.filter')

--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -50,6 +50,12 @@ describe('Multi-Select Facets', () => {
         .should('have.length', 3);
     });
 
+    it('facets have matching results count', () => {
+      cy.get('@cityFacet')
+        .contains('Boston, MA (30000)')
+        .should('exist');
+    });
+
     describe('and a facet filter is selected', () => {
       beforeEach(() => {
         cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryAmesJSON').as(

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -50,6 +50,12 @@ describe('Single-Select Facets', () => {
         .should('have.length', 3);
     });
 
+    it('facets have matching results count', () => {
+      cy.get('@cityFacet')
+        .contains('Boston, MA (30000)')
+        .should('exist');
+    });
+
     describe('and a facet filter is selected', () => {
       beforeEach(() => {
         cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryAmesJSON').as(

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -29,7 +29,7 @@ describe('Single-Select Facets', () => {
         .as('priceFacet');
     });
 
-    it('available facets are listed on the side', () => {
+    it('shows available facets listed on the side', () => {
       cy.get('.bx--search-facet')
         .as('allFacets')
         .should('have.length', 4);
@@ -38,7 +38,7 @@ describe('Single-Select Facets', () => {
       cy.get('@priceFacet').should('exist');
     });
 
-    it('facets are displayed as radio buttons', () => {
+    it('has facets displayed as radio buttons', () => {
       cy.get('@cityFacet')
         .find('.bx--radio-button')
         .should('have.length', 5);
@@ -50,7 +50,7 @@ describe('Single-Select Facets', () => {
         .should('have.length', 3);
     });
 
-    it('facets have matching results count', () => {
+    it('shows the facet matching results count', () => {
       cy.get('@cityFacet')
         .contains('Boston, MA (30000)')
         .should('exist');
@@ -109,7 +109,7 @@ describe('Single-Select Facets', () => {
             .should('eq', '');
         });
 
-        it('the "Clear all" button disappears', () => {
+        it('has the "Clear all" button disappear', () => {
           cy.get('button')
             .contains('Clear all')
             .should('not.exist');
@@ -160,7 +160,7 @@ describe('Single-Select Facets', () => {
           .click();
       });
 
-      it('the list of facets is expanded', () => {
+      it('has the list of facets expand', () => {
         cy.get('@cuisineFacet')
           .find('input')
           .should('have.length', 9);
@@ -173,7 +173,7 @@ describe('Single-Select Facets', () => {
             .click();
         });
 
-        it('the list of facets is collapsed', () => {
+        it('has the list of facets collapse', () => {
           cy.get('@cuisineFacet')
             .find('input')
             .should('have.length', 5);

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -100,6 +100,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
       </legend>
       {shouldDisplayAsMultiSelect ? (
         <MultiSelectFacetsGroup
+          messages={messages}
           facets={collapsedFacets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}
@@ -107,6 +108,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
         />
       ) : (
         <SingleSelectFacetsGroup
+          messages={messages}
           facets={collapsedFacets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -56,12 +56,8 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
     <>
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results || 0;
-        let labelText = text;
-        // To prevent showing the number of Dynamic Facets until the API supports this
-        if (matchingResults > 0) {
-          labelText += ' (' + matchingResults + ')';
-        }
+        const matchingResults = facet.matching_results || null;
+        const labelText = matchingResults ? text + ' (' + matchingResults + ')' : text;
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -56,6 +56,12 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
     <>
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
+        const matchingResults = get(facet, 'matching_results');
+        let fullText = text;
+        // To prevent showing the number of Dynamic Facets until the API supports this
+        if (matchingResults > 0) {
+          fullText += ' (' + matchingResults + ')';
+        }
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');
@@ -65,7 +71,7 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
             className={optionLabelClass}
             wrapperClassName={optionClass}
             onChange={handleOnChange}
-            labelText={text}
+            labelText={fullText}
             key={`checkbox-${escapedName}-${base64data}`}
             id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
             data-name={aggregationSettings.name || aggregationSettings.field}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -56,11 +56,11 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
     <>
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = get(facet, 'matching_results');
-        let fullText = text;
+        const matchingResults = facet.matching_results || 0;
+        let labelText = text;
         // To prevent showing the number of Dynamic Facets until the API supports this
         if (matchingResults > 0) {
-          fullText += ' (' + matchingResults + ')';
+          labelText += ' (' + matchingResults + ')';
         }
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
@@ -71,7 +71,7 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
             className={optionLabelClass}
             wrapperClassName={optionClass}
             onChange={handleOnChange}
-            labelText={fullText}
+            labelText={labelText}
             key={`checkbox-${escapedName}-${base64data}`}
             id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
             data-name={aggregationSettings.name || aggregationSettings.field}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -56,8 +56,9 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
     <>
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results || null;
-        const labelText = matchingResults ? text + ' (' + matchingResults + ')' : text;
+        const matchingResults = facet.matching_results;
+        const labelText =
+          matchingResults !== undefined ? text + ' (' + matchingResults + ')' : text;
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useContext, SyntheticEvent } from 'react';
 import { optionClass, optionLabelClass } from '../../cssClasses';
+import { Messages } from 'components/SearchFacets/messages';
+import { formatMessage } from 'utils/formatMessage';
 import { Checkbox as CarbonCheckbox } from 'carbon-components-react';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import {
@@ -10,6 +12,10 @@ import {
 import get from 'lodash/get';
 
 interface MultiSelectFacetsGroupProps {
+  /**
+   * override default messages for the component by specifying custom and/or internationalized text strings
+   */
+  messages: Messages;
   /**
    * Dynamic facets text and selected flag
    */
@@ -29,6 +35,7 @@ interface MultiSelectFacetsGroupProps {
 }
 
 export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
+  messages,
   facets,
   facetsTextField,
   aggregationSettings,
@@ -52,15 +59,20 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
     onChange(selectedFacetName, selectedFacetKey, checked);
   };
 
+  const getLabel = (facetText: string, count: number | undefined) => {
+    return count !== undefined
+      ? formatMessage(messages.labelTextWithCount, { facetText: facetText, count: count }, false)
+      : formatMessage(messages.labelText, { facetText: facetText }, false);
+  };
+
   return (
     <>
       {facets.map(facet => {
-        const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results;
-        const labelText =
-          matchingResults !== undefined ? text + ' (' + matchingResults + ')' : text;
+        const facetText = get(facet, facetsTextField, '');
+        const count = facet.matching_results;
+        const labelText = getLabel(facetText, count);
         const query = naturalLanguageQuery || '';
-        const buff = new Buffer(query + text);
+        const buff = new Buffer(query + facetText);
         const base64data = buff.toString('base64');
 
         return (
@@ -70,9 +82,9 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
             onChange={handleOnChange}
             labelText={labelText}
             key={`checkbox-${escapedName}-${base64data}`}
-            id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
+            id={`checkbox-${escapedName}-${facetText.replace(/\s+/g, '_')}`}
             data-name={aggregationSettings.name || aggregationSettings.field}
-            data-key={text}
+            data-key={facetText}
             checked={!!facet.selected}
           />
         );

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
@@ -65,11 +65,11 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
     >
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = get(facet, 'matching_results');
-        let fullText = text;
+        const matchingResults = facet.matching_results || 0;
+        let labelText = text;
         // To prevent showing the number of Dynamic Facets until the API supports this
         if (matchingResults > 0) {
-          fullText += ' (' + matchingResults + ')';
+          labelText += ' (' + matchingResults + ')';
         }
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
@@ -78,7 +78,7 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
         return (
           <CarbonRadioButton
             className={optionLabelClass}
-            labelText={fullText}
+            labelText={labelText}
             key={`checkbox-${escapedName}-${base64data}`}
             id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
             value={text}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
@@ -65,8 +65,9 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
     >
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results || null;
-        const labelText = matchingResults ? text + ' (' + matchingResults + ')' : text;
+        const matchingResults = facet.matching_results;
+        const labelText =
+          matchingResults !== undefined ? text + ' (' + matchingResults + ')' : text;
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
@@ -65,12 +65,8 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
     >
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results || 0;
-        let labelText = text;
-        // To prevent showing the number of Dynamic Facets until the API supports this
-        if (matchingResults > 0) {
-          labelText += ' (' + matchingResults + ')';
-        }
+        const matchingResults = facet.matching_results || null;
+        const labelText = matchingResults ? text + ' (' + matchingResults + ')' : text;
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
@@ -65,6 +65,12 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
     >
       {facets.map(facet => {
         const text = get(facet, facetsTextField, '');
+        const matchingResults = get(facet, 'matching_results');
+        let fullText = text;
+        // To prevent showing the number of Dynamic Facets until the API supports this
+        if (matchingResults > 0) {
+          fullText += ' (' + matchingResults + ')';
+        }
         const query = naturalLanguageQuery || '';
         const buff = new Buffer(query + text);
         const base64data = buff.toString('base64');
@@ -72,7 +78,7 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
         return (
           <CarbonRadioButton
             className={optionLabelClass}
-            labelText={text}
+            labelText={fullText}
             key={`checkbox-${escapedName}-${base64data}`}
             id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
             value={text}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/SingleSelectFacetsGroup.tsx
@@ -4,6 +4,8 @@ import {
   RadioButton as CarbonRadioButton
 } from 'carbon-components-react';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
+import { Messages } from 'components/SearchFacets/messages';
+import { formatMessage } from 'utils/formatMessage';
 import { optionLabelClass, singleSelectGroupClass } from 'components/SearchFacets/cssClasses';
 import {
   SelectableDynamicFacets,
@@ -13,6 +15,10 @@ import {
 import get from 'lodash/get';
 
 interface SingleSelectFacetsGroupProps {
+  /**
+   * override default messages for the component by specifying custom and/or internationalized text strings
+   */
+  messages: Messages;
   /**
    * Facets text and selected flag
    */
@@ -36,6 +42,7 @@ interface SingleSelectFacetsGroupProps {
 }
 
 export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
+  messages,
   facets,
   facetsTextField,
   selectedFacet,
@@ -56,6 +63,12 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
     onChange(name, text, true);
   };
 
+  const getLabel = (facetText: string, count: number | undefined) => {
+    return count !== undefined
+      ? formatMessage(messages.labelTextWithCount, { facetText: facetText, count: count }, false)
+      : formatMessage(messages.labelText, { facetText: facetText }, false);
+  };
+
   return (
     <CarbonRadioButtonGroup
       name={aggregationSettings.name || aggregationSettings.field}
@@ -64,12 +77,11 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
       className={singleSelectGroupClass}
     >
       {facets.map(facet => {
-        const text = get(facet, facetsTextField, '');
-        const matchingResults = facet.matching_results;
-        const labelText =
-          matchingResults !== undefined ? text + ' (' + matchingResults + ')' : text;
+        const facetText = get(facet, facetsTextField, '');
+        const count = facet.matching_results;
+        const labelText = getLabel(facetText, count);
         const query = naturalLanguageQuery || '';
-        const buff = new Buffer(query + text);
+        const buff = new Buffer(query + facetText);
         const base64data = buff.toString('base64');
 
         return (
@@ -77,8 +89,8 @@ export const SingleSelectFacetsGroup: FC<SingleSelectFacetsGroupProps> = ({
             className={optionLabelClass}
             labelText={labelText}
             key={`checkbox-${escapedName}-${base64data}`}
-            id={`checkbox-${escapedName}-${text.replace(/\s+/g, '_')}`}
-            value={text}
+            id={`checkbox-${escapedName}-${facetText.replace(/\s+/g, '_')}`}
+            value={facetText}
             onClick={handleOnClick}
           />
         );

--- a/packages/discovery-react-components/src/components/SearchFacets/messages.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/messages.ts
@@ -1,4 +1,6 @@
 export interface Messages {
+  labelText: string;
+  labelTextWithCount: string;
   clearAllButtonText: string;
   clearFacetTitle: string;
   clearFacetSelectionTitle: string;
@@ -9,6 +11,8 @@ export interface Messages {
   dynamicFacetsLabel: string;
 }
 export const defaultMessages: Messages = {
+  labelText: '{facetText}',
+  labelTextWithCount: '{facetText} ({count})',
   clearAllButtonText: 'Clear all',
   clearFacetTitle: 'Clear all selected items',
   clearFacetSelectionTitle: 'Clear selected item',

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
@@ -21,6 +21,7 @@ export interface SearchFilterFacets {
 }
 
 export interface SelectableDynamicFacets extends DiscoveryV2.QuerySuggestedRefinement {
+  matching_results?: number;
   selected?: boolean;
 }
 


### PR DESCRIPTION
#### What do these changes do/fix?
Adds the number of found documents to each search facet label. The search facets are ordered in descending order. Does not show a count for Dynamic Facets as those are not supported by the API yet.
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/59846843/77798088-37867d00-7040-11ea-9a15-39bc842101da.gif)

https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/911

#### How do you test/verify these changes?
- Run `yarn storybook` inside `discovery-react-components`, click on Search Facets and see the document counts are now there.
- Or link components to `discovery-tooling` and see the search facets now have result counts.

#### Have you documented your changes (if necessary)?
Cypress tests in the example app have been updated.

#### Are there any breaking changes included in this pull request?
No