### PR TITLE
[WIP] fix: implement search facet results label

### DIFF
--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -50,6 +50,12 @@ describe('Multi-Select Facets', () => {
         .should('have.length', 3);
     });
 
+    it('shows the facet matching results count', () => {
+      cy.get('@cityFacet')
+        .contains('Boston, MA (30000)')
+        .should('exist');
+    });
+
     describe('and a facet filter is selected', () => {
       beforeEach(() => {
         cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryAmesJSON').as(

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -50,6 +50,12 @@ describe('Single-Select Facets', () => {
         .should('have.length', 3);
     });
 
+    it('shows the facet matching results count', () => {
+      cy.get('@cityFacet')
+        .contains('Boston, MA (30000)')
+        .should('exist');
+    });
+
     describe('and a facet filter is selected', () => {
       beforeEach(() => {
         cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryAmesJSON').as(

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -54,7 +54,7 @@ interface SearchFacetsProps {
 const SearchFacets: FC<SearchFacetsProps> = ({
   showCollections = true,
   showDynamicFacets = true,
-  showMatchingResults = false,
+  showMatchingResults = true,
   messages = defaultMessages,
   overrideComponentSettingsAggregations,
   collapsedFacetsCount = 5

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.tsx
@@ -22,13 +22,11 @@ interface Setup {
 interface SetupConfig {
   filter: string;
   collapsedFacetsCount: number;
-  showMatchingResults: boolean;
 }
 
 const defaultSetupConfig: SetupConfig = {
   filter: '',
-  collapsedFacetsCount: 5,
-  showMatchingResults: true
+  collapsedFacetsCount: 5
 };
 
 const setup = (setupConfig: Partial<SetupConfig> = {}): Setup => {
@@ -52,10 +50,7 @@ const setup = (setupConfig: Partial<SetupConfig> = {}): Setup => {
   };
   const searchFacetsComponent = render(
     wrapWithContext(
-      <SearchFacets
-        collapsedFacetsCount={mergedSetupConfig.collapsedFacetsCount}
-        showMatchingResults={mergedSetupConfig.showMatchingResults}
-      />,
+      <SearchFacets collapsedFacetsCount={mergedSetupConfig.collapsedFacetsCount} />,
       api,
       context
     )

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -21,7 +21,6 @@ interface SetupConfig {
   componentSettingsAggregations: DiscoveryV2.ComponentSettingsAggregation[];
   collapsedFacetsCount: number;
   aggregationResults: DiscoveryV2.QueryAggregation[] | undefined;
-  showMatchingResults: boolean;
 }
 
 const aggregationComponentSettings: DiscoveryV2.ComponentSettingsAggregation[] = [
@@ -41,8 +40,7 @@ const defaultSetupConfig: SetupConfig = {
   filter: '',
   componentSettingsAggregations: aggregationComponentSettings,
   collapsedFacetsCount: 5,
-  aggregationResults: weirdFacetsQueryResponse.result.aggregations,
-  showMatchingResults: true
+  aggregationResults: weirdFacetsQueryResponse.result.aggregations
 };
 
 const updateSelectionSettings = (
@@ -79,7 +77,6 @@ const setup = (setupConfig: Partial<SetupConfig> = {}): Setup => {
       <SearchFacets
         collapsedFacetsCount={mergedSetupConfig.collapsedFacetsCount}
         overrideComponentSettingsAggregations={mergedSetupConfig.componentSettingsAggregations}
-        showMatchingResults={mergedSetupConfig.showMatchingResults}
       />,
       api,
       context


### PR DESCRIPTION
#### What do these changes do/fix?
Changes flag `showMatchingResults` to true. This shows the matching results count next to each search facet label. This is the final part of [issue 911](https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/911).

This will remain a draft until https://github.ibm.com/Watson-Discovery/wire-plugin-tracker/issues/591 is resolved.

#### How do you test/verify these changes?
- Run linked to tooling and see the result counts next to the labels
- See all Cypress and unit tests are passing
<img width="124" alt="Screen Shot 2020-04-13 at 3 22 57 PM" src="https://user-images.githubusercontent.com/59846843/79364435-f8489f00-7f0e-11ea-8f7a-d812392fafb6.png">

#### Have you documented your changes (if necessary)?
Tests have been updated.

#### Are there any breaking changes included in this pull request?
No