### PR TITLE
fix: some bad set states in Document components

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -86,6 +86,8 @@ const DocumentPreview: FC<Props> = ({
               highlight={highlight}
               setLoading={setLoading}
               setHideToolbarControls={setHideToolbarControls}
+              loading={loading}
+              hideToolbarControls={hideToolbarControls}
             />
           </div>
           {loading && (
@@ -108,11 +110,15 @@ interface PreviewDocumentProps {
   highlight?: any;
   setLoading: (loading: boolean) => void;
   setHideToolbarControls?: (disabled: boolean) => void;
+  loading: boolean;
+  hideToolbarControls: boolean;
 }
 
 function PreviewDocument({
   document,
+  loading,
   setLoading,
+  hideToolbarControls,
   setHideToolbarControls,
   highlight
 }: PreviewDocumentProps): ReactElement | null {
@@ -133,7 +139,9 @@ function PreviewDocument({
       <SimpleDocument
         document={document}
         highlight={highlight}
+        hideToolbarControls={hideToolbarControls}
         setHideToolbarControls={setHideToolbarControls}
+        loading={loading}
         setLoading={setLoading}
       />
     );

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/SimpleDocument.tsx
@@ -26,12 +26,16 @@ interface Props {
 
   cannotPreviewMessage?: string;
   cannotPreviewMessage2?: string;
+  loading: boolean;
+  hideToolbarControls: boolean;
 }
 
 export const SimpleDocument: FC<Props> = ({
   document,
   highlight,
+  loading,
   setLoading,
+  hideToolbarControls,
   setHideToolbarControls,
   cannotPreviewMessage = "Can't preview document",
   cannotPreviewMessage2 = "Try the JSON tab for a different view of this document's data."
@@ -89,13 +93,18 @@ export const SimpleDocument: FC<Props> = ({
         })
         .join('\n');
     }
-
-    // set parent states
-    setLoading(false);
-    if (setHideToolbarControls) {
-      setHideToolbarControls(true);
-    }
   }
+
+  useEffect(() => {
+    if (document) {
+      if (loading) {
+        setLoading(false);
+      }
+      if (typeof setHideToolbarControls === 'function' && !hideToolbarControls) {
+        setHideToolbarControls(true);
+      }
+    }
+  }, [document, hideToolbarControls, loading, setHideToolbarControls, setLoading]);
 
   // highlight passage and scroll into view
   useEffect(() => {


### PR DESCRIPTION
#### What do these changes do/fix?
Noticed when cleaning up tooling tests that were were getting the following error:

```
console.error src/setupTests.js:107
    Warning: Cannot update a component (`DocumentPreview`) while rendering a different component (`SimpleDocument`). To locate the bad setState() call inside `SimpleDocument`, follow the stack trace as described in https://fb.me/setstate-in-render
        in SimpleDocument (created by PreviewDocument)
        in PreviewDocument (created by DocumentPreview)
        in div (created by DocumentPreview)
        in div (created by DocumentPreview)
        in DocumentPreview (created by WithErrorBoundary(DocumentPreview))
        in WithErrorBoundary(DocumentPreview) (at DocumentDetails.js:205)
        in LazyLoadContent (at TabContentRenderedOnlyWhenSelected.tsx:46)
        in div (at TabContentRenderedOnlyWhenSelected.tsx:40)
        in TabContentRenderedOnlyWhenSelected (created by Tabs)
        in Tabs (at DocumentDetails.js:183)
        in div (at DocumentDetails.js:179)
        in DocumentDetailsContent (at DocumentDetails.spec.tsx:41)
        in Router (created by ConnectedRouter)
        in ConnectedRouter (created by Context.Consumer)
        in ConnectedRouterWithContext (created by ConnectFunction)
        in ConnectFunction (at withApp.js:19)
        in Provider (at withApp.js:18)
        in IntlProvider (at withApp.js:17)
        in AppWrapper (at createCustomRender.tsx:37)
        in wrapper
```

`setState` should never be called with the render call of a component. It needs to be done within a `useEffect` or `useLayoutEffect`.

@maniax89 - Do you know why this was done? It looks like it was done at the initial release. I just want to make sure that I am not undoing some bug fix.

#### How do you test/verify these changes?
Verify that all of the tests still pass correctly. Link to Discovery Tooling and verify that all of tooling tests still pass as well.

#### Have you documented your changes (if necessary)?
I don't think anything is necessary.

#### Are there any breaking changes included in this pull request?
No.