### PR TITLE
chore: remove independent versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "packages": ["packages/*"],
-  "version": "independent",
+  "version": "1.1.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
@@ -9,7 +9,7 @@
       "allowBranch": ["develop", "release/*", "hotfix/*"]
     },
     "version": {
-      "message": "chore: publish to NPM [ci skip]",
+      "message": "chore: publish %s [ci skip]",
       "ignoreChanges": ["examples/**"]
     }
   }

--- a/packages/discovery-styles/package.json
+++ b/packages/discovery-styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibm-watson/discovery-styles",
-  "version": "1.1.1",
+  "version": "1.1.0",
   "description": "Discovery components SASS/CSS styles used with discovery components",
   "license": "Apache-2.0",
   "author": "IBM Corp.",


### PR DESCRIPTION
#### What do these changes do/fix?

We don't benefit much from doing independent versioning. storage space on npm in cheap -> remembering which packages go with each other is not.

This swaps out our versioning process from `independent` to the default `fixed` versioning. lerna will manually go through and update the `lerna.json` and various `package.json` files after a release.

#### How do you test/verify these changes?

run `npx lerna version --allowBranch remove_independent_versioning` to validate that versions for all packages are kept in sync (seems like the `styles` was out of sync)

#### Have you documented your changes (if necessary)?

N/A

#### Are there any breaking changes included in this pull request?

N/A
