### PR TITLE
fix: category facet not showing correct number

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CategoryFacets.tsx
@@ -106,7 +106,7 @@ export const CategoryFacets: FC<CategoryFacetsProps> = ({
     setIsModalOpen(true);
   };
 
-  const categoryFacetsToShow = isCollapsed ? facets.slice(0, collapsedFacetsCount - 1) : facets;
+  const categoryFacetsToShow = isCollapsed ? facets.slice(0, collapsedFacetsCount) : facets;
   const iconToRender = categoryIsExpanded ? ChevronUp : ChevronDown;
   const totalNumberFacets = facets.length;
   const showMoreButtonOnClick =

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -97,6 +97,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
     });
 
     test('facets are initially shown collapsed', () => {
+      // Check SingleSelect facets
       const { searchFacetsComponent } = setup({ collapsedFacetsCount: 2 });
       const authorFacets = searchFacetsComponent.queryAllByText((content, element) => {
         return (
@@ -106,6 +107,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
       });
       expect(authorFacets).toHaveLength(2);
 
+      // Check MultiSelect facets
       const subjectFacets = searchFacetsComponent.queryAllByText((content, element) => {
         return (
           element.tagName.toLowerCase() === 'span' &&
@@ -120,6 +122,23 @@ describe('CollapsibleFacetsGroupComponent', () => {
         );
       });
       expect(subjectFacets).toHaveLength(2);
+
+      // Check CatagoryFacets
+      const locationCategoryHeader = searchFacetsComponent.getByText('Location');
+      fireEvent.click(locationCategoryHeader);
+      const locationFacets = searchFacetsComponent.queryAllByText((content, element) => {
+        return (
+          element.tagName.toLowerCase() === 'span' &&
+          [
+            'us (57158)',
+            'eu (57158)',
+            'new york (57158)',
+            'pittsberg (57158)',
+            'austin (57158)'
+          ].includes(content)
+        );
+      });
+      expect(locationFacets).toHaveLength(2);
     });
 
     describe('clicking show more button', () => {


### PR DESCRIPTION
#### What do these changes do/fix?
Fixes a one off error inside the CategoryFacets so that they show up to 5 facets when `show more` is added. It was previously showing 4 and was inconsistent with the other facets.

Issue: https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1545

#### How do you test/verify these changes?
- Run storybook **without** the change in `CategoryFacets.tsx`
    - See that the CategoryFacet `Locations` and `Quantity` only have 4 facets
    - See `Products`, `Machine Learning`, and `Dynamic Facets` have 5 facets
    - See that the added test fails

- Add back the change and run storybook
    - See that both `Locations` and `Quantity` have 5 facets
    - See that the added test passes

#### Have you documented your changes (if necessary)?
Tests have been updated

#### Are there any breaking changes included in this pull request?
No
