### PR TITLE
Add Broulaye to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @maniax89 @noah-eigenfeld @kabeaty @Steven-Gassert @ChrisGillin @jhpedemonte @ColbyJohnIBM
+* @maniax89 @noah-eigenfeld @kabeaty @Steven-Gassert @ChrisGillin @jhpedemonte @ColbyJohnIBM @broulaye
 
 /packages/discovery-components-react/src/components/DocumentPreview/ @JuanNicolasGarcia @broulaye @anibapat
 /packages/discovery-components-react/src/components/CIDocument/ @JuanNicolasGarcia @broulaye @anibapat


### PR DESCRIPTION
#### What do these changes do/fix?
Adds @broulaye  as a codeowner, since @noah-eigenfeld is moving to support for a six-week rotation (and @kabeaty is out on parental leave).