### PR TITLE
fix: add a callback - handleSelectedResult to SearchResults

### DIFF
--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -74,7 +74,7 @@ export interface SearchResultsProps {
    */
   messages?: Partial<Messages>;
   /**
-   * override default messages for the component by specifying custom and/or internationalized text strings
+   * callback function from the component for sending document
    */
   handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void | undefined;
 }

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -76,7 +76,7 @@ export interface SearchResultsProps {
   /**
    * callback function from the component for sending document
    */
-  onSelectResult?: (document: DiscoveryV2.QueryResult) => void | undefined;
+  onSelectResult?: (document: { document: DiscoveryV2.QueryResult }) => void | undefined;
 }
 
 const SearchResults: React.FunctionComponent<SearchResultsProps> = ({

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -73,6 +73,10 @@ export interface SearchResultsProps {
    * override default messages for the component by specifying custom and/or internationalized text strings
    */
   messages?: Partial<Messages>;
+  /**
+   * override default messages for the component by specifying custom and/or internationalized text strings
+   */
+  handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void | undefined;
 }
 
 const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
@@ -86,7 +90,8 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
   passageTextClassName,
   showTablesOnlyToggle,
   showTablesOnly = false,
-  messages = defaultMessages
+  messages = defaultMessages,
+  handleSelectedResult
 }) => {
   const mergedMessages = { ...defaultMessages, ...messages };
 
@@ -207,6 +212,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
                     showTablesOnlyResults={showTablesOnlyResults}
                     table={table}
                     messages={mergedMessages}
+                    handleSelectedResult={handleSelectedResult}
                   />
                 );
               })
@@ -231,6 +237,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
                     usePassages={displaySettings.usePassages}
                     dangerouslyRenderHtml={dangerouslyRenderHtml}
                     messages={mergedMessages}
+                    handleSelectedResult={handleSelectedResult}
                   />
                 );
               })}

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -76,7 +76,7 @@ export interface SearchResultsProps {
   /**
    * callback function from the component for sending document
    */
-  handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void | undefined;
+  onSelectResult?: (document: DiscoveryV2.QueryResult) => void | undefined;
 }
 
 const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
@@ -91,7 +91,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
   showTablesOnlyToggle,
   showTablesOnly = false,
   messages = defaultMessages,
-  handleSelectedResult
+  onSelectResult
 }) => {
   const mergedMessages = { ...defaultMessages, ...messages };
 
@@ -212,7 +212,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
                     showTablesOnlyResults={showTablesOnlyResults}
                     table={table}
                     messages={mergedMessages}
-                    handleSelectedResult={handleSelectedResult}
+                    onSelectResult={onSelectResult}
                   />
                 );
               })
@@ -237,7 +237,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
                     usePassages={displaySettings.usePassages}
                     dangerouslyRenderHtml={dangerouslyRenderHtml}
                     messages={mergedMessages}
-                    handleSelectedResult={handleSelectedResult}
+                    onSelectResult={onSelectResult}
                   />
                 );
               })}

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -78,7 +78,7 @@ export interface ResultProps {
   /**
    * callback function from the component for sending document
    */
-  onSelectResult?: (document: DiscoveryV2.QueryResult) => void;
+  onSelectResult?: (document: { document: DiscoveryV2.QueryResult }) => void;
 }
 export const Result: React.FunctionComponent<ResultProps> = ({
   bodyField,

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -78,7 +78,7 @@ export interface ResultProps {
   /**
    * callback function from the component for sending document
    */
-  handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void;
+  onSelectResult?: (document: DiscoveryV2.QueryResult) => void;
 }
 export const Result: React.FunctionComponent<ResultProps> = ({
   bodyField,
@@ -92,7 +92,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
   table,
   dangerouslyRenderHtml,
   usePassages,
-  handleSelectedResult,
+  onSelectResult,
   messages
 }) => {
   const { setSelectedResult } = useContext(SearchApi);
@@ -151,7 +151,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
         window.open(url);
       } else if (result) {
         setSelectedResult({ document: result, element, elementType });
-        handleSelectedResult && handleSelectedResult({ document: result });
+        onSelectResult && onSelectResult({ document: result });
       }
     };
   };

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -75,6 +75,10 @@ export interface ResultProps {
    * override default messages for the component by specifying custom and/or internationalized text strings
    */
   messages: Partial<Messages>;
+  /**
+   * override default messages for the component by specifying custom and/or internationalized text strings
+   */
+  handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void;
 }
 export const Result: React.FunctionComponent<ResultProps> = ({
   bodyField,
@@ -88,6 +92,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
   table,
   dangerouslyRenderHtml,
   usePassages,
+  handleSelectedResult,
   messages
 }) => {
   const { setSelectedResult } = useContext(SearchApi);
@@ -146,6 +151,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
         window.open(url);
       } else if (result) {
         setSelectedResult({ document: result, element, elementType });
+        handleSelectedResult && handleSelectedResult({ document: result });
       }
     };
   };

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -76,7 +76,7 @@ export interface ResultProps {
    */
   messages: Partial<Messages>;
   /**
-   * override default messages for the component by specifying custom and/or internationalized text strings
+   * callback function from the component for sending document
    */
   handleSelectedResult?: (document: DiscoveryV2.QueryResult) => void;
 }

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -151,6 +151,7 @@ export const Result: React.FunctionComponent<ResultProps> = ({
         window.open(url);
       } else if (result) {
         setSelectedResult({ document: result, element, elementType });
+        //When onSelectResult props is present, send back document
         onSelectResult && onSelectResult({ document: result });
       }
     };

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
@@ -15,6 +15,7 @@ import SearchResults, { SearchResultsProps } from 'components/SearchResults/Sear
 interface Setup {
   searchResults: RenderResult;
   selectResultMock: jest.Mock;
+  onSelectResult: jest.Mock;
 }
 
 function setup(
@@ -54,7 +55,8 @@ function setup(
   );
   return {
     searchResults,
-    selectResultMock: api.setSelectedResult
+    selectResultMock: api.setSelectedResult,
+    onSelectResult: api.setSelectedResult
   };
 }
 
@@ -66,6 +68,7 @@ describe('<Result />', () => {
   let collectionsResults: Collection[] | undefined;
   let fetchDocumentsResponseStore: any;
   let componentProps: Partial<SearchResultsProps> = {};
+  let onSelectResult: jest.Mock;
 
   beforeEach(() => {
     browserWindow.open = jest.fn();
@@ -190,15 +193,20 @@ describe('<Result />', () => {
 
     describe('on result click', () => {
       beforeEach(() => {
-        ({ selectResultMock, searchResults } = setup({ queryResults }));
+        componentProps.onSelectResult = jest.fn();
+        ({ selectResultMock, searchResults, onSelectResult } = setup(
+          { queryResults },
+          componentProps
+        ));
         fireEvent.click(searchResults.getByText('View document'));
       });
 
-      test('will call onSelectResult with result and no element as parameters by default', () => {
+      test('will call onSelectResult and with result and no element as parameters by default', () => {
         expect(selectResultMock.mock.calls.length).toBe(1);
         expect(selectResultMock.mock.calls[0][0].document).toBe(queryResults![0]);
         expect(selectResultMock.mock.calls[0][0].element).toBe(null);
         expect(selectResultMock.mock.calls[0][0].elementType).toBe(null);
+        expect(onSelectResult.mock.calls[0][0].document).toBe(queryResults![0]);
       });
     });
 

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/__tests__/Result.test.tsx
@@ -201,7 +201,7 @@ describe('<Result />', () => {
         fireEvent.click(searchResults.getByText('View document'));
       });
 
-      test('will call onSelectResult and with result and no element as parameters by default', () => {
+      test('will call onSelectResult with result and no element as parameters by default', () => {
         expect(selectResultMock.mock.calls.length).toBe(1);
         expect(selectResultMock.mock.calls[0][0].document).toBe(queryResults![0]);
         expect(selectResultMock.mock.calls[0][0].element).toBe(null);


### PR DESCRIPTION
#### What do these changes do/fix?

This PR handles and adds a callback - `handleSelectedResult` and pass document, so that `document` will be readily available when the user clicks on "view passage in document" etc.

Helps fixes: https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1239

#### How do you test/verify these changes?
Link this and test PR: https://github.ibm.com/Watson-Discovery/discovery-tooling/pull/7356

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No
