### PR TITLE
fix: dynamic search facets modal

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
@@ -508,61 +508,43 @@ export const facetsQueryResponse: DiscoveryV2.Response<
       text: 'naive bayes'
     },
     {
-      text: 'test 1'
+      text: 'classifier'
     },
     {
-      text: 'test 2'
+      text: 'algorithm'
     },
     {
-      text: 'test 3'
+      text: 'decision tree'
     },
     {
-      text: 'test 4'
+      text: 'clustering'
     },
     {
-      text: 'test 5'
+      text: 'linear'
     },
     {
-      text: 'test 6'
+      text: 'logistic'
     },
     {
-      text: 'test 7'
+      text: 'theorem'
     },
     {
-      text: 'test 8'
+      text: 'training'
     },
     {
-      text: 'test 9'
+      text: 'data'
     },
     {
-      text: 'test 10'
+      text: 'informative'
     },
     {
-      text: 'test 11'
+      text: 'assumption'
     },
     {
-      text: 'test 12'
+      text: 'classify'
     },
     {
-      text: 'test 13'
-    },
-    {
-      text: 'test 14'
-    },
-    {
-      text: 'test 15'
-    },
-    {
-      text: 'test 16'
-    },
-    {
-      text: 'test 17'
-    },
-    {
-      text: 'test 18'
-    },
-    {
-      text: 'test 19'
+      text: 'trees'
     }
   ]
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/facetsQueryResponse.ts
@@ -506,6 +506,63 @@ export const facetsQueryResponse: DiscoveryV2.Response<
     },
     {
       text: 'naive bayes'
+    },
+    {
+      text: 'test 1'
+    },
+    {
+      text: 'test 2'
+    },
+    {
+      text: 'test 3'
+    },
+    {
+      text: 'test 4'
+    },
+    {
+      text: 'test 5'
+    },
+    {
+      text: 'test 6'
+    },
+    {
+      text: 'test 7'
+    },
+    {
+      text: 'test 8'
+    },
+    {
+      text: 'test 9'
+    },
+    {
+      text: 'test 10'
+    },
+    {
+      text: 'test 11'
+    },
+    {
+      text: 'test 12'
+    },
+    {
+      text: 'test 13'
+    },
+    {
+      text: 'test 14'
+    },
+    {
+      text: 'test 15'
+    },
+    {
+      text: 'test 16'
+    },
+    {
+      text: 'test 17'
+    },
+    {
+      text: 'test 18'
+    },
+    {
+      text: 'test 19'
     }
   ]
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/__stories__/SearchFacets.stories.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/__stories__/SearchFacets.stories.tsx
@@ -62,61 +62,43 @@ const discoverySearchProps = (
         text: 'naive bayes'
       },
       {
-        text: 'test 1'
+        text: 'classifier'
       },
       {
-        text: 'test 2'
+        text: 'algorithm'
       },
       {
-        text: 'test 3'
+        text: 'decision tree'
       },
       {
-        text: 'test 4'
+        text: 'clustering'
       },
       {
-        text: 'test 5'
+        text: 'linear'
       },
       {
-        text: 'test 6'
+        text: 'logistic'
       },
       {
-        text: 'test 7'
+        text: 'theorem'
       },
       {
-        text: 'test 8'
+        text: 'training'
       },
       {
-        text: 'test 9'
+        text: 'data'
       },
       {
-        text: 'test 10'
+        text: 'informative'
       },
       {
-        text: 'test 11'
+        text: 'assumption'
       },
       {
-        text: 'test 12'
+        text: 'classify'
       },
       {
-        text: 'test 13'
-      },
-      {
-        text: 'test 14'
-      },
-      {
-        text: 'test 15'
-      },
-      {
-        text: 'test 16'
-      },
-      {
-        text: 'test 17'
-      },
-      {
-        text: 'test 18'
-      },
-      {
-        text: 'test 19'
+        text: 'trees'
       }
     ]
   }

--- a/packages/discovery-react-components/src/components/SearchFacets/__stories__/SearchFacets.stories.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/__stories__/SearchFacets.stories.tsx
@@ -60,6 +60,63 @@ const discoverySearchProps = (
       },
       {
         text: 'naive bayes'
+      },
+      {
+        text: 'test 1'
+      },
+      {
+        text: 'test 2'
+      },
+      {
+        text: 'test 3'
+      },
+      {
+        text: 'test 4'
+      },
+      {
+        text: 'test 5'
+      },
+      {
+        text: 'test 6'
+      },
+      {
+        text: 'test 7'
+      },
+      {
+        text: 'test 8'
+      },
+      {
+        text: 'test 9'
+      },
+      {
+        text: 'test 10'
+      },
+      {
+        text: 'test 11'
+      },
+      {
+        text: 'test 12'
+      },
+      {
+        text: 'test 13'
+      },
+      {
+        text: 'test 14'
+      },
+      {
+        text: 'test 15'
+      },
+      {
+        text: 'test 16'
+      },
+      {
+        text: 'test 17'
+      },
+      {
+        text: 'test 18'
+      },
+      {
+        text: 'test 19'
       }
     ]
   }

--- a/packages/discovery-react-components/src/components/SearchFacets/components/DynamicFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/DynamicFacets.tsx
@@ -4,7 +4,7 @@ import {
   SearchFilterFacets,
   SelectedFacet
 } from '../utils/searchFacetInterfaces';
-import get from 'lodash/get';
+import cloneDeep from 'lodash/cloneDeep';
 import { Messages } from '../messages';
 import { CollapsibleFacetsGroup } from './FacetsGroups/CollapsibleFacetsGroup';
 
@@ -39,13 +39,14 @@ export const DynamicFacets: FC<DynamicFacetsProps> = ({
   onChange
 }) => {
   const handleOnChange = (selectedFacets: SelectedFacet[]): void => {
-    const newDynamicFacets: SelectableDynamicFacets[] = dynamicFacets.map(suggestion => {
-      const text = get(suggestion, 'text', '');
-      return text === selectedFacets[0].selectedFacetKey
-        ? Object.assign({}, suggestion, { selected: selectedFacets[0].checked })
-        : suggestion;
+    let updatedFacets = cloneDeep(dynamicFacets);
+    selectedFacets.map(({ selectedFacetKey, checked }) => {
+      const facetKeyIndex = dynamicFacets.findIndex(facet => facet.text === selectedFacetKey);
+      if (facetKeyIndex > -1) {
+        updatedFacets[facetKeyIndex].selected = checked;
+      }
     });
-    onChange({ filterDynamic: newDynamicFacets });
+    onChange({ filterDynamic: updatedFacets });
   };
 
   const handleOnClear = (): void => {

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -125,7 +125,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
   const selectedFacets = filter(facets, ['selected', true]);
   const selectedFacetText = get(selectedFacets[0], facetsTextField, '');
   const shouldDisplayAsMultiSelect = areMultiSelectionsAllowed || selectedFacets.length > 1;
-  const shouldDisplayClearButton = shouldDisplayAsMultiSelect && selectedFacets.length > 0;
+  const shouldDisplayClearButton = selectedFacets.length > 0;
   const showMoreButtonOnClick =
     totalNumberFacets <= MAX_FACETS_UNTIL_MODAL ? toggleFacetsCollapse : setModalOpen;
   const handleClearFacets = (): void => {

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ModalSearchInput.tsx
@@ -26,6 +26,10 @@ interface ModalSearchInputProps {
    */
   facetsLabel: string;
   /**
+   * Facet text field
+   */
+  facetsTextField: 'key' | 'text';
+  /**
    * i18n messages for the component
    */
   messages: Messages;
@@ -36,6 +40,7 @@ export const ModalSearchInput: FC<ModalSearchInputProps> = ({
   setFilteredFacets,
   isModalOpen,
   facetsLabel,
+  facetsTextField,
   messages
 }) => {
   const [value, setValue] = useState<string>('');
@@ -53,8 +58,8 @@ export const ModalSearchInput: FC<ModalSearchInputProps> = ({
     const tempFacets = [...facets];
     setFilteredFacets(
       tempFacets.filter(facet => {
-        if (facet.key) {
-          return facet.key.toLowerCase().includes(tempValue.toLowerCase());
+        if (facet[facetsTextField]) {
+          return facet[facetsTextField].toLowerCase().includes(tempValue.toLowerCase());
         }
         return null;
       })

--- a/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/ShowMore/ShowMoreModal.tsx
@@ -108,6 +108,7 @@ export const ShowMoreModal: FC<ShowMoreModalProps> = ({
           setFilteredFacets={setFilteredFacets}
           isModalOpen={isOpen}
           facetsLabel={facetsLabel}
+          facetsTextField={facetsTextField}
         />
       ) : (
         <></>


### PR DESCRIPTION
#### What do these changes do/fix?
Fixes a bug found during integration testing for the Dynamic Facets modal.
- Modal was only applying the first selection for Dynamic Facets
- Modal search bar was not reloading the Dynamic Facet list upload clearing the entry
This is because Dynamic Facets are handled slightly differently than all other facets. The fixes now account for that.

This also includes a small change to add a tag to SingleSelect facets so that users know when one is selected without having to open the modal.
<img width="216" alt="Screen Shot 2020-05-06 at 1 59 11 PM" src="https://user-images.githubusercontent.com/59846843/81217284-f3bd5680-8fa1-11ea-984c-85578d00b06e.png">

#### How do you test/verify these changes?
Run `yarn storybook` and click on `Show all` for the Dynamic Facets. See that the modal now behaves correctly.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No