### PR TITLE
fix: add collections facets hook for event tracking

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -26,6 +26,10 @@ import { withErrorBoundary } from 'react-error-boundary';
 
 interface SearchFacetsProps {
   /**
+   * ID for the SearchInput
+   */
+  id?: string;
+  /**
    * Show list of collections as facets
    */
   showCollections?: boolean;
@@ -50,12 +54,14 @@ interface SearchFacetsProps {
    */
   collapsedFacetsCount?: number;
   /**
-   * custom handler invoked when any input element changes in the SearchFacets component
+   * Custom handler invoked when any input element changes in the SearchFacets component.
+   * Takes a synthethic event from an HTML Input Element or a string array.
    */
   onChange?: (e: SyntheticEvent<HTMLInputElement> | string[]) => void;
 }
 
 const SearchFacets: FC<SearchFacetsProps> = ({
+  id = '',
   showCollections = true,
   showDynamicFacets = true,
   showMatchingResults = false,
@@ -102,6 +108,10 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     overrideComponentSettingsAggregations ||
     (componentSettings && componentSettings.aggregations) ||
     [];
+
+  if (id !== '') {
+    id = id.concat('--');
+  }
 
   useEffect(() => {
     fetchAggregations(searchParameters);
@@ -195,7 +205,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
         {hasSelection && (
           <Button
             className={`${settings.prefix}--search-facets__button-clear-all`}
-            id={'search-facets-button-clear-all'}
+            id={`${id}search-facets-button-clear-all`}
             kind="ghost"
             renderIcon={Close}
             size="small"

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -52,7 +52,7 @@ interface SearchFacetsProps {
   /**
    * custom handler invoked when any input element changes in the SearchFacets component
    */
-  onChange?: (e: SyntheticEvent<HTMLInputElement>) => void;
+  onChange?: (e: SyntheticEvent<HTMLInputElement> | string[]) => void;
 }
 
 const SearchFacets: FC<SearchFacetsProps> = ({
@@ -160,6 +160,18 @@ const SearchFacets: FC<SearchFacetsProps> = ({
         return collection.id.split(collectionFacetIdPrefix).pop() || '';
       })
       .filter(id => id !== '');
+
+    if (onChange) {
+      // returning collection labels
+      onChange(
+        selectedCollectionItems.selectedItems
+          .map(collection => {
+            return collection.label.split(collectionFacetIdPrefix).pop() || '';
+          })
+          .filter(label => label !== '')
+      );
+    }
+
     performSearch({ ...searchParameters, offset: 0, collectionIds });
   };
 
@@ -183,6 +195,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
         {hasSelection && (
           <Button
             className={`${settings.prefix}--search-facets__button-clear-all`}
+            id={'search-facets-button-clear-all'}
             kind="ghost"
             renderIcon={Close}
             size="small"

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -14,6 +14,7 @@ import {
   SelectedCollectionItems
 } from './utils/searchFacetInterfaces';
 import get from 'lodash/get';
+import uuid from 'uuid';
 import { CollectionFacets } from './components/CollectionFacets';
 import { FieldFacets } from './components/FieldFacets';
 import { DynamicFacets } from './components/DynamicFacets';
@@ -26,7 +27,7 @@ import { withErrorBoundary } from 'react-error-boundary';
 
 interface SearchFacetsProps {
   /**
-   * ID for the SearchInput
+   * ID for the SearchFacets
    */
   id?: string;
   /**
@@ -55,13 +56,14 @@ interface SearchFacetsProps {
   collapsedFacetsCount?: number;
   /**
    * Custom handler invoked when any input element changes in the SearchFacets component.
-   * Takes a synthethic event from an HTML Input Element or a string array.
+   * Takes a synthethic event from an HTML Input Element or a string array from custom
+   * onChange events that do not use synthethic events.
    */
   onChange?: (e: SyntheticEvent<HTMLInputElement> | string[]) => void;
 }
 
 const SearchFacets: FC<SearchFacetsProps> = ({
-  id = '',
+  id,
   showCollections = true,
   showDynamicFacets = true,
   showMatchingResults = false,
@@ -70,6 +72,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
   collapsedFacetsCount = 5,
   onChange
 }) => {
+  const facetsId = id || `search-facets__${uuid.v4()}`;
   const {
     aggregationResults,
     searchResponseStore: {
@@ -108,10 +111,6 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     overrideComponentSettingsAggregations ||
     (componentSettings && componentSettings.aggregations) ||
     [];
-
-  if (id !== '') {
-    id = id.concat('--');
-  }
 
   useEffect(() => {
     fetchAggregations(searchParameters);
@@ -201,11 +200,11 @@ const SearchFacets: FC<SearchFacetsProps> = ({
 
   if (shouldShowFields || shouldShowCollections) {
     return (
-      <div className={`${settings.prefix}--search-facets`}>
+      <div id={facetsId} className={`${settings.prefix}--search-facets`}>
         {hasSelection && (
           <Button
             className={`${settings.prefix}--search-facets__button-clear-all`}
-            id={`${id}search-facets-button-clear-all`}
+            id={`${facetsId}--search-facets-button-clear-all`}
             kind="ghost"
             renderIcon={Close}
             size="small"

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -133,7 +133,10 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
   const shouldDisplayClearButton = selectedFacets.length > 0;
   const showMoreButtonOnClick =
     totalNumberFacets <= MAX_FACETS_UNTIL_MODAL ? toggleFacetsCollapse : setModalOpen;
-  const handleClearFacets = (): void => {
+  const handleClearFacets = (event: SyntheticEvent<HTMLInputElement>): void => {
+    if (onChange) {
+      onChange(event);
+    }
     onClear(aggregationSettings.name || aggregationSettings.field);
   };
 
@@ -152,6 +155,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
           {facetsLabel}
           {shouldDisplayClearButton && (
             <ListBox.Selection
+              id="search-facets-clear-listbox"
               clearSelection={handleClearFacets}
               selectionCount={selectedFacets.length}
               translateWithId={translateWithId}

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -155,7 +155,6 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
           {facetsLabel}
           {shouldDisplayClearButton && (
             <ListBox.Selection
-              id="search-facets-clear-listbox"
               clearSelection={handleClearFacets}
               selectionCount={selectedFacets.length}
               translateWithId={translateWithId}


### PR DESCRIPTION
#### What do these changes do/fix?

This adds an event callback for toggling collection facets that can be used for event tracking.
Companion tooling PR: https://github.ibm.com/Watson-Discovery/discovery-tooling/pull/7655

#### How do you test/verify these changes?

Pull down the tooling PR branch and use `yarn link-components` to test changes.
In a project workspace (sample project is fine), perform any search.  Select a collection facet, and see in the console a list of selected collection facets.
