### PR TITLE
fix: failing cypress test

### DIFF
--- a/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
@@ -70,9 +70,11 @@ describe('Collection Filter', () => {
 
         describe('and we click the clear selected collections button', () => {
           beforeEach(() => {
-            cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('newPostQuery');
+            cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as(
+              'postQueryClearedSelections'
+            );
             cy.get('div[aria-label="Clear Selection"]').click();
-            cy.wait('@newPostQuery').as('clearedCollectionsQueryObject');
+            cy.wait('@postQueryClearedSelections').as('clearedCollectionsQueryObject');
           });
 
           it('makes a query against all available collections', () => {
@@ -104,9 +106,11 @@ describe('Collection Filter', () => {
 
           describe('and we clear the selected collections', () => {
             beforeEach(() => {
-              cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('newPostQuery');
+              cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as(
+                'postQueryClearedSelections'
+              );
               cy.get('div[aria-label="Clear Selection"]').click();
-              cy.wait('@newPostQuery').as('originalQueryObject');
+              cy.wait('@postQueryClearedSelections').as('originalQueryObject');
             });
 
             it('makes a query against all available collections', () => {

--- a/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/collection_filter/spec.ts
@@ -70,9 +70,9 @@ describe('Collection Filter', () => {
 
         describe('and we click the clear selected collections button', () => {
           beforeEach(() => {
-            cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
+            cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('newPostQuery');
             cy.get('div[aria-label="Clear Selection"]').click();
-            cy.wait('@postQuery').as('clearedCollectionsQueryObject');
+            cy.wait('@newPostQuery').as('clearedCollectionsQueryObject');
           });
 
           it('makes a query against all available collections', () => {
@@ -104,9 +104,9 @@ describe('Collection Filter', () => {
 
           describe('and we clear the selected collections', () => {
             beforeEach(() => {
-              cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('postQuery');
+              cy.route('POST', '**/query?version=2019-01-01', '@queryJSON').as('newPostQuery');
               cy.get('div[aria-label="Clear Selection"]').click();
-              cy.wait('@postQuery').as('originalQueryObject');
+              cy.wait('@newPostQuery').as('originalQueryObject');
             });
 
             it('makes a query against all available collections', () => {


### PR DESCRIPTION
#### What do these changes do/fix?
This fixes the two failing cypress tests in `collection_filter` that are preventing the current master from building. 

I had to change the alias name in both tests since a describe that wraps these was using the same alias name. Not sure how the original test ever worked.

#### How do you test/verify these changes?
run `yarn cypress` and see that all tests now pass

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No