### PR TITLE
fix: readme setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   * [Manual setup](#manual-setup)
     + [Windows Only](#windows-only)
 - [Using Discovery Components in a React application](#using-discovery-components-in-a-react-application)
+  * [Interacting with Discovery data in custom components](#interacting-with-discovery-data-in-custom-components)
 - [Development](#development)
   * [Project structure](#project-structure)
   * [Install](#install)
@@ -179,125 +180,125 @@ If you don't have a React application already, start with [create react app](htt
 
 3. Add the `DiscoverySearch` component with corresponding `searchClient` and optionally any components you would like to use to display Discovery Search Results.
 
-   ```jsx
-   // src/App.js
-  import React from 'react';
-  import {
-    DiscoverySearch,
-    SearchInput,
-    SearchResults,
-    SearchFacets,
-    ResultsPagination,
-    DocumentPreview
-  } from '@ibm-watson/discovery-react-components';
-  import DiscoveryV2 from 'ibm-watson/discovery/v2';
-  import { BearerTokenAuthenticator } from 'ibm-watson/auth';
-  import '@ibm-watson/discovery-styles/scss/index.scss';
-  // Replace these values
-  const bearerToken = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details which expires daily
-  const url = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details
-  const version = '{REPLACE_ME}'; // YYYY-MM-DD date format
-  const projectId = '{REPLACE_ME}'; // retrieved from Discovery Tooling UI
-  const App = () => {
-    let authenticator, searchClient, success;
-    try {
-      // see https://github.com/IBM/node-sdk-core/blob/master/AUTHENTICATION.md#bearer-token-authentication
-      authenticator = new BearerTokenAuthenticator({ bearerToken });
-      searchClient = new DiscoveryV2({ url, version, authenticator });
-      success = true;
-    } catch (err) {
-      console.error(err);
+  ```jsx
+    // src/App.js
+    import React from 'react';
+    import {
+      DiscoverySearch,
+      SearchInput,
+      SearchResults,
+      SearchFacets,
+      ResultsPagination,
+      DocumentPreview
+    } from '@ibm-watson/discovery-react-components';
+    import DiscoveryV2 from 'ibm-watson/discovery/v2';
+    import { BearerTokenAuthenticator } from 'ibm-watson/auth';
+    import '@ibm-watson/discovery-styles/scss/index.scss';
+    // Replace these values
+    const bearerToken = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details which expires daily
+    const url = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details
+    const version = '{REPLACE_ME}'; // YYYY-MM-DD date format
+    const projectId = '{REPLACE_ME}'; // retrieved from Discovery Tooling UI
+    const App = () => {
+      let authenticator, searchClient, success;
+      try {
+        // see https://github.com/IBM/node-sdk-core/blob/master/AUTHENTICATION.md#bearer-token-authentication
+        authenticator = new BearerTokenAuthenticator({ bearerToken });
+        searchClient = new DiscoveryV2({ url, version, authenticator });
+        success = true;
+      } catch (err) {
+        console.error(err);
+      }
+      return success ? (
+          <DiscoverySearch searchClient={searchClient} projectId={projectId}>
+            <SearchInput />
+            <SearchResults />
+            <SearchFacets />
+            <ResultsPagination />
+            <DocumentPreview />
+          </DiscoverySearch>
+      ) : (
+        setupMessage()
+      );
+    };
+    function setupMessage() {
+      return (
+        <div style={{
+          textAlign: 'center',
+          margin: '20%',
+          fontSize: '1.5rem',
+        }}>
+          Please replace the constants in App.js in order to see the Discovery sample application.
+          <br /><br />
+          Check the console log for more information if you have replaced these constants and are still seeing this message.
+        </div>
+      );
     }
-    return success ? (
-        <DiscoverySearch searchClient={searchClient} projectId={projectId}>
-          <SearchInput />
-          <SearchResults />
-          <SearchFacets />
-          <ResultsPagination />
-          <DocumentPreview />
-        </DiscoverySearch>
-    ) : (
-      setupMessage()
+    export default App;
+  ```
+
+  For more information on how each component can be customized and configured, check out our hosted [storybook](https://watson-developer-cloud.github.io/discovery-components)
+
+  ### Interacting with Discovery data in custom components
+
+  Interacting with Discovery data is facilitated by the use of [React Context](https://reactjs.org/docs/context.html). The only requirement for a component to consume or request data is that it be nested underneath the `DiscoverySearch` component.
+
+  ex.
+
+  ```jsx
+  // src/App.js
+
+  import React from 'react';
+  import { DiscoverySearch } from '@ibm-watson/discovery-react-components';
+  import { MyCustomComponent } from './MyCustomComponent.js';
+
+  const App = () => {
+    // see more detailed searchClient example above for `searchClient` variable
+    return (
+      <DiscoverySearch searchClient={searchClient} projectId={'REPLACE_ME'}>
+        <MyCustomComponent />
+      </DiscoverySearch>
     );
   };
-  function setupMessage() {
-    return (
-      <div style={{
-        textAlign: 'center',
-        margin: '20%',
-        fontSize: '1.5rem',
-      }}>
-        Please replace the constants in App.js in order to see the Discovery sample application.
-        <br /><br />
-        Check the console log for more information if you have replaced these constants and are still seeing this message.
-      </div>
-    );
-  }
+
   export default App;
   ```
 
-For more information on how each component can be customized and configured, check out our hosted [storybook](https://watson-developer-cloud.github.io/discovery-components)
+  ```jsx
+  // src/MyCustomComponent.js
 
-### Interacting with Discovery data in custom components
+  import React from 'react';
+  import { SearchContext, SearchApi } from '@ibm-watson/discovery-react-components';
 
-Interacting with Discovery data is facilitated by the use of [React Context](https://reactjs.org/docs/context.html). The only requirement for a component to consume or request data is that it be nested underneath the `DiscoverySearch` component.
+  const MyCustomComponent = () => {
+    // for more information about the shape of SearchContext, see SearchContextIFC defined in DiscoverySearch.tsx
+    const {
+      searchResponseStore: { data: searchResponse }
+    } = React.useContext(SearchContext);
 
-ex.
+    const { performSearch } = useContext(SearchApi);
+    // for more information about the params needed to perform searches, see the Watson Developer Cloud SDK
+    // DiscoveryV2.QueryParams in https://github.com/watson-developer-cloud/node-sdk/blob/master/discovery/v2.ts
+    const searchParameters = {
+      projectId: 'REPLACE_ME',
+      naturalLanguageQuery: 'SEARCH TERM'
+    };
 
-```jsx
-// src/App.js
-
-import React from 'react';
-import { DiscoverySearch } from '@ibm-watson/discovery-react-components';
-import { MyCustomComponent } from './MyCustomComponent.js';
-
-const App = () => {
-  // see more detailed searchClient example above for `searchClient` variable
-  return (
-    <DiscoverySearch searchClient={searchClient} projectId={'REPLACE_ME'}>
-      <MyCustomComponent />
-    </DiscoverySearch>
-  );
-};
-
-export default App;
-```
-
-```jsx
-// src/MyCustomComponent.js
-
-import React from 'react';
-import { SearchContext, SearchApi } from '@ibm-watson/discovery-react-components';
-
-const MyCustomComponent = () => {
-  // for more information about the shape of SearchContext, see SearchContextIFC defined in DiscoverySearch.tsx
-  const {
-    searchResponseStore: { data: searchResponse }
-  } = React.useContext(SearchContext);
-
-  const { performSearch } = useContext(SearchApi);
-  // for more information about the params needed to perform searches, see the Watson Developer Cloud SDK
-  // DiscoveryV2.QueryParams in https://github.com/watson-developer-cloud/node-sdk/blob/master/discovery/v2.ts
-  const searchParameters = {
-    projectId: 'REPLACE_ME',
-    naturalLanguageQuery: 'SEARCH TERM'
+    return (
+      <div>
+        There are {searchResponse.matching_results} results
+        <button
+          onClick={() => {
+            performSearch(searchParameters);
+          }}
+        >
+          Click here to search
+        </button>
+      </div>
+    );
   };
 
-  return (
-    <div>
-      There are {searchResponse.matching_results} results
-      <button
-        onClick={() => {
-          performSearch(searchParameters);
-        }}
-      >
-        Click here to search
-      </button>
-    </div>
-  );
-};
-
-export default MyCustomComponent;
+  export default MyCustomComponent;
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -157,13 +157,13 @@ If you don't have a React application already, start with [create react app](htt
 1. Add the component, style, and client library to your application:
 
    ```
-   yarn add @ibm-watson/discovery-react-components @ibm-watson/discovery-styles ibm-watson carbon-components carbon-components-react
+   yarn add @ibm-watson/discovery-react-components @ibm-watson/discovery-styles ibm-watson carbon-components carbon-components-react carbon-icons
    ```
 
    or
 
    ```
-   npm install --save @ibm-watson/discovery-react-components @ibm-watson/discovery-styles ibm-watson carbon-components carbon-components-react
+   npm install --save @ibm-watson/discovery-react-components @ibm-watson/discovery-styles ibm-watson carbon-components carbon-components-react carbon-icons
    ```
 
 2. Add `node-sass` as a dev dependency

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
   * [Manual setup](#manual-setup)
     + [Windows Only](#windows-only)
 - [Using Discovery Components in a React application](#using-discovery-components-in-a-react-application)
-  * [Interacting with Discovery data in custom components](#interacting-with-discovery-data-in-custom-components)
 - [Development](#development)
   * [Project structure](#project-structure)
   * [Install](#install)
@@ -182,43 +181,59 @@ If you don't have a React application already, start with [create react app](htt
 
    ```jsx
    // src/App.js
-
-   import React from 'react';
-   import {
-     DiscoverySearch,
-     SearchInput,
-     SearchResults,
-     SearchFacets,
-     ResultsPagination,
-     DocumentPreview
-   } from '@ibm-watson/discovery-react-components';
-   import DiscoveryV2 from 'ibm-watson/discovery/v2';
-   import { BearerTokenAuthenticator } from 'ibm-watson/auth';
-   import '@ibm-watson/discovery-styles/scss/index.scss';
-
-   // Replace these values
-   const bearerToken = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details which expires daily
-   const url = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details
-   const version = '{REPLACE_ME}'; // YYYY-MM-DD date format
-   const projectId = '{REPLACE_ME}'; // retrieved from Discovery Tooling UI
-
-   const App = () => {
-     // see https://github.com/IBM/node-sdk-core/blob/master/AUTHENTICATION.md#bearer-token-authentication
-     const authenticator = new BearerTokenAuthenticator({ bearerToken });
-     const searchClient = new DiscoveryV2({ url, version, authenticator });
-
-     return (
-       <DiscoverySearch searchClient={searchClient} projectId={projectId}>
-         <SearchInput />
-         <SearchResults />
-         <SearchFacets />
-         <ResultsPagination />
-         <DocumentPreview />
-       </DiscoverySearch>
-     );
-   };
-
-   export default App;
+  import React from 'react';
+  import {
+    DiscoverySearch,
+    SearchInput,
+    SearchResults,
+    SearchFacets,
+    ResultsPagination,
+    DocumentPreview
+  } from '@ibm-watson/discovery-react-components';
+  import DiscoveryV2 from 'ibm-watson/discovery/v2';
+  import { BearerTokenAuthenticator } from 'ibm-watson/auth';
+  import '@ibm-watson/discovery-styles/scss/index.scss';
+  // Replace these values
+  const bearerToken = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details which expires daily
+  const url = '{REPLACE_ME}'; // retrieved from CP4D Admin UI under instance details
+  const version = '{REPLACE_ME}'; // YYYY-MM-DD date format
+  const projectId = '{REPLACE_ME}'; // retrieved from Discovery Tooling UI
+  const App = () => {
+    let authenticator, searchClient, success;
+    try {
+      // see https://github.com/IBM/node-sdk-core/blob/master/AUTHENTICATION.md#bearer-token-authentication
+      authenticator = new BearerTokenAuthenticator({ bearerToken });
+      searchClient = new DiscoveryV2({ url, version, authenticator });
+      success = true;
+    } catch (err) {
+      console.error(err);
+    }
+    return success ? (
+        <DiscoverySearch searchClient={searchClient} projectId={projectId}>
+          <SearchInput />
+          <SearchResults />
+          <SearchFacets />
+          <ResultsPagination />
+          <DocumentPreview />
+        </DiscoverySearch>
+    ) : (
+      setupMessage()
+    );
+  };
+  function setupMessage() {
+    return (
+      <div style={{
+        textAlign: 'center',
+        margin: '20%',
+        fontSize: '1.5rem',
+      }}>
+        Please replace the constants in App.js in order to see the Discovery sample application.
+        <br /><br />
+        Check the console log for more information if you have replaced these constants and are still seeing this message.
+      </div>
+    );
+  }
+  export default App;
    ```
 
 For more information on how each component can be customized and configured, check out our hosted [storybook](https://watson-developer-cloud.github.io/discovery-components)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ If you don't have a React application already, start with [create react app](htt
     );
   }
   export default App;
-   ```
+  ```
 
 For more information on how each component can be customized and configured, check out our hosted [storybook](https://watson-developer-cloud.github.io/discovery-components)
 


### PR DESCRIPTION
#### What do these changes do/fix?
Following "Using Discovery Components in React" steps results in a compile error. There was previously another error resolved by [1408](https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1408), this was an error uncovered after that. 

This also changes the default code snippet so that if a user does not replace all the variables, they will not see en error page but rather a message with instructions.

#### How do you test/verify these changes?
1. Follow steps in https://github.com/watson-developer-cloud/discovery-components#using-discovery-components-in-a-react-application
2. See error:
    ```Module not found: Can't resolve 'carbon-icons' in '.../create-react-app/node_modules/carbon-components-react/es/components/Icon'```
3. Follow steps now documented in this PR.
4. See that project compiles.
5. See that message directing you to set your variables is provided.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No