### PR TITLE
fix: improve query for Top Entities

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
@@ -27,21 +27,21 @@ describe('BuildAggregationQuery', () => {
   test('it converts configuration with multiple terms, count, and name, including Top Entities, to expected aggregation parameter', () => {
     const aggParam = buildAggregationQuery(configurationWithTopEntities);
     expect(aggParam).toEqual(
-      '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author)]'
+      '[nested(enriched_text.entities).term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author)]'
     );
   });
 
   test('it converts configuration with nested query aggregation to expected aggregation parameter', () => {
     const aggParam = buildAggregationQuery(configurationWithNestedQueryAggregation);
     expect(aggParam).toEqual(
-      '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities).filter(enriched_text.entities.model_name:"Dictionary:.products").term(enriched_text.entities.text,count:4,name:dict_ypKBKYnM8LOq)]'
+      '[nested(enriched_text.entities).term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities).filter(enriched_text.entities.model_name:"Dictionary:.products").term(enriched_text.entities.text,count:4,name:dict_ypKBKYnM8LOq)]'
     );
   });
 
   test('it converts configuration with filter query aggregation to expected aggregation parameter', () => {
     const aggParam = buildAggregationQuery(configurationWithFilterQueryAggregation);
     expect(aggParam).toEqual(
-      '[term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities.enriched_text.entities.text).filter(enriched_text.entities.enriched_text.entities.model_name:"Dictionary:.test").term(enriched_text.entities.enriched_text.entities.text,count:4,name:dict_yqYQPpM8OljE)]'
+      '[nested(enriched_text.entities).term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities.enriched_text.entities.text).filter(enriched_text.entities.enriched_text.entities.model_name:"Dictionary:.test").term(enriched_text.entities.enriched_text.entities.text,count:4,name:dict_yqYQPpM8OljE)]'
     );
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -9,7 +9,18 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
         let nestedTypeTermAgg = '';
         if (field.includes('enriched_') && field.includes('entities.text')) {
           const topLevelTermEntityField = field.split('.')[0];
+          const topLevelNestedField = field.slice(0, field.lastIndexOf('.'));
           nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
+          return (
+            'nested(' +
+            topLevelNestedField +
+            ').term(' +
+            field +
+            termCount +
+            termName +
+            ')' +
+            nestedTypeTermAgg
+          );
         }
         return 'term(' + field + termCount + termName + ')' + nestedTypeTermAgg;
         // This supports nested and filter aggregations, including dictionary aggregations

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -11,16 +11,7 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
           const topLevelTermEntityField = field.split('.')[0];
           const topLevelNestedField = field.slice(0, field.lastIndexOf('.'));
           nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
-          return (
-            'nested(' +
-            topLevelNestedField +
-            ').term(' +
-            field +
-            termCount +
-            termName +
-            ')' +
-            nestedTypeTermAgg
-          );
+          return `nested(${topLevelNestedField}).term(${field}${termCount}${termName})${nestedTypeTermAgg}`;
         }
         return 'term(' + field + termCount + termName + ')' + nestedTypeTermAgg;
         // This supports nested and filter aggregations, including dictionary aggregations


### PR DESCRIPTION
#### What do these changes do/fix?
Changes the aggregation request for Top Entities so that it uses `nested`. Doing this allows for more accurate categories in the response.

issue: https://github.ibm.com/Watson-Discovery/the-tooling-core-tracker/issues/1579

**Before:**
<img width="271" alt="Screen Shot 2020-05-27 at 2 23 07 PM" src="https://user-images.githubusercontent.com/59846843/83063363-9dce5280-a025-11ea-9dd4-3b11e6b6b67f.png">

**After:**
<img width="240" alt="Screen Shot 2020-05-27 at 2 22 59 PM" src="https://user-images.githubusercontent.com/59846843/83063375-a6268d80-a025-11ea-9f17-8315a0096b55.png">

#### How do you test/verify these changes?
1. Go to https://zen-25-cpd-zen-25.apps.weary-griffin-master-1.fyre.ibm.com/discovery/core/instances/00000000-0000-0000-0001-590585699206/projects/1b62db48-f7b4-449c-9702-f22e3bebb4a2/workspace
2. See the facets appear as the before picture above.
3. Link this PR to tooling by running `yarn link-components` in `tooling`.
4. Go back to the `Throw away your television` project on `weary-griffin` and see that the categories match the after image above.

#### Have you documented your changes (if necessary)?
Tests have been updated

#### Are there any breaking changes included in this pull request?
No
