### PR TITLE
fix: carbon component dependency outside example app

### DIFF
--- a/packages/discovery-styles/scss/components/search-input/_search-input.scss
+++ b/packages/discovery-styles/scss/components/search-input/_search-input.scss
@@ -8,7 +8,7 @@
 }
 
 .#{$prefix}--search-autocompletion {
-  @include layer('overlay');
+  @include box-shadow;
   left: 0;
   position: absolute;
   right: 0;

--- a/packages/discovery-styles/scss/components/search-results/_search-results.scss
+++ b/packages/discovery-styles/scss/components/search-results/_search-results.scss
@@ -24,7 +24,7 @@ $result-table-fade-offset: calc(#{$result-element-max-height} - #{$result-table-
 }
 
 .#{$prefix}--search-result {
-  @include layer('overlay');
+  @include box-shadow;
   background-color: $result-background;
   padding: $spacing-05;
   margin: $layout-01 0;

--- a/packages/discovery-styles/scss/index.scss
+++ b/packages/discovery-styles/scss/index.scss
@@ -6,8 +6,6 @@ $css--use-layer: true !default;
 @import '~carbon-components/scss/globals/scss/_typography.scss';
 @import '~carbon-components/scss/globals/scss/_colors.scss';
 @import '~carbon-components/scss/globals/scss/_layout.scss';
-// Removing _layer.scss per: https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1408
-// @import '~carbon-components/scss/globals/scss/_layer.scss';
 
 // Component styles
 @import 'components/search-input/search-input';

--- a/packages/discovery-styles/scss/index.scss
+++ b/packages/discovery-styles/scss/index.scss
@@ -5,8 +5,9 @@ $css--use-layer: true !default;
 @import '~carbon-components/scss/globals/scss/_css--font-face.scss';
 @import '~carbon-components/scss/globals/scss/_typography.scss';
 @import '~carbon-components/scss/globals/scss/_colors.scss';
-@import '~carbon-components/scss/globals/scss/_layer.scss';
 @import '~carbon-components/scss/globals/scss/_layout.scss';
+// Removing _layer.scss per: https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1408
+// @import '~carbon-components/scss/globals/scss/_layer.scss';
 
 // Component styles
 @import 'components/search-input/search-input';


### PR DESCRIPTION
#### What do these changes do/fix?
https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1408

Carbon component dependency outside example app


#### How do you test/verify these changes?
1. [Setup create react app](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app
) 
2. Pull down this PR.
3. Follow steps https://github.com/watson-developer-cloud/discovery-components#using-discovery-components-in-a-react-application to setup stuff. 
4. Under create-react-app -> cd node_modules/react -> yarn link
5. Under components repo -> discovery-react-components -> yarn link "react" (react version match needed)
6. Under components repo  run `yarn link` under `discovery-react-components` and ` discovery-styles`
7. Under create-react-app -> yarn link "@ibm-watson/discovery-react-components"  & yarn link "@ibm-watson/discovery-styles"
8. Under create-react-app -> `npm start`
9. Should be able to load the UI 

#### Have you documented your changes (if necessary)?
No

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
