### PR TITLE
fix: updating rendering of html to add role presentation to tables

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState, useRef } from 'react';
+import React, { FC, useEffect, useState, useRef, useLayoutEffect } from 'react';
 import { settings } from 'carbon-components';
 import { QueryResult, QueryResultPassage, QueryTableResult } from 'ibm-watson/discovery/v2';
 import DOMPurify from 'dompurify';
@@ -60,7 +60,7 @@ export const HtmlView: FC<Props> = ({
   const [processedDoc, setProcessedDoc] = useState<ProcessedDoc | null>(null);
   const [highlightLocations, setHighlightLocations] = useState<Location[]>([]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     DOMPurify.addHook('afterSanitizeAttributes', function(node) {
       if (node.tagName === 'TABLE') {
         node.setAttribute('role', 'presentation');

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -61,6 +61,18 @@ export const HtmlView: FC<Props> = ({
   const [highlightLocations, setHighlightLocations] = useState<Location[]>([]);
 
   useEffect(() => {
+    DOMPurify.addHook('afterSanitizeAttributes', function(node) {
+      if (node.tagName === 'TABLE') {
+        node.setAttribute('role', 'presentation');
+      }
+    });
+
+    return () => {
+      DOMPurify.removeHook('afterSanitizeAttributes');
+    };
+  }, []);
+
+  useEffect(() => {
     if (document) {
       const docHtml = document.html;
       if (docHtml && highlight) {

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -22,6 +22,7 @@ import {
 } from 'components/SearchResults/cssClasses';
 import { getDocumentTitle } from 'utils/getDocumentTitle';
 import { Messages } from 'components/SearchResults/messages';
+import { formatMessage } from 'utils/formatMessage';
 
 export interface ResultProps {
   /**
@@ -193,6 +194,15 @@ export const Result: React.FunctionComponent<ResultProps> = ({
                 handleSelectResult={handleSelectResult}
                 hasResult={!!result}
                 dangerouslyRenderHtml={true}
+                elementLabel={
+                  messages.elementTableLabel
+                    ? formatMessage(
+                        messages.elementTableLabel,
+                        { documentName: title },
+                        false
+                      ).join('')
+                    : undefined
+                }
               />
             )}
           </>

--- a/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useLayoutEffect } from 'react';
+import React, { useLayoutEffect } from 'react';
 import { SelectedResult } from 'components/DiscoverySearch/DiscoverySearch';
 import { Button, Tile } from 'carbon-components-react';
 import Launch from '@carbon/icons-react/lib/launch/16';

--- a/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { SelectedResult } from 'components/DiscoverySearch/DiscoverySearch';
 import { Button, Tile } from 'carbon-components-react';
 import Launch from '@carbon/icons-react/lib/launch/16';
@@ -46,6 +46,10 @@ export interface ResultElementProps {
    * specifies whether to use dangerouslySetInnerHtml when rendering this result element
    */
   dangerouslyRenderHtml?: boolean;
+  /**
+   * label used to describe the element
+   */
+  elementLabel?: string;
 }
 
 export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
@@ -53,6 +57,7 @@ export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
   buttonText = 'View document',
   element = null,
   elementType = null,
+  elementLabel,
   handleSelectResult,
   passageTextClassName,
   hasResult,
@@ -71,8 +76,26 @@ export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
 
   const elementBodyProps = {
     className: elementBodyClassNames.join(' '),
-    'data-testid': `search-result-element-body-${elementType}`
+    'data-testid': `search-result-element-body-${elementType}`,
+    'aria-label': elementLabel,
+    ...(elementType === 'table' ? { role: 'img' } : {})
   };
+
+  useEffect(() => {
+    if (elementType === 'table') {
+      DOMPurify.addHook('afterSanitizeAttributes', function(node) {
+        if (node.tagName === 'TABLE') {
+          node.setAttribute('role', 'presentation');
+        }
+      });
+    }
+
+    return () => {
+      if (elementType === 'table') {
+        DOMPurify.removeHook('afterSanitizeAttributes');
+      }
+    };
+  }, [elementType]);
 
   return (
     <Tile>

--- a/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { SelectedResult } from 'components/DiscoverySearch/DiscoverySearch';
 import { Button, Tile } from 'carbon-components-react';
 import Launch from '@carbon/icons-react/lib/launch/16';
@@ -81,7 +81,7 @@ export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
     ...(elementType === 'table' ? { role: 'img' } : {})
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (elementType === 'table') {
       DOMPurify.addHook('afterSanitizeAttributes', function(node) {
         if (node.tagName === 'TABLE') {

--- a/packages/discovery-react-components/src/components/SearchResults/messages.ts
+++ b/packages/discovery-react-components/src/components/SearchResults/messages.ts
@@ -27,6 +27,10 @@ export interface Messages {
    * override the default text to show when no search results are found
    */
   noResultsFoundText: string;
+  /**
+   * override the default text to use as the label for the table result
+   */
+  elementTableLabel: string;
 }
 
 export const defaultMessages: Messages = {
@@ -36,5 +40,6 @@ export const defaultMessages: Messages = {
   tablesOnlyToggleLabelText: 'Show table results only',
   spellingSuggestionsPrefix: 'Did you mean:',
   emptyResultContentBodyText: 'Excerpt unavailable.',
-  noResultsFoundText: 'There were no results found'
+  noResultsFoundText: 'There were no results found',
+  elementTableLabel: 'Table snippet extracted from {documentName}'
 };


### PR DESCRIPTION
#### What do these changes do/fix?
Table results are unable to be read by screen readers. For now, we are going to mark them as "presentation" so that the screen readers don't incorrectly them. We will follow up with a better solution that attempts to add headers to the data if they are available.

#### How do you test/verify these changes?
1. Run linked to tooling against cloud
2. Select a project with table results
3. When the results are returned in the search, and have a table in them run the [IBM Equal Accessibility Checker](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) to verify it doesn't read the tables

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No