### PR TITLE
fix: select field to display as title

### DIFF
--- a/packages/discovery-react-components/src/utils/getDocumentTitle.ts
+++ b/packages/discovery-react-components/src/utils/getDocumentTitle.ts
@@ -7,7 +7,7 @@ export const getDocumentTitle = (
 ): string => {
   if (document) {
     return (
-      document[titleField] ||
+      get(document, titleField) ||
       get(document, 'extracted_metadata.title') ||
       get(document, 'extracted_metadata.filename') ||
       document.document_id


### PR DESCRIPTION
#### What do these changes do/fix?
Changing "Select field to display as titles" didn't work for nested object values even though the value was available in the json
 <!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
Link react component with discovery tooling, run the app and follow these steps:
1- got to Simple Document and search for Pak.
2- On the Improvement tools panel, select Customize display, then choose Search results. In the Select field to display as titles, choose extracted_metadata.file_type from the drop-down 

The document identifier in each search result should switch from the document name to the file type, this is broken on tooling right now.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
