### PR TITLE
fix: buildAggregationQuery should work with dictionary (nested and filter) aggregations

### DIFF
--- a/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
@@ -72,6 +72,8 @@ describe('Collection Filter', () => {
           beforeEach(() => {
             cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
             cy.get('div[aria-label="Clear Selection"]').click();
+            cy.wait('@postQuery');
+            cy.wait('@postQuery');
             cy.wait('@postQuery').as('clearedCollectionsQueryObject');
           });
 
@@ -106,6 +108,8 @@ describe('Collection Filter', () => {
             beforeEach(() => {
               cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
               cy.get('div[aria-label="Clear Selection"]').click();
+              cy.wait('@postQuery');
+              cy.wait('@postQuery');
               cy.wait('@postQuery').as('originalQueryObject');
             });
 

--- a/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
@@ -72,8 +72,6 @@ describe('Collection Filter', () => {
           beforeEach(() => {
             cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
             cy.get('div[aria-label="Clear Selection"]').click();
-            cy.wait('@postQuery');
-            cy.wait('@postQuery');
             cy.wait('@postQuery').as('clearedCollectionsQueryObject');
           });
 
@@ -108,8 +106,6 @@ describe('Collection Filter', () => {
             beforeEach(() => {
               cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
               cy.get('div[aria-label="Clear Selection"]').click();
-              cy.wait('@postQuery');
-              cy.wait('@postQuery');
               cy.wait('@postQuery').as('originalQueryObject');
             });
 

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -280,6 +280,8 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
                   searchParameters
                 );
                 setAggregationResults(updatedAggregations || null);
+              } else {
+                setAggregationResults(response.result.aggregations);
               }
             }
           });

--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
@@ -1,5 +1,5 @@
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
-import { QueryTermAggregationWithName } from '../utils/searchFacetInterfaces';
+import { QueryAggregationWithName } from '../utils/searchFacetInterfaces';
 
 export const configurationWithOneField: DiscoveryV2.QueryTermAggregation[] = [
   {
@@ -33,7 +33,7 @@ export const configurationWithoutCounts: DiscoveryV2.QueryTermAggregation[] = [
   }
 ];
 
-export const configurationWithTopEntities: QueryTermAggregationWithName[] = [
+export const configurationWithTopEntities: QueryAggregationWithName[] = [
   {
     type: 'term',
     field: 'enriched_text.entities.text',
@@ -43,5 +43,64 @@ export const configurationWithTopEntities: QueryTermAggregationWithName[] = [
   {
     type: 'term',
     field: 'author'
+  }
+];
+
+export const configurationWithNestedQueryAggregation: QueryAggregationWithName[] = [
+  {
+    type: 'term',
+    field: 'enriched_text.entities.text',
+    count: 12,
+    name: 'entities'
+  },
+  {
+    type: 'term',
+    field: 'author'
+  },
+  {
+    type: 'nested',
+    path: 'enriched_text.entities',
+    matching_results: 496,
+    aggregations: [
+      {
+        type: 'filter',
+        match: 'enriched_text.entities.model_name:"Dictionary:.products"',
+        matching_results: 0,
+        aggregations: [
+          {
+            type: 'term',
+            field: 'enriched_text.entities.text',
+            count: 4,
+            name: 'dict_ypKBKYnM8LOq'
+          }
+        ]
+      }
+    ]
+  }
+];
+
+export const configurationWithFilterQueryAggregation: QueryAggregationWithName[] = [
+  {
+    type: 'term',
+    field: 'enriched_text.entities.text',
+    count: 12,
+    name: 'entities'
+  },
+  {
+    type: 'term',
+    field: 'author'
+  },
+  {
+    type: 'filter',
+    match: 'enriched_text.entities.enriched_text.entities.model_name:"Dictionary:.test"',
+    matching_results: 0,
+    aggregations: [
+      {
+        type: 'term',
+        field: 'enriched_text.entities.enriched_text.entities.text',
+        count: 4,
+        name: 'dict_yqYQPpM8OljE'
+      }
+    ]
   }
 ];

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
@@ -3,7 +3,9 @@ import {
   configurationWithOneField,
   configurationWithTwoFields,
   configurationWithoutCounts,
-  configurationWithTopEntities
+  configurationWithTopEntities,
+  configurationWithFilterQueryAggregation,
+  configurationWithNestedQueryAggregation
 } from 'components/SearchFacets/__fixtures__/configuration';
 
 describe('BuildAggregationQuery', () => {
@@ -26,6 +28,20 @@ describe('BuildAggregationQuery', () => {
     const aggParam = buildAggregationQuery(configurationWithTopEntities);
     expect(aggParam).toEqual(
       '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author)]'
+    );
+  });
+
+  test('it converts configuration with nested query aggregation to expected aggregation parameter', () => {
+    const aggParam = buildAggregationQuery(configurationWithNestedQueryAggregation);
+    expect(aggParam).toEqual(
+      '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities).filter(enriched_text.entities.model_name:"Dictionary:.products").term(enriched_text.entities.text,count:4,name:dict_ypKBKYnM8LOq)]'
+    );
+  });
+
+  test('it converts configuration with filter query aggregation to expected aggregation parameter', () => {
+    const aggParam = buildAggregationQuery(configurationWithFilterQueryAggregation);
+    expect(aggParam).toEqual(
+      '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities.enriched_text.entities.text).filter(enriched_text.entities.enriched_text.entities.model_name:"Dictionary:.test").term(enriched_text.entities.enriched_text.entities.text,count:4,name:dict_yqYQPpM8OljE)]'
     );
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -2,14 +2,36 @@ import { QueryAggregationWithName } from './searchFacetInterfaces';
 
 export const buildAggregationQuery = (configuration: QueryAggregationWithName[]): string => {
   const aggregation = configuration.map(term => {
-    const termCount = term.count ? ',count:' + term.count : '';
-    const termName = term.name ? ',name:' + term.name : '';
-    let nestedTypeTermAgg = '';
-    if (term.field.includes('enriched_') && term.field.includes('entities.text')) {
-      const topLevelTermEntityField = term.field.split('.')[0];
-      nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
+    if (term.type === 'term') {
+      const termCount = term.count ? ',count:' + term.count : '';
+      const termName = term.name ? ',name:' + term.name : '';
+      let nestedTypeTermAgg = '';
+      if (term.field.includes('enriched_') && term.field.includes('entities.text')) {
+        const topLevelTermEntityField = term.field.split('.')[0];
+        nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
+      }
+      return 'term(' + term.field + termCount + termName + ')' + nestedTypeTermAgg;
+      // This supports nested dictionary aggregations
+    } else {
+      let nestedOrFilterAgg = '';
+      if (term.aggregations && term.aggregations[0]) {
+        const initialNested = 'nested(' + term.path ? term.path : term.aggregations[0].field;
+        nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ')';
+        const matchAgg = term.match ? term.match : term.aggregations[0].match;
+        nestedOrFilterAgg = nestedOrFilterAgg + '.filter(' + matchAgg + ')';
+        let termAggregation;
+        if (term.aggregations[0].aggregations) {
+          termAggregation = term.aggregations[0].aggregations[0];
+        } else {
+          termAggregation = term.aggregations[0];
+        }
+        nestedOrFilterAgg += '.term(' + termAggregation.field;
+        const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
+        const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
+        nestedOrFilterAgg = nestedOrFilterAgg + termCount + termName + ')';
+      }
+      return nestedOrFilterAgg;
     }
-    return 'term(' + term.field + termCount + termName + ')' + nestedTypeTermAgg;
   });
   return '[' + aggregation.toString() + ']';
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -2,7 +2,7 @@ import { QueryAggregationWithName } from './searchFacetInterfaces';
 
 export const buildAggregationQuery = (configuration: QueryAggregationWithName[]): string => {
   const aggregation = configuration.map(term => {
-    if (term.type === 'term') {
+    if (term.type === 'term' && term.field) {
       const termCount = term.count ? ',count:' + term.count : '';
       const termName = term.name ? ',name:' + term.name : '';
       let nestedTypeTermAgg = '';

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -15,20 +15,20 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
     } else {
       let nestedOrFilterAgg = '';
       if (term.aggregations && term.aggregations[0]) {
-        const initialNested = 'nested(' + term.path ? term.path : term.aggregations[0].field;
-        nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ')';
+        nestedOrFilterAgg += 'nested(';
+        const initialNested = term.path ? term.path : term.aggregations[0].field;
         const matchAgg = term.match ? term.match : term.aggregations[0].match;
-        nestedOrFilterAgg = nestedOrFilterAgg + '.filter(' + matchAgg + ')';
+        nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
         let termAggregation;
         if (term.aggregations[0].aggregations) {
           termAggregation = term.aggregations[0].aggregations[0];
         } else {
           termAggregation = term.aggregations[0];
         }
-        nestedOrFilterAgg += '.term(' + termAggregation.field;
         const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
         const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
-        nestedOrFilterAgg = nestedOrFilterAgg + termCount + termName + ')';
+        nestedOrFilterAgg =
+          nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
       }
       return nestedOrFilterAgg;
     }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -11,7 +11,7 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
         nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
       }
       return 'term(' + term.field + termCount + termName + ')' + nestedTypeTermAgg;
-      // This supports nested dictionary aggregations
+      // This supports nested and filter aggregations, including dictionary aggregations
     } else {
       let nestedOrFilterAgg = '';
       if (term.aggregations && term.aggregations[0]) {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -1,37 +1,39 @@
 import { QueryAggregationWithName } from './searchFacetInterfaces';
 
 export const buildAggregationQuery = (configuration: QueryAggregationWithName[]): string => {
-  const aggregation = configuration.map(term => {
-    if (term.type === 'term' && term.field) {
-      const termCount = term.count ? ',count:' + term.count : '';
-      const termName = term.name ? ',name:' + term.name : '';
-      let nestedTypeTermAgg = '';
-      if (term.field.includes('enriched_') && term.field.includes('entities.text')) {
-        const topLevelTermEntityField = term.field.split('.')[0];
-        nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
-      }
-      return 'term(' + term.field + termCount + termName + ')' + nestedTypeTermAgg;
-      // This supports nested and filter aggregations, including dictionary aggregations
-    } else {
-      let nestedOrFilterAgg = '';
-      if (term.aggregations && term.aggregations[0]) {
-        nestedOrFilterAgg += 'nested(';
-        const initialNested = term.path ? term.path : term.aggregations[0].field;
-        const matchAgg = term.match ? term.match : term.aggregations[0].match;
-        nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
-        let termAggregation;
-        if (term.aggregations[0].aggregations) {
-          termAggregation = term.aggregations[0].aggregations[0];
-        } else {
-          termAggregation = term.aggregations[0];
+  const aggregation = configuration.map(
+    ({ type, count, name, field, aggregations, match, path }) => {
+      if (type === 'term' && field) {
+        const termCount = count ? ',count:' + count : '';
+        const termName = name ? ',name:' + name : '';
+        let nestedTypeTermAgg = '';
+        if (field.includes('enriched_') && field.includes('entities.text')) {
+          const topLevelTermEntityField = field.split('.')[0];
+          nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
         }
-        const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
-        const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
-        nestedOrFilterAgg =
-          nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
+        return 'term(' + field + termCount + termName + ')' + nestedTypeTermAgg;
+        // This supports nested and filter aggregations, including dictionary aggregations
+      } else {
+        let nestedOrFilterAgg = '';
+        if (aggregations && aggregations[0]) {
+          nestedOrFilterAgg += 'nested(';
+          const initialNested = path ? path : aggregations[0].field;
+          const matchAgg = match ? match : aggregations[0].match;
+          nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
+          let termAggregation;
+          if (aggregations[0].aggregations) {
+            termAggregation = aggregations[0].aggregations[0];
+          } else {
+            termAggregation = aggregations[0];
+          }
+          const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
+          const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
+          nestedOrFilterAgg =
+            nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
+        }
+        return nestedOrFilterAgg;
       }
-      return nestedOrFilterAgg;
     }
-  });
+  );
   return '[' + aggregation.toString() + ']';
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
@@ -51,12 +51,19 @@ export interface QueryAggregationWithName extends DiscoveryV2.QueryAggregation {
   field: string;
   count?: number;
   name?: string;
+  path?: string;
+  match?: string;
+  aggregations?: QueryAggregationWithName[];
 }
 
 export const isQueryAggregationWithName = (
   aggregations?: (DiscoveryV2.QueryAggregation | QueryAggregationWithName)[]
 ): aggregations is QueryAggregationWithName[] => {
-  return (aggregations as QueryAggregationWithName[])[0].field !== undefined;
+  return (
+    (aggregations as QueryAggregationWithName[])[0].field !== undefined ||
+    (aggregations as QueryAggregationWithName[])[0].path !== undefined ||
+    (aggregations as QueryAggregationWithName[])[0].match !== undefined
+  );
 };
 
 export interface SelectableFieldFacetWithCategory {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
@@ -60,11 +60,8 @@ export interface QueryAggregationWithName extends DiscoveryV2.QueryAggregation {
 export const isQueryAggregationWithName = (
   aggregations?: (DiscoveryV2.QueryAggregation | QueryAggregationWithName)[]
 ): aggregations is QueryAggregationWithName[] => {
-  return (
-    (aggregations as QueryAggregationWithName[])[0].field !== undefined ||
-    (aggregations as QueryAggregationWithName[])[0].path !== undefined ||
-    (aggregations as QueryAggregationWithName[])[0].match !== undefined
-  );
+  const { field, path, match } = (aggregations as QueryAggregationWithName[])[0];
+  return field !== undefined || path !== undefined || match !== undefined;
 };
 
 export interface SelectableFieldFacetWithCategory {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
@@ -48,12 +48,13 @@ export interface CollectionItem {
 }
 
 export interface QueryAggregationWithName extends DiscoveryV2.QueryAggregation {
-  field: string;
+  field?: string;
   count?: number;
   name?: string;
   path?: string;
   match?: string;
   aggregations?: QueryAggregationWithName[];
+  matching_results?: number;
 }
 
 export const isQueryAggregationWithName = (


### PR DESCRIPTION
#### What do these changes do/fix?
During Integration Testing for the grouping top entities issue, Laxmi caught that dictionary aggregations (`nested` and `filter`) were causing an error. This is because their configuration wasn't checked for in the `buildAggregationQuery`. I've updated to check for them and build the query according to their configuration(s) as well.

#### How do you test/verify these changes?
Link these changes with Tooling and run against a project that includes dictionary facets. For example, there are two set up on `weary-griffin` at this time in the Sample project, if they're still there during testing. See that the expected facets render without error when searching. Check network requests and confirm that what is expected to be sent/received from the `query` endpoint is.

#### Have you documented your changes (if necessary)?
no

#### Are there any breaking changes included in this pull request?
no
