### PR TITLE
fix: html highlighting

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/Highlight/passages.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/Highlight/passages.tsx
@@ -37,7 +37,7 @@ export function getPassagePageInfo(
 ): ReadonlyArray<CellPage> | null {
   const { start_offset, end_offset, field } = passage;
 
-  if (!start_offset || !end_offset) {
+  if (typeof start_offset !== 'number' || typeof end_offset !== 'number') {
     return null;
   }
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -41,7 +41,7 @@ const SANITIZE_CONFIG = {
   WHOLE_DOCUMENT: true
 };
 
-const base = `${settings.prefix}--html`;
+const baseClassName = `${settings.prefix}--html`;
 
 export const HtmlView: FC<Props> = ({
   document,
@@ -91,10 +91,9 @@ export const HtmlView: FC<Props> = ({
 
           // set sanitized HTML (removing scripts, etc)
           setHtml(`
-          <div>
             <style>${processedDoc.styles}</style>
             ${DOMPurify.sanitize(fullHtml, SANITIZE_CONFIG)}
-          </div>`);
+          `);
           setLoading(false);
         };
         process();
@@ -171,10 +170,11 @@ export const HtmlView: FC<Props> = ({
   }, [highlight, html, highlightLocations]);
 
   return (
-    <div className={base}>
+    <div className={baseClassName}>
       <div ref={highlightRef} />
       {html && (
         <div
+          className={`${baseClassName}__content`}
           dangerouslySetInnerHTML={{
             __html: html
           }}

--- a/packages/discovery-styles/scss/_vars.scss
+++ b/packages/discovery-styles/scss/_vars.scss
@@ -1,4 +1,1 @@
-$disco-highlight-background-with-opacity: scale-color($highlight, $lightness: -40%);
-$disco-highlight-background-opacity: 0.25;
-
 $empty_state_message_width: 500px;

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview-html.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview-html.scss
@@ -12,7 +12,10 @@
   .field--rect {
     position: absolute;
     background-color: $highlight;
-    // TODO why is z-index necessary?
-    z-index: -1;
   }
+}
+
+.#{$prefix}--html__content {
+  // needed so that absolutely positioned `.field--rect`s render underneath text
+  position: relative;
 }

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview.scss
@@ -27,20 +27,6 @@
   width: 100%;
 }
 
-.#{$prefix}--document-preview__highlight-overlay {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  pointer-events: none;
-}
-
-.#{$prefix}--document-preview__highlight {
-  fill: $disco-highlight-background-with-opacity;
-  fill-opacity: $disco-highlight-background-opacity;
-}
-
 .#{$prefix}--document-preview__error {
   text-align: center;
   margin: $spacing-2xl;

--- a/packages/discovery-styles/scss/components/document-preview/_simple-document.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_simple-document.scss
@@ -8,8 +8,7 @@ $icon-size: 80px;
 
   .field--rect {
     position: absolute;
-    background-color: $disco-highlight-background-with-opacity;
-    opacity: $disco-highlight-background-opacity;
+    background-color: $highlight;
   }
 }
 
@@ -21,6 +20,8 @@ $icon-size: 80px;
 
 .#{$prefix}--simple-document__content {
   max-width: 78ch;
+  // needed so that absolutely positioned `.field--rect`s render underneath text
+  position: relative;
 }
 
 .#{$prefix}--simple-document__error-view {


### PR DESCRIPTION
#### What do these changes do/fix?

Fix how highlighting is handled:
1. Fix issue where if offset had value of zero, highlight was ignored.
2. If background-color was applied, then highlights in HTML docs disappeared (z-index issue).

This also updates the CSS for highlights rects in `SimpleDocument` to match the implementation in `HtmlView`.

#### How do you test/verify these changes?

To verify fix (1):
1. Start storybook and load **DocumentPreview > passage highlighting**
2. Using React Dev Tools plugin, select the `HtmlView` component
3. In box at upper-right (labeled "props"), update the `highlight` property to have `end_offset` of 20 and a `start_offset` of 0.
4. Notice that highlight properly renders

To verify fix (2):
1. In same storybook, go to **Inspector > Elements** and select the node `<div class="bx--document-preview">`
2. Add style of `background-color: white`.
3. Highlight rects should still show.

Compare against deployed instance: https://watson-developer-cloud.github.io/discovery-components/storybook/?path=/story/documentpreview--passage-highlighting

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
