### PR TITLE
feat: add search bar to facet modal

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
@@ -459,7 +459,7 @@ export const facetsQueryResponse: DiscoveryV2.Response<
           matching_results: 57158
         },
         {
-          key: 'api kit',
+          key: 'API kit',
           matching_results: 57158
         },
         {

--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
@@ -428,7 +428,7 @@ export const facetsQueryResponse: DiscoveryV2.Response<
       type: 'term',
       name: 'products',
       field: 'products',
-      count: 11,
+      count: 16,
       results: [
         {
           key: 'discovery',
@@ -472,6 +472,26 @@ export const facetsQueryResponse: DiscoveryV2.Response<
         },
         {
           key: 'language translator',
+          matching_results: 57158
+        },
+        {
+          key: 'machine learning',
+          matching_results: 57158
+        },
+        {
+          key: 'tone analyzer',
+          matching_results: 57158
+        },
+        {
+          key: 'personality insights',
+          matching_results: 57158
+        },
+        {
+          key: 'cybersecurity',
+          matching_results: 57158
+        },
+        {
+          key: 'language classifier',
           matching_results: 57158
         }
       ]

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
@@ -17,6 +17,7 @@ import {
   SelectableFieldFacetWithCategory,
   SelectedFacet
 } from 'components/SearchFacets/utils/searchFacetInterfaces';
+import { MAX_FACETS_UNTIL_MODAL } from '../../constants';
 
 interface CategoryFacetsProps {
   /**
@@ -108,7 +109,8 @@ export const CategoryFacets: FC<CategoryFacetsProps> = ({
   const categoryFacetsToShow = isCollapsed ? facets.slice(0, collapsedFacetsCount - 1) : facets;
   const iconToRender = categoryIsExpanded ? ChevronUp : ChevronDown;
   const totalNumberFacets = facets.length;
-  const showMoreButtonOnClick = totalNumberFacets <= 10 ? toggleFacetsCollapse : setModalOpen;
+  const showMoreButtonOnClick =
+    totalNumberFacets <= MAX_FACETS_UNTIL_MODAL ? toggleFacetsCollapse : setModalOpen;
 
   return (
     <div className={categoryClass}>
@@ -148,10 +150,10 @@ export const CategoryFacets: FC<CategoryFacetsProps> = ({
                 onClick={showMoreButtonOnClick}
                 idSuffix={categoryName}
                 isCollapsed={isCollapsed}
-                isShowAllMessage={totalNumberFacets > 10}
+                isShowAllMessage={totalNumberFacets > MAX_FACETS_UNTIL_MODAL}
                 messages={messages}
               />
-              {totalNumberFacets > 10 && (
+              {totalNumberFacets > MAX_FACETS_UNTIL_MODAL && (
                 <ShowMoreModal
                   messages={messages}
                   aggregationSettings={aggregationSettings}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
@@ -17,7 +17,7 @@ import {
   SelectableFieldFacetWithCategory,
   SelectedFacet
 } from 'components/SearchFacets/utils/searchFacetInterfaces';
-import { MAX_FACETS_UNTIL_MODAL } from '../../constants';
+import { MAX_FACETS_UNTIL_MODAL, MAX_FACETS_UNTIL_SEARCHBAR } from '../../constants';
 
 interface CategoryFacetsProps {
   /**
@@ -166,7 +166,7 @@ export const CategoryFacets: FC<CategoryFacetsProps> = ({
                   shouldDisplayAsMultiSelect={shouldDisplayAsMultiSelect}
                   selectedFacet={selectedFacet}
                   showMatchingResults={showMatchingResults}
-                  hasSearchBar={totalNumberFacets > 15}
+                  hasSearchBar={totalNumberFacets > MAX_FACETS_UNTIL_SEARCHBAR}
                   categoryName={categoryName}
                 />
               )}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
@@ -166,6 +166,7 @@ export const CategoryFacets: FC<CategoryFacetsProps> = ({
                   shouldDisplayAsMultiSelect={shouldDisplayAsMultiSelect}
                   selectedFacet={selectedFacet}
                   showMatchingResults={showMatchingResults}
+                  hasSearchBar={totalNumberFacets > 15}
                   categoryName={categoryName}
                 />
               )}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -21,7 +21,7 @@ import { MultiSelectFacetsGroup } from './MultiSelectFacetsGroup';
 import { SingleSelectFacetsGroup } from './SingleSelectFacetsGroup';
 import { ShowMoreModal } from '../ShowMore/ShowMoreModal';
 import { ShowMoreButton } from '../ShowMore/ShowMoreButton';
-import { MAX_FACETS_UNTIL_MODAL } from '../../constants';
+import { MAX_FACETS_UNTIL_MODAL, MAX_FACETS_UNTIL_SEARCHBAR } from '../../constants';
 
 interface CollapsibleFacetsGroupProps {
   /**
@@ -210,7 +210,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
                   setIsModalOpen={setIsModalOpen}
                   shouldDisplayAsMultiSelect={shouldDisplayAsMultiSelect}
                   selectedFacet={selectedFacetText}
-                  hasSearchBar={totalNumberFacets > 15}
+                  hasSearchBar={totalNumberFacets > MAX_FACETS_UNTIL_SEARCHBAR}
                   showMatchingResults={showMatchingResults}
                 />
               )}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -21,6 +21,7 @@ import { MultiSelectFacetsGroup } from './MultiSelectFacetsGroup';
 import { SingleSelectFacetsGroup } from './SingleSelectFacetsGroup';
 import { ShowMoreModal } from '../ShowMore/ShowMoreModal';
 import { ShowMoreButton } from '../ShowMore/ShowMoreButton';
+import { MAX_FACETS_UNTIL_MODAL } from '../../constants';
 
 interface CollapsibleFacetsGroupProps {
   /**
@@ -125,7 +126,8 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
   const selectedFacetText = get(selectedFacets[0], facetsTextField, '');
   const shouldDisplayAsMultiSelect = areMultiSelectionsAllowed || selectedFacets.length > 1;
   const shouldDisplayClearButton = shouldDisplayAsMultiSelect && selectedFacets.length > 0;
-  const showMoreButtonOnClick = totalNumberFacets <= 10 ? toggleFacetsCollapse : setModalOpen;
+  const showMoreButtonOnClick =
+    totalNumberFacets <= MAX_FACETS_UNTIL_MODAL ? toggleFacetsCollapse : setModalOpen;
   const handleClearFacets = (): void => {
     onClear(aggregationSettings.name || aggregationSettings.field);
   };
@@ -193,10 +195,10 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
                 onClick={showMoreButtonOnClick}
                 idSuffix={facetsLabel}
                 isCollapsed={isCollapsed}
-                isShowAllMessage={totalNumberFacets > 10}
+                isShowAllMessage={totalNumberFacets > MAX_FACETS_UNTIL_MODAL}
                 messages={messages}
               />
-              {totalNumberFacets > 10 && (
+              {totalNumberFacets > MAX_FACETS_UNTIL_MODAL && (
                 <ShowMoreModal
                   messages={messages}
                   aggregationSettings={aggregationSettings}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -210,6 +210,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
                   setIsModalOpen={setIsModalOpen}
                   shouldDisplayAsMultiSelect={shouldDisplayAsMultiSelect}
                   selectedFacet={selectedFacetText}
+                  hasSearchBar={totalNumberFacets > 15}
                   showMatchingResults={showMatchingResults}
                 />
               )}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -106,12 +106,11 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
         // If this is in the Show more modal, we need to check the facet value's temporary selection value
         let facetSelected = !!facet.selected;
         if (tempSelectedFacets) {
-          const tempIndex = tempSelectedFacets.findIndex(
-            ({ selectedFacetKey }) => selectedFacetKey === facetText
-          );
-          if (tempIndex > -1) {
-            facetSelected = tempSelectedFacets[tempIndex].checked;
-          }
+          tempSelectedFacets.find(({ selectedFacetKey, checked }) => {
+            if (selectedFacetKey === facetText) {
+              facetSelected = !!checked;
+            }
+          });
         }
 
         let keyAndIdPrefix = tempSelectedFacets ? 'modal-checkbox' : 'checkbox';

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -104,7 +104,7 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
         const base64data = buff.toString('base64');
 
         // If this is in the Show more modal, we need to check the facet value's temporary selection value
-        let facetSelected: boolean = !!facet.selected;
+        let facetSelected = !!facet.selected;
         if (tempSelectedFacets) {
           const tempIndex = tempSelectedFacets.findIndex(
             ({ selectedFacetKey }) => selectedFacetKey === facetText

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FieldFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FieldFacets.tsx
@@ -1,6 +1,7 @@
 import React, { FC } from 'react';
 import get from 'lodash/get';
 import filter from 'lodash/filter';
+import cloneDeep from 'lodash/cloneDeep';
 import {
   InternalQueryTermAggregation,
   SelectableQueryTermAggregationResult,
@@ -51,11 +52,11 @@ export const FieldFacets: FC<FieldFacetsProps> = ({
   };
 
   const handleOnChange = (selectedFacets: SelectedFacet[]): void => {
-    let updatedFacets = [...allFacets];
+    let updatedFacets = cloneDeep(allFacets);
     selectedFacets.map(({ selectedFacetName, selectedFacetKey, checked }) => {
       const facetsForNameIndex = getFacetsForNameIndex(selectedFacetName);
       if (facetsForNameIndex > -1) {
-        const facetsForName = allFacets[facetsForNameIndex];
+        const facetsForName = updatedFacets[facetsForNameIndex];
         const multiselect = get(facetsForName, 'multiple_selections_allowed', true);
         const facetResults: SelectableQueryTermAggregationResult[] = get(
           facetsForName,
@@ -90,10 +91,10 @@ export const FieldFacets: FC<FieldFacetsProps> = ({
   };
 
   const handleOnClear = (selectedFacetName: string): void => {
-    let updatedFacets = [...allFacets];
+    let updatedFacets = cloneDeep(allFacets);
     const facetsForNameIndex = getFacetsForNameIndex(selectedFacetName);
     if (facetsForNameIndex > -1) {
-      const results = allFacets[facetsForNameIndex].results || [];
+      const results = updatedFacets[facetsForNameIndex].results || [];
       const deselectedResults = (results as SelectableQueryTermAggregationResult[]).map(result => {
         return { ...result, selected: false };
       });

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/EmptyModalState.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/EmptyModalState.tsx
@@ -1,0 +1,12 @@
+import React, { FC } from 'react';
+import { Messages } from 'components/SearchFacets/messages';
+
+interface EmptyModalStateProps {
+  /**
+   * i18n messages for the component
+   */
+  messages: Messages;
+}
+export const EmptyModalState: FC<EmptyModalStateProps> = ({ messages }) => {
+  return <p>{messages.emptyModalSearch}</p>;
+};

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react';
+import { Messages } from 'components/SearchFacets/messages';
+import { Search as CarbonSearchInput } from 'carbon-components-react';
+import {
+  SelectableDynamicFacets,
+  SelectableQueryTermAggregationResult
+} from 'components/SearchFacets/utils/searchFacetInterfaces';
+
+interface ModalSearchInputProps {
+  /**
+   * Facets configuration with fields and results counts
+   */
+  facets: (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[];
+  /**
+   * i18n messages for the component
+   */
+  messages: Messages;
+}
+
+export const ModalSearchInput: FC<ModalSearchInputProps> = ({ facets, messages }) => {
+  const handleOnChange = (event: any) => {
+    let value = event.target.value;
+    console.log(value);
+    console.log(facets[0].key);
+    const tempFacets = facets;
+    let list = tempFacets.filter(facet => {
+      if (facet.key) {
+        return facet.key.toLowerCase().includes(value.toLowerCase());
+      } else {
+        return null;
+      }
+    });
+    console.log(list);
+  };
+
+  return (
+    <CarbonSearchInput
+      labelText={messages.modalSearchBarPrompt}
+      placeHolderText={messages.modalSearchBarPrompt}
+      onChange={handleOnChange}
+    />
+  );
+};

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { Messages } from 'components/SearchFacets/messages';
 import { Search as CarbonSearchInput } from 'carbon-components-react';
 import {
@@ -12,25 +12,38 @@ interface ModalSearchInputProps {
    */
   facets: (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[];
   /**
+   * True if the search facet modal is open
+   */
+  modalIsOpen: boolean;
+  /**
    * i18n messages for the component
    */
   messages: Messages;
 }
 
-export const ModalSearchInput: FC<ModalSearchInputProps> = ({ facets, messages }) => {
+export const ModalSearchInput: FC<ModalSearchInputProps> = ({ facets, modalIsOpen, messages }) => {
+  const [searchBarValue, setSearchBarValue] = useState<any>();
+
+  // Clear search bar if modal is closed
+  if (!modalIsOpen) {
+    setSearchBarValue('');
+    console.log('clear search bar');
+  }
+
   const handleOnChange = (event: any) => {
     let value = event.target.value;
-    console.log(value);
-    console.log(facets[0].key);
-    const tempFacets = facets;
-    let list = tempFacets.filter(facet => {
+    const tempFacets = [...facets];
+
+    const facetList = tempFacets.filter(facet => {
       if (facet.key) {
         return facet.key.toLowerCase().includes(value.toLowerCase());
       } else {
         return null;
       }
     });
-    console.log(list);
+
+    console.log(value);
+    console.log(facetList);
   };
 
   return (

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState } from 'react';
+import React, { FC } from 'react';
 import { Messages } from 'components/SearchFacets/messages';
 import { Search as CarbonSearchInput } from 'carbon-components-react';
 import {
@@ -12,38 +12,33 @@ interface ModalSearchInputProps {
    */
   facets: (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[];
   /**
-   * True if the search facet modal is open
+   * Sets the list of filtered facets
    */
-  modalIsOpen: boolean;
+  setFilteredFacets: any;
   /**
    * i18n messages for the component
    */
   messages: Messages;
 }
 
-export const ModalSearchInput: FC<ModalSearchInputProps> = ({ facets, modalIsOpen, messages }) => {
-  const [searchBarValue, setSearchBarValue] = useState<any>();
-
-  // Clear search bar if modal is closed
-  if (!modalIsOpen) {
-    setSearchBarValue('');
-    console.log('clear search bar');
-  }
-
+export const ModalSearchInput: FC<ModalSearchInputProps> = ({
+  facets,
+  setFilteredFacets,
+  messages
+}) => {
   const handleOnChange = (event: any) => {
-    let value = event.target.value;
+    const value = event.target.value;
     const tempFacets = [...facets];
 
-    const facetList = tempFacets.filter(facet => {
-      if (facet.key) {
-        return facet.key.toLowerCase().includes(value.toLowerCase());
-      } else {
-        return null;
-      }
-    });
-
-    console.log(value);
-    console.log(facetList);
+    setFilteredFacets(
+      tempFacets.filter(facet => {
+        if (facet.key) {
+          return facet.key.toLowerCase().includes(value.toLowerCase());
+        } else {
+          return null;
+        }
+      })
+    );
   };
 
   return (

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useState, useEffect, FormEvent } from 'react';
+import React, { FC, useState, useEffect, SyntheticEvent } from 'react';
 import { Messages } from 'components/SearchFacets/messages';
 import { Search as CarbonSearchInput } from 'carbon-components-react';
 import {
@@ -46,9 +46,10 @@ export const ModalSearchInput: FC<ModalSearchInputProps> = ({
     }
   }, [facets, isModalOpen, setFilteredFacets]);
 
-  const handleOnChange = (event: FormEvent<HTMLInputElement>) => {
-    setValue(event.currentTarget.value);
-    const tempValue = event.currentTarget.value;
+  const handleOnChange = (event: SyntheticEvent<EventTarget>): void => {
+    const target = event.currentTarget as HTMLInputElement;
+    setValue(!!target ? target.value : '');
+    const tempValue = !!target ? target.value : '';
     const tempFacets = [...facets];
     setFilteredFacets(
       tempFacets.filter(facet => {

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react';
+import React, { FC, useState, useEffect, FormEvent } from 'react';
 import { Messages } from 'components/SearchFacets/messages';
 import { Search as CarbonSearchInput } from 'carbon-components-react';
 import {
@@ -14,7 +14,13 @@ interface ModalSearchInputProps {
   /**
    * Sets the list of filtered facets
    */
-  setFilteredFacets: any;
+  setFilteredFacets: (
+    value: (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[]
+  ) => void;
+  /**
+   * Specifies whether the modal is open
+   */
+  isModalOpen: boolean;
   /**
    * i18n messages for the component
    */
@@ -24,25 +30,34 @@ interface ModalSearchInputProps {
 export const ModalSearchInput: FC<ModalSearchInputProps> = ({
   facets,
   setFilteredFacets,
+  isModalOpen,
   messages
 }) => {
-  const handleOnChange = (event: any) => {
-    const value = event.target.value;
-    const tempFacets = [...facets];
+  const [value, setValue] = useState<string>('');
+  useEffect(() => {
+    if (!isModalOpen) {
+      setValue('');
+      setFilteredFacets([...facets]);
+    }
+  }, [facets, isModalOpen, setFilteredFacets]);
 
+  const handleOnChange = (event: FormEvent<HTMLInputElement>) => {
+    setValue(event.currentTarget.value);
+    const tempValue = event.currentTarget.value;
+    const tempFacets = [...facets];
     setFilteredFacets(
       tempFacets.filter(facet => {
         if (facet.key) {
-          return facet.key.toLowerCase().includes(value.toLowerCase());
-        } else {
-          return null;
+          return facet.key.toLowerCase().includes(tempValue.toLowerCase());
         }
+        return null;
       })
     );
   };
 
   return (
     <CarbonSearchInput
+      value={value}
       labelText={messages.modalSearchBarPrompt}
       placeHolderText={messages.modalSearchBarPrompt}
       onChange={handleOnChange}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -22,6 +22,10 @@ interface ModalSearchInputProps {
    */
   isModalOpen: boolean;
   /**
+   * Facet label text
+   */
+  facetsLabel: string;
+  /**
    * i18n messages for the component
    */
   messages: Messages;
@@ -31,6 +35,7 @@ export const ModalSearchInput: FC<ModalSearchInputProps> = ({
   facets,
   setFilteredFacets,
   isModalOpen,
+  facetsLabel,
   messages
 }) => {
   const [value, setValue] = useState<string>('');
@@ -61,6 +66,7 @@ export const ModalSearchInput: FC<ModalSearchInputProps> = ({
       labelText={messages.modalSearchBarPrompt}
       placeHolderText={messages.modalSearchBarPrompt}
       onChange={handleOnChange}
+      data-testid={`search-facet-modal-search-bar-${facetsLabel}`}
     />
   );
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreButton.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreButton.tsx
@@ -32,18 +32,17 @@ export const ShowMoreButton: FC<ShowMoreButtonProps> = ({
   isShowAllMessage,
   messages
 }) => {
-  const showMessage = () => {
-    if (isShowAllMessage) {
-      return messages.collapsedFacetShowAllText;
-    } else if (isCollapsed) {
-      return messages.collapsedFacetShowMoreText;
-    }
-    return messages.collapsedFacetShowLessText;
-  };
+  let message = messages.collapsedFacetShowLessText;
+
+  if (isShowAllMessage) {
+    message = messages.collapsedFacetShowAllText;
+  } else if (isCollapsed) {
+    message = messages.collapsedFacetShowMoreText;
+  }
 
   return (
     <Button kind="ghost" size="small" onClick={onClick} data-testid={`show-more-less-${idSuffix}`}>
-      {showMessage()}
+      {message}
     </Button>
   );
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -110,7 +110,11 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       secondaryButtonText={messages.showMoreModalSecondaryButtonText}
       data-testid={`search-facet-show-more-modal-${facetsLabel}`}
     >
-      {hasSearchBar ? <ModalSearchInput facets={facets} messages={messages} /> : <></>}
+      {hasSearchBar ? (
+        <ModalSearchInput facets={facets} modalIsOpen={isOpen} messages={messages} />
+      ) : (
+        <></>
+      )}
       {shouldDisplayAsMultiSelect ? (
         <MultiSelectFacetsGroup
           messages={messages}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -85,7 +85,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
   const [tempSelectedFacets, setTempSelectedFacets] = useState<SelectedFacet[]>([]);
   const [filteredFacets, setFilteredFacets] = useState<
     (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[]
-  >([]);
+  >();
 
   const handleOnRequestSubmit = () => {
     onChange(tempSelectedFacets);
@@ -118,6 +118,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
           facets={facets}
           messages={messages}
           setFilteredFacets={setFilteredFacets}
+          isModalOpen={isOpen}
         />
       ) : (
         <></>
@@ -125,7 +126,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       {shouldDisplayAsMultiSelect ? (
         <MultiSelectFacetsGroup
           messages={messages}
-          facets={filteredFacets.length != 0 ? filteredFacets : facets}
+          facets={filteredFacets || facets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}
           facetsTextField={facetsTextField}
@@ -136,7 +137,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       ) : (
         <SingleSelectFacetsGroup
           messages={messages}
-          facets={filteredFacets.length != 0 ? filteredFacets : facets}
+          facets={filteredFacets || facets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}
           selectedFacet={selectedFacet}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -11,6 +11,7 @@ import {
 import { MultiSelectFacetsGroup } from '../FacetsGroups/MultiSelectFacetsGroup';
 import { SingleSelectFacetsGroup } from '../FacetsGroups/SingleSelectFacetsGroup';
 import { ModalSearchInput } from './ModalSearchInput';
+import { EmptyModalState } from './EmptyModalState';
 
 interface ShowMoreModalProps {
   /**
@@ -121,6 +122,11 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
           isModalOpen={isOpen}
           facetsLabel={facetsLabel}
         />
+      ) : (
+        <></>
+      )}
+      {filteredFacets && filteredFacets.length == 0 ? (
+        <EmptyModalState messages={messages} />
       ) : (
         <></>
       )}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -99,7 +99,22 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
     setIsModalOpen(false);
   };
 
-  const modalHeading = categoryName ? `${facetsLabel}: ${categoryName}` : facetsLabel;
+  const modalHeading = (
+    <>
+      {categoryName ? `${facetsLabel}: ${categoryName}` : facetsLabel}
+      {hasSearchBar ? (
+        <ModalSearchInput
+          facets={facets}
+          messages={messages}
+          setFilteredFacets={setFilteredFacets}
+          isModalOpen={isOpen}
+          facetsLabel={facetsLabel}
+        />
+      ) : (
+        <></>
+      )}
+    </>
+  );
 
   return (
     <Modal
@@ -114,17 +129,6 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       secondaryButtonText={messages.showMoreModalSecondaryButtonText}
       data-testid={`search-facet-show-more-modal-${facetsLabel}`}
     >
-      {hasSearchBar ? (
-        <ModalSearchInput
-          facets={facets}
-          messages={messages}
-          setFilteredFacets={setFilteredFacets}
-          isModalOpen={isOpen}
-          facetsLabel={facetsLabel}
-        />
-      ) : (
-        <></>
-      )}
       {filteredFacets && filteredFacets.length == 0 ? (
         <EmptyModalState messages={messages} />
       ) : (

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -119,6 +119,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
           messages={messages}
           setFilteredFacets={setFilteredFacets}
           isModalOpen={isOpen}
+          facetsLabel={facetsLabel}
         />
       ) : (
         <></>

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -10,6 +10,7 @@ import {
 } from 'components/SearchFacets/utils/searchFacetInterfaces';
 import { MultiSelectFacetsGroup } from '../FacetsGroups/MultiSelectFacetsGroup';
 import { SingleSelectFacetsGroup } from '../FacetsGroups/SingleSelectFacetsGroup';
+import { ModalSearchInput } from './ModalSearchInput';
 
 interface ShowMoreModalProps {
   /**
@@ -57,6 +58,10 @@ interface ShowMoreModalProps {
    */
   showMatchingResults: boolean;
   /**
+   * If more than 15 facets, adds a search bar
+   */
+  hasSearchBar: boolean;
+  /**
    * Category name if the modal is for a category facet group
    */
   categoryName?: string;
@@ -74,6 +79,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
   shouldDisplayAsMultiSelect,
   selectedFacet,
   showMatchingResults,
+  hasSearchBar,
   categoryName
 }) => {
   const [tempSelectedFacets, setTempSelectedFacets] = useState<SelectedFacet[]>([]);
@@ -104,6 +110,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       secondaryButtonText={messages.showMoreModalSecondaryButtonText}
       data-testid={`search-facet-show-more-modal-${facetsLabel}`}
     >
+      {hasSearchBar ? <ModalSearchInput facets={facets} messages={messages} /> : <></>}
       {shouldDisplayAsMultiSelect ? (
         <MultiSelectFacetsGroup
           messages={messages}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -83,6 +83,9 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
   categoryName
 }) => {
   const [tempSelectedFacets, setTempSelectedFacets] = useState<SelectedFacet[]>([]);
+  const [filteredFacets, setFilteredFacets] = useState<
+    (SelectableDynamicFacets | SelectableQueryTermAggregationResult)[]
+  >([]);
 
   const handleOnRequestSubmit = () => {
     onChange(tempSelectedFacets);
@@ -111,14 +114,18 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       data-testid={`search-facet-show-more-modal-${facetsLabel}`}
     >
       {hasSearchBar ? (
-        <ModalSearchInput facets={facets} modalIsOpen={isOpen} messages={messages} />
+        <ModalSearchInput
+          facets={facets}
+          messages={messages}
+          setFilteredFacets={setFilteredFacets}
+        />
       ) : (
         <></>
       )}
       {shouldDisplayAsMultiSelect ? (
         <MultiSelectFacetsGroup
           messages={messages}
-          facets={facets}
+          facets={filteredFacets.length != 0 ? filteredFacets : facets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}
           facetsTextField={facetsTextField}
@@ -129,7 +136,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
       ) : (
         <SingleSelectFacetsGroup
           messages={messages}
-          facets={facets}
+          facets={filteredFacets.length != 0 ? filteredFacets : facets}
           aggregationSettings={aggregationSettings}
           onChange={onChange}
           selectedFacet={selectedFacet}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -411,6 +411,15 @@ describe('CollapsibleFacetsGroupComponent', () => {
       expect(filteredFacets).toHaveLength(0);
     });
 
+    test('search bar clears when user clicks the clear search button', () => {
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: 'studio' } });
+      expect(productsSearchBar.getAttribute('value')).toBe('studio');
+      const clearSearchBtn = within(productsModal).getByLabelText('Clear search input');
+      fireEvent.click(clearSearchBtn);
+      expect(productsSearchBar.getAttribute('value')).toBe('');
+    });
+
     test('search bar clears on modal cancel', () => {
       // user filters
       fireEvent.focus(productsSearchBar);

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -60,6 +60,7 @@ const setup = (setupConfig: Partial<SetupConfig> = {}): Setup => {
       context
     )
   );
+  fireEvent.focus(window);
   return {
     context,
     performSearchMock,
@@ -200,7 +201,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
                 'speech to text (57158)',
                 'knowledge catalog (57158)',
                 'nlu (57158)',
-                'api kit (57158)',
+                'API kit (57158)',
                 'openpages (57158)',
                 'visual recognition (57158)',
                 'language translator (57158)',
@@ -321,7 +322,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
       'speech to text (57158)',
       'knowledge catalog (57158)',
       'nlu (57158)',
-      'api kit (57158)',
+      'API kit (57158)',
       'openpages (57158)',
       'visual recognition (57158)',
       'language translator (57158)',
@@ -347,10 +348,12 @@ describe('CollapsibleFacetsGroupComponent', () => {
       );
     });
 
-    test('opens modal with search bar and all facets', () => {
+    test('opens modal with an empty search bar and all facets', () => {
       expect(productsSearchBar).toBeDefined();
       const placeHolderText = productsSearchBar.getAttribute('placeholder');
       expect(placeHolderText).toEqual('What are you looking for today?');
+      const searchBarValue = productsSearchBar.getAttribute('value');
+      expect(searchBarValue).toBe('');
       // all facets are initially shown
       const productsFacets = within(productsModal).queryAllByText((content, element) => {
         return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
@@ -362,22 +365,39 @@ describe('CollapsibleFacetsGroupComponent', () => {
       // user filters by "st"
       fireEvent.focus(productsSearchBar);
       fireEvent.change(productsSearchBar, { target: { value: 'st' } });
+      expect(productsSearchBar.getAttribute('value')).toBe('st');
       // only two facets are left showing
       const filteredProductsFacets = within(productsModal).queryAllByText((content, element) => {
         return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
       });
       expect(filteredProductsFacets).toHaveLength(2);
+      const studioFacet = within(productsModal).getByLabelText('studio (57158)');
+      const assistantFacet = within(productsModal).getByLabelText('assistant (32444)');
+      expect(studioFacet).toBeDefined();
+      expect(assistantFacet).toBeDefined();
     });
 
     test('search bar filter is case insensitive', () => {
-      // user filters by "sT"
+      // user filters by "DiScOvErY"
       fireEvent.focus(productsSearchBar);
-      fireEvent.change(productsSearchBar, { target: { value: 'sT' } });
-      // should return two facets which contain "st"
+      fireEvent.change(productsSearchBar, { target: { value: 'DiScOvErY' } });
+      // should return only the "discovery" facet
       const filteredFacets = within(productsModal).queryAllByText((content, element) => {
         return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
       });
-      expect(filteredFacets).toHaveLength(2);
+      expect(filteredFacets).toHaveLength(1);
+      const discoveryFacet = within(productsModal).getByLabelText('discovery (138993)');
+      expect(discoveryFacet).toBeDefined();
+      // user filters by "api KIT"
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: 'api KIT' } });
+      // should return only the "API kit" facet
+      const filteredProductsFacets = within(productsModal).queryAllByText((content, element) => {
+        return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
+      });
+      expect(filteredProductsFacets).toHaveLength(1);
+      const apiFacet = within(productsModal).getByLabelText('API kit (57158)');
+      expect(apiFacet).toBeDefined();
     });
 
     test('no results are shown when facets do not contain the search value', () => {
@@ -398,8 +418,12 @@ describe('CollapsibleFacetsGroupComponent', () => {
       // user exits modal
       const cancelButton = within(productsModal).getByText('Cancel');
       fireEvent.click(cancelButton);
-      // TODO: user reopens modal and search bar is clear
-      //fireEvent.click(searchFacetsComponent.getByTestId('show-more-less-products'));
+      // user reopens modal and search bar is clear
+      fireEvent.click(productsShowMoreButton);
+      const searchBarValue = productsSearchBar.getAttribute('value');
+      expect(searchBarValue).toBe('');
+      const closeButton = within(productsModal).getByTitle('close the modal');
+      fireEvent.click(closeButton);
     });
   });
 

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -203,11 +203,16 @@ describe('CollapsibleFacetsGroupComponent', () => {
                 'api kit (57158)',
                 'openpages (57158)',
                 'visual recognition (57158)',
-                'language translator (57158)'
+                'language translator (57158)',
+                'machine learning (57158)',
+                'tone analyzer (57158)',
+                'personality insights (57158)',
+                'cybersecurity (57158)',
+                'language classifier (57158)'
               ].includes(content)
             );
           });
-          expect(productsFacets).toHaveLength(11);
+          expect(productsFacets).toHaveLength(16);
         });
 
         test('allows for selection and deselection of these facet terms', () => {
@@ -304,6 +309,97 @@ describe('CollapsibleFacetsGroupComponent', () => {
           expect(assistantFacetValues[1]['checked']).toEqual(false);
         });
       });
+    });
+  });
+
+  describe('when there are greater than 15 facet values', () => {
+    const productsFacetArray = [
+      'discovery (138993)',
+      'studio (57158)',
+      'openscale (32444)',
+      'assistant (32444)',
+      'speech to text (57158)',
+      'knowledge catalog (57158)',
+      'nlu (57158)',
+      'api kit (57158)',
+      'openpages (57158)',
+      'visual recognition (57158)',
+      'language translator (57158)',
+      'machine learning (57158)',
+      'tone analyzer (57158)',
+      'personality insights (57158)',
+      'cybersecurity (57158)',
+      'language classifier (57158)'
+    ];
+
+    let productsShowMoreButton: HTMLElement;
+    let productsModal: HTMLElement;
+    let productsSearchBar: HTMLElement;
+
+    beforeEach(() => {
+      const { searchFacetsComponent } = setup();
+      productsShowMoreButton = searchFacetsComponent.getByTestId('show-more-less-products');
+      fireEvent.click(productsShowMoreButton);
+      productsModal = searchFacetsComponent.getByTestId('search-facet-show-more-modal-products');
+      expect(productsModal).toBeDefined();
+      productsSearchBar = within(productsModal).getByTestId(
+        'search-facet-modal-search-bar-products'
+      );
+    });
+
+    test('opens modal with search bar and all facets', () => {
+      expect(productsSearchBar).toBeDefined();
+      const placeHolderText = productsSearchBar.getAttribute('placeholder');
+      expect(placeHolderText).toEqual('What are you looking for today?');
+      // all facets are initially shown
+      const productsFacets = within(productsModal).queryAllByText((content, element) => {
+        return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
+      });
+      expect(productsFacets).toHaveLength(16);
+    });
+
+    test('search bar starts with all facets and filters down based on user input', () => {
+      // user filters by "st"
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: 'st' } });
+      // only two facets are left showing
+      const filteredProductsFacets = within(productsModal).queryAllByText((content, element) => {
+        return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
+      });
+      expect(filteredProductsFacets).toHaveLength(2);
+    });
+
+    test('search bar filter is case insensitive', () => {
+      // user filters by "sT"
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: 'sT' } });
+      // should return two facets which contain "st"
+      const filteredFacets = within(productsModal).queryAllByText((content, element) => {
+        return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
+      });
+      expect(filteredFacets).toHaveLength(2);
+    });
+
+    test('no results are shown when facets do not contain the search value', () => {
+      // user filters by "1"
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: '1' } });
+      // should show no matching facets
+      const filteredFacets = within(productsModal).queryAllByText((content, element) => {
+        return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
+      });
+      expect(filteredFacets).toHaveLength(0);
+    });
+
+    test('search bar clears on modal cancel', () => {
+      // user filters
+      fireEvent.focus(productsSearchBar);
+      fireEvent.change(productsSearchBar, { target: { value: 'studio' } });
+      // user exits modal
+      const cancelButton = within(productsModal).getByText('Cancel');
+      fireEvent.click(cancelButton);
+      // TODO: user reopens modal and search bar is clear
+      //fireEvent.click(searchFacetsComponent.getByTestId('show-more-less-products'));
     });
   });
 

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -60,7 +60,6 @@ const setup = (setupConfig: Partial<SetupConfig> = {}): Setup => {
       context
     )
   );
-  fireEvent.focus(window);
   return {
     context,
     performSearchMock,
@@ -351,7 +350,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
     test('opens modal with an empty search bar and all facets', () => {
       expect(productsSearchBar).toBeDefined();
       const placeHolderText = productsSearchBar.getAttribute('placeholder');
-      expect(placeHolderText).toEqual('What are you looking for today?');
+      expect(placeHolderText).toEqual('Find');
       const searchBarValue = productsSearchBar.getAttribute('value');
       expect(searchBarValue).toBe('');
       // all facets are initially shown
@@ -400,7 +399,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
       expect(apiFacet).toBeDefined();
     });
 
-    test('no results are shown when facets do not contain the search value', () => {
+    test('empty state message is shown when facets do not contain the search value', () => {
       // user filters by "1"
       fireEvent.focus(productsSearchBar);
       fireEvent.change(productsSearchBar, { target: { value: '1' } });
@@ -409,6 +408,8 @@ describe('CollapsibleFacetsGroupComponent', () => {
         return element.tagName.toLowerCase() === 'span' && productsFacetArray.includes(content);
       });
       expect(filteredFacets).toHaveLength(0);
+      const emptyStateMessage = within(productsModal).getByText('There were no results found');
+      expect(emptyStateMessage).toBeDefined();
     });
 
     test('search bar clears when user clicks the clear search button', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -722,7 +722,7 @@ describe('FieldFacetsComponent', () => {
           expect(pennsylvaniaFacetValue).toBeDefined();
         });
 
-        test('if a category has between 11-15 facet values, a modal with no search bar opens when Show all is clicked', () => {
+        test('if a category has 11-15 facet values, a modal with no search bar opens when Show all is clicked', () => {
           const { fieldFacetsComponent } = setupResult;
           const quantityCategoryHeader = fieldFacetsComponent.getByText('Quantity');
           fireEvent.click(quantityCategoryHeader);
@@ -784,7 +784,7 @@ describe('FieldFacetsComponent', () => {
                 'speech to text (57158)',
                 'knowledge catalog (57158)',
                 'nlu (57158)',
-                'api kit (57158)',
+                'API kit (57158)',
                 'openpages (57158)',
                 'visual recognition (57158)',
                 'language translator (57158)',

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -642,6 +642,11 @@ describe('FieldFacetsComponent', () => {
             name: 'machine_learning_id',
             label: 'Machine Learning Terms',
             multiple_selections_allowed: true
+          },
+          {
+            name: 'products',
+            label: 'Products',
+            multiple_selections_allowed: false
           }
         ]
       });
@@ -717,7 +722,7 @@ describe('FieldFacetsComponent', () => {
           expect(pennsylvaniaFacetValue).toBeDefined();
         });
 
-        test('if a category has more than 10 facet values, a modal opens when Show more is clicked', () => {
+        test('if a category has between 11-15 facet values, a modal with no search bar opens when Show all is clicked', () => {
           const { fieldFacetsComponent } = setupResult;
           const quantityCategoryHeader = fieldFacetsComponent.getByText('Quantity');
           fireEvent.click(quantityCategoryHeader);
@@ -729,6 +734,10 @@ describe('FieldFacetsComponent', () => {
           expect(quantityModal).toBeDefined();
           const topEntitiesHeader = within(quantityModal).getByText('Top Entities: Quantity');
           expect(topEntitiesHeader).toBeDefined();
+          const quantitySearchBar = within(quantityModal).queryByTestId(
+            'search-facet-modal-search-bar-Top Entities'
+          );
+          expect(quantitySearchBar).toBeNull();
           const topEntitiesQuantityFacets = within(quantityModal).queryAllByText(
             (content, element) => {
               return (
@@ -750,6 +759,44 @@ describe('FieldFacetsComponent', () => {
             }
           );
           expect(topEntitiesQuantityFacets).toHaveLength(11);
+        });
+
+        test('if a category has over 15 facet values, a modal with a search bar opens when Show all is clicked', () => {
+          const { fieldFacetsComponent } = setupResult;
+          const showMore = fieldFacetsComponent.getByTestId('show-more-less-Products');
+          fireEvent.click(showMore);
+          const productsModal = fieldFacetsComponent.getByTestId(
+            'search-facet-show-more-modal-Products'
+          );
+          expect(productsModal).toBeDefined();
+          const productsSearchBar = within(productsModal).getByTestId(
+            'search-facet-modal-search-bar-Products'
+          );
+          expect(productsSearchBar).toBeDefined();
+          const productsFacets = within(productsModal).queryAllByText((content, element) => {
+            return (
+              element.tagName.toLowerCase() === 'span' &&
+              [
+                'discovery (138993)',
+                'studio (57158)',
+                'openscale (32444)',
+                'assistant (32444)',
+                'speech to text (57158)',
+                'knowledge catalog (57158)',
+                'nlu (57158)',
+                'api kit (57158)',
+                'openpages (57158)',
+                'visual recognition (57158)',
+                'language translator (57158)',
+                'machine learning (57158)',
+                'tone analyzer (57158)',
+                'personality insights (57158)',
+                'cybersecurity (57158)',
+                'language classifier (57158)'
+              ].includes(content)
+            );
+          });
+          expect(productsFacets).toHaveLength(16);
         });
 
         test('can expand multiple categories and collapse them again', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/constants.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/constants.ts
@@ -1,1 +1,2 @@
 export const MAX_FACETS_UNTIL_MODAL = 10;
+export const MAX_FACETS_UNTIL_SEARCHBAR = 15;

--- a/packages/discovery-react-components/src/components/SearchFacets/constants.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_FACETS_UNTIL_MODAL = 10;

--- a/packages/discovery-react-components/src/components/SearchFacets/messages.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/messages.ts
@@ -14,6 +14,7 @@ export interface Messages {
   showMoreModalSecondaryButtonText: string;
   showMoreModalAriaLabel: string;
   categoryExpandCollapseIconDescription: string;
+  modalSearchBarPrompt: string;
 }
 export const defaultMessages: Messages = {
   labelText: '{facetText}',
@@ -30,5 +31,6 @@ export const defaultMessages: Messages = {
   showMoreModalPrimaryButtonText: 'Apply',
   showMoreModalSecondaryButtonText: 'Cancel',
   showMoreModalAriaLabel: 'Modal to select and deselect facets',
-  categoryExpandCollapseIconDescription: 'Expand/Collapse'
+  categoryExpandCollapseIconDescription: 'Expand/Collapse',
+  modalSearchBarPrompt: 'What are you looking for today?'
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/messages.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/messages.ts
@@ -15,6 +15,7 @@ export interface Messages {
   showMoreModalAriaLabel: string;
   categoryExpandCollapseIconDescription: string;
   modalSearchBarPrompt: string;
+  emptyModalSearch: string;
 }
 export const defaultMessages: Messages = {
   labelText: '{facetText}',
@@ -32,5 +33,6 @@ export const defaultMessages: Messages = {
   showMoreModalSecondaryButtonText: 'Cancel',
   showMoreModalAriaLabel: 'Modal to select and deselect facets',
   categoryExpandCollapseIconDescription: 'Expand/Collapse',
-  modalSearchBarPrompt: 'What are you looking for today?'
+  modalSearchBarPrompt: 'Find',
+  emptyModalSearch: 'There were no results found'
 };

--- a/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
+++ b/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
@@ -10,12 +10,16 @@
 }
 
 .#{$prefix}--search-facet__facet__show-more-modal {
+  .#{$prefix}--modal-header {
+    padding-right: $spacing-md;
+
+    .#{$prefix}--search {
+      padding-top: $spacing-xs;
+    }
+  }
+
   .#{$prefix}--modal-content {
     height: 40vh;
-    padding-right: $spacing-md;
-    .#{$prefix}--search {
-      padding-bottom: $spacing-xs;
-    }
   }
 }
 

--- a/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
+++ b/packages/discovery-styles/scss/components/search-facets/_search-facets.scss
@@ -12,6 +12,10 @@
 .#{$prefix}--search-facet__facet__show-more-modal {
   .#{$prefix}--modal-content {
     height: 40vh;
+    padding-right: $spacing-md;
+    .#{$prefix}--search {
+      padding-bottom: $spacing-xs;
+    }
   }
 }
 


### PR DESCRIPTION
#### What do these changes do/fix?
This PR is based off of Kathryn's modal PR. This implements a search bar in the modal for when there are more than 15 facets. The search is case insensitive.

<img width="580" alt="Screen Shot 2020-04-28 at 4 58 02 PM" src="https://user-images.githubusercontent.com/59846843/80541937-ba696300-8971-11ea-9cad-7437f484dcc4.png">

#### How do you test/verify these changes?
- Run storybook with `yarn storybook`. See that the modal under `Products` contains the search bar. Play around with it and see that it behaves as expected. To see a modal without the search bar, got to `Quantity`.
- Link to tooling. Create a facet with more than 15 fields (I usually do `extracted_metadata.filename`). See the modal with a search bar appears when you click `See all`. Play with the modal and see it works as expected.
- Check that tests are everything we want.

#### Have you documented your changes (if necessary)?
Tests have been updated.

#### Are there any breaking changes included in this pull request?
No