### PR TITLE
fix: wrapping tables in article role

### DIFF
--- a/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
@@ -78,6 +78,8 @@ export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
     className: elementBodyClassNames.join(' '),
     'data-testid': `search-result-element-body-${elementType}`,
     'aria-label': elementLabel,
+    // Tables must be wrapped in an element that has role of article to ensure screen readers
+    // understand that the table is not semantically correct.
     ...(elementType === 'table' ? { role: 'article' } : {})
   };
 

--- a/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/ResultElement/ResultElement.tsx
@@ -78,7 +78,7 @@ export const ResultElement: React.FunctionComponent<ResultElementProps> = ({
     className: elementBodyClassNames.join(' '),
     'data-testid': `search-result-element-body-${elementType}`,
     'aria-label': elementLabel,
-    ...(elementType === 'table' ? { role: 'img' } : {})
+    ...(elementType === 'table' ? { role: 'article' } : {})
   };
 
   useLayoutEffect(() => {

--- a/packages/discovery-react-components/src/utils/document/processDoc.ts
+++ b/packages/discovery-react-components/src/utils/document/processDoc.ts
@@ -234,7 +234,7 @@ function setupSectionParser(
           if (tagName === TABLE_TAG) {
             const descriptionId = `table-description-${p.startIndex}`;
             const tableDescription =
-              'This table was generated using AI. It may be missing semantic table markup for accessibility';
+              'This table was generated using AI. It may be missing semantic table markup for accessibility.';
             const ariaLabel = `Table generated from ${doc.title} (id: ${p.startIndex})`;
 
             sectionHtml.push(


### PR DESCRIPTION
#### What do these changes do/fix?
Improves the accessibility for table results, because the `article` allows the screen reader to still read table. However it will not attempt to read the table like an actually table.

The goal of these tables in the results is to allow the user to verify that the result is what they are looking for, and not to display an exact replica of the table from the document.

#### How do you test/verify these changes?
1. Run linked to tooling against cloud
2. Select a project with table results
3. When the results are returned in the search, and have a table in them run the IBM Equal Accessibility Checker to verify it doesn't read the tables

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No