### PR TITLE
fix: Upgrade watson sdk

### DIFF
--- a/examples/discovery-search-app/package.json
+++ b/examples/discovery-search-app/package.json
@@ -32,7 +32,7 @@
     "dotenv": "^8.1.0",
     "express": "^4.17.1",
     "http-proxy-middleware": "^0.20.0",
-    "ibm-watson": "5.2.0-alpha-1",
+    "ibm-watson": "^6.0.2",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",
     "react-dom": "^16.4.1"

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rollup-plugin-typescript2": "^0.23.0",
     "seedrandom": "^3.0.5",
     "source-map-explorer": "2.0.1",
-    "start-server-and-test": "^1.10.0",
+    "start-server-and-test": "^1.11.7",
     "ts-loader": "^6.2.1",
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "typescript": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "fast-xml-parser": "^3.14.0",
     "gh-pages": "^2.1.1",
     "husky": "^3.0.5",
-    "ibm-watson": "5.2.0-alpha-1",
+    "ibm-watson": "^6.0.2",
     "lerna": "^3.16.4",
     "lerna-update-wizard": "^0.16.0",
     "lint-staged": "^9.2.5",

--- a/packages/discovery-react-components/.storybook/webpack.config.js
+++ b/packages/discovery-react-components/.storybook/webpack.config.js
@@ -4,7 +4,8 @@ const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 module.exports = ({ config }) => {
   config.node = {
-    fs: 'empty'
+    fs: 'empty',
+    module: 'empty'
   };
   config.module.rules.push({
     test: /\.(ts|tsx)$/,

--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -34,7 +34,7 @@
     "@ibm-watson/discovery-styles": "1.x.x",
     "carbon-components": ">= 10.6.0 < 11",
     "carbon-components-react": ">= 7.6.0 < 8",
-    "ibm-watson": "^5.2.0-alpha-1",
+    "ibm-watson": "^6.0.2",
     "react": ">= 16.8.0 < 17",
     "react-dom": ">= 16.8.0 < 17"
   },

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__stories__/CIDocument.stories.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__stories__/CIDocument.stories.tsx
@@ -44,6 +44,10 @@ storiesOf('CIDocument', module)
   })
   .add('parse error', () => {
     const badDoc = {
+      document_id: 'document_id',
+      result_metadata: {
+        collection_id: 'collection_id'
+      },
       extracted_metadata: {
         publicationdate: '2018-10-24',
         sha1: '754836ffd690207d39b9f8db08b8099e787c61fa',

--- a/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
@@ -1,5 +1,5 @@
 import React, { cloneElement } from 'react';
-import { render, act, fireEvent, RenderResult, wait, findByText } from '@testing-library/react';
+import { render, fireEvent, RenderResult, wait } from '@testing-library/react';
 import DiscoverySearch, {
   DiscoverySearchProps,
   SearchApi,
@@ -103,7 +103,13 @@ describe('DiscoverySearch', () => {
       } = setup(
         {
           overrideSelectedResult: {
-            document: { extracted_metadata: { title: 'foo' } },
+            document: {
+              document_id: 'document_id',
+              result_metadata: {
+                collection_id: 'collection_id'
+              },
+              extracted_metadata: { title: 'foo' }
+            },
             element: null,
             elementType: null
           }
@@ -288,7 +294,7 @@ describe('DiscoverySearch', () => {
         passages: {
           enabled: false
         },
-        returnFields: [],
+        _return: [],
         tableResults: {
           enabled: false
         }

--- a/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
@@ -4,3 +4,10 @@ export type SearchClient = Pick<
   DiscoveryV2,
   'query' | 'getAutocompletion' | 'listCollections' | 'getComponentSettings' | 'listFields'
 >;
+
+export type SearchParams = Omit<DiscoveryV2.QueryParams, 'projectId' | 'headers'> & {
+  /**
+   * @deprecated "returnFields" has been renamed as "_return"
+   */
+  returnFields?: string[];
+};

--- a/packages/discovery-react-components/src/components/SearchResults/utils/findCollectionName.ts
+++ b/packages/discovery-react-components/src/components/SearchResults/utils/findCollectionName.ts
@@ -2,7 +2,7 @@ import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import get from 'lodash/get';
 
 export const findCollectionName = (
-  collectionResponse: DiscoveryV2.ListCollectionsResponse | null,
+  collectionResponse: DiscoveryV2.ListCollectionsResponse | undefined,
   queryResult: DiscoveryV2.QueryResult | DiscoveryV2.QueryTableResult
 ): string => {
   const collectionId =

--- a/packages/discovery-react-components/src/utils/__tests__/deprecation.test.ts
+++ b/packages/discovery-react-components/src/utils/__tests__/deprecation.test.ts
@@ -1,0 +1,24 @@
+import { deprecateReturnFields } from '../deprecation';
+
+describe('deprecation', () => {
+  const originalWarn = console.warn;
+  beforeEach(() => {
+    console.warn = jest.fn();
+    jest.resetAllMocks();
+  });
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+  describe('deprecateReturnFields', () => {
+    it('copies returnFields to _return', () => {
+      expect(deprecateReturnFields({ returnFields: ['foo'] })).toEqual({ _return: ['foo'] });
+    });
+
+    it('logs a deprecation warning when returnFields is used', () => {
+      deprecateReturnFields({ returnFields: ['foo'] });
+      expect(console.warn).toHaveBeenCalledWith(
+        '"returnFields" has been renamed to "_return". Support for "returnFields" will be removed in the next major release'
+      );
+    });
+  });
+});

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -77,14 +77,14 @@ const TestSearchStoreComponent: FC<TestSearchStoreComponentProps> = ({
   searchParameters = {
     projectId: ''
   },
-  searchResults = null,
+  searchResults,
   searchClient = new BaseSearchClient(),
   callback
 }) => {
   const [searchResponseStore, searchResponseApi] = useSearchResultsApi(
     searchParameters,
-    searchResults,
-    searchClient
+    searchClient,
+    searchResults
   );
 
   return (
@@ -348,15 +348,16 @@ describe('useSearchResultsApi', () => {
 
   const TestAutocompleteStoreComponent: FC<TestAutocompleteStoreComponentProps> = ({
     autocompleteParameters = {
-      projectId: ''
+      projectId: '',
+      prefix: ''
     },
-    autocompletionResults = null,
+    autocompletionResults,
     searchClient = new BaseSearchClient()
   }) => {
     const [autocompleteStore, autocompleteApi] = useAutocompleteApi(
       autocompleteParameters,
-      autocompletionResults,
-      searchClient
+      searchClient,
+      autocompletionResults
     );
 
     return (

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -740,9 +740,9 @@ describe('useFetchDocumentsApi', () => {
           return createDummyResponse({});
         }
       }
-      const searchParameters = {
+      const searchParameters: DiscoveryV2.QueryParams = {
         projectId: 'foo',
-        returnFields: [],
+        _return: [],
         aggregation: '',
         passages: {},
         tableResults: {}
@@ -758,7 +758,7 @@ describe('useFetchDocumentsApi', () => {
       fireEvent.click(fetchDocumentsButton, { target: { value: 'filter_string' } });
       expect(checkParametersMock).toHaveBeenCalledWith({
         projectId: 'foo',
-        returnFields: [],
+        _return: [],
         aggregation: '',
         passages: {},
         tableResults: {},

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -101,6 +101,12 @@ const TestSearchStoreComponent: FC<TestSearchStoreComponentProps> = ({
         data-testid="setSearchParameters"
         onClick={() => searchResponseApi.setSearchParameters({ projectId: 'set' })}
       />
+      <button
+        data-testid="setSearchParametersLegacy"
+        onClick={() =>
+          searchResponseApi.setSearchParameters({ projectId: 'set', returnFields: ['field'] })
+        }
+      />
       <div data-testid="searchResponseStore">{JSON.stringify(searchResponseStore)}</div>
     </>
   );
@@ -132,6 +138,24 @@ describe('useSearchResultsApi', () => {
         expect.objectContaining({
           projectId: 'foo',
           naturalLanguageQuery: 'bar'
+        })
+      );
+    });
+
+    test('can set initial search parameters with legacy returnFields', () => {
+      const searchParameters = {
+        projectId: 'foo',
+        returnFields: ['bar']
+      };
+      const result = render(<TestSearchStoreComponent searchParameters={searchParameters} />);
+      const json: SearchResponseStore = JSON.parse(
+        result.getByTestId('searchResponseStore').textContent || '{}'
+      );
+
+      expect(json.parameters).toEqual(
+        expect.objectContaining({
+          projectId: 'foo',
+          _return: ['bar']
         })
       );
     });
@@ -335,6 +359,24 @@ describe('useSearchResultsApi', () => {
       expect(json.parameters).toEqual(
         expect.objectContaining({
           projectId: 'set'
+        })
+      );
+    });
+  });
+
+  describe('when calling setSearchParametersLegacy', () => {
+    test('it sets search parameters', () => {
+      const result = render(<TestSearchStoreComponent searchClient={new BaseSearchClient()} />);
+      const setSearchParametersLegacyButton = result.getByTestId('setSearchParametersLegacy');
+
+      fireEvent.click(setSearchParametersLegacyButton);
+      const json: SearchResponseStore = JSON.parse(
+        result.getByTestId('searchResponseStore').textContent || '{}'
+      );
+      expect(json.parameters).toEqual(
+        expect.objectContaining({
+          projectId: 'set',
+          _return: ['field']
         })
       );
     });

--- a/packages/discovery-react-components/src/utils/deprecation.ts
+++ b/packages/discovery-react-components/src/utils/deprecation.ts
@@ -8,10 +8,11 @@ export function deprecateReturnFields(
     | undefined
 ): DiscoveryV2.QueryParams | SearchParams | undefined {
   if (queryParams && queryParams.returnFields) {
+    const { returnFields, ...rest } = queryParams;
     console.warn(
       '"returnFields" has been renamed to "_return". Support for "returnFields" will be removed in the next major release'
     );
-    return { ...queryParams, _return: queryParams.returnFields };
+    return { ...rest, _return: returnFields };
   }
   return queryParams;
 }

--- a/packages/discovery-react-components/src/utils/deprecation.ts
+++ b/packages/discovery-react-components/src/utils/deprecation.ts
@@ -1,0 +1,17 @@
+import DiscoveryV2 from 'ibm-watson/discovery/v2';
+import { SearchParams } from '../components/DiscoverySearch/types';
+
+export function deprecateReturnFields(
+  queryParams:
+    | (DiscoveryV2.QueryParams & { returnFields?: string[] })
+    | (SearchParams & { returnFields?: string[] })
+    | undefined
+): DiscoveryV2.QueryParams | SearchParams | undefined {
+  if (queryParams && queryParams.returnFields) {
+    console.warn(
+      '"returnFields" has been renamed to "_return". Support for "returnFields" will be removed in the next major release'
+    );
+    return { ...queryParams, _return: queryParams.returnFields };
+  }
+  return queryParams;
+}

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -1,6 +1,7 @@
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import { useState, useEffect, useReducer, useCallback, useRef } from 'react';
 import { SearchClient } from 'components/DiscoverySearch/types';
+import { deprecateReturnFields } from 'utils/deprecation';
 
 /**
  * generic reducer to handle updating loading, error, and data
@@ -36,7 +37,7 @@ const dataFetchReducer = (state: any, action: any) => {
 /**
  * interface to explain the return value of useDataApi
  */
-interface UseDataApiReturn {
+interface UseDataApiReturn<T, U> {
   /**
    * similar to useReducer, state is where the data and loading/error information live
    */
@@ -44,15 +45,15 @@ interface UseDataApiReturn {
   /**
    * parameters are sent to the API for the corresponding SDK method
    */
-  parameters: any;
+  parameters: T;
   /**
    * a method used to update the parameters that are sent to the API
    */
-  setParameters: (initialData: any) => void;
+  setParameters: React.Dispatch<React.SetStateAction<T>>;
   /**
    * a method that can be used to override the data attribute directly
    */
-  setData: React.Dispatch<React.SetStateAction<any>>;
+  setData: (value?: U) => void;
   /**
    * a method that is used to invoke the API call with whatever parameters are currently stored
    */
@@ -83,12 +84,12 @@ interface FetchToken {
  * @param searchClientMethod - api method reference on the searchClient
  * @param searchClient - the client used to do data fetching
  */
-const useDataApi = (
-  initialParameters: any,
-  initialData: any,
-  searchClientMethod: (params: any, callback?: any) => void | Promise<any>,
+const useDataApi = <T, U>(
+  initialParameters: T,
+  initialData: U | null,
+  searchClientMethod: (params: T, callback?: any) => void | Promise<any>,
   searchClient: SearchClient
-): UseDataApiReturn => {
+): UseDataApiReturn<T, U> => {
   // useRef stores state without rerenders
   // token to pass by reference instead of by value to keep track of cancellation state on unmount
   const cancelToken = useRef(false);
@@ -96,14 +97,14 @@ const useDataApi = (
   const requestIdRef = useRef(0);
   // token used to invoke the API call and optionally return the response data to the callback
   const [fetchToken, setFetchToken] = useState<FetchToken>({ trigger: false, callback: undefined });
-  const [parameters, setParameters] = useState(initialParameters);
+  const [parameters, setParameters] = useState<T>(initialParameters);
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: false,
     isError: false,
     data: initialData
   });
 
-  const setData = (data: any): void => {
+  const setData = (data?: U): void => {
     dispatch({ type: 'FETCH_SUCCESS', payload: data });
   };
 
@@ -178,7 +179,7 @@ export interface FieldsStoreActions {
    * method used to invoke the search request with an optional callback to return the response data
    */
   fetchFields: () => void;
-  setFieldsResponse: (overrideResults: DiscoveryV2.ListFieldsResponse | null) => void;
+  setFieldsResponse: (overrideResults?: DiscoveryV2.ListFieldsResponse) => void;
 }
 
 /**
@@ -192,12 +193,10 @@ export const useFieldsApi = (
   fetchFieldsParams: DiscoveryV2.ListFieldsParams,
   searchClient: SearchClient
 ): [FieldsStore, FieldsStoreActions] => {
-  const { state: fieldsState, setData: setFieldsResponse, setFetchToken } = useDataApi(
-    fetchFieldsParams,
-    null,
-    searchClient.listFields,
-    searchClient
-  );
+  const { state: fieldsState, setData: setFieldsResponse, setFetchToken } = useDataApi<
+    DiscoveryV2.ListFieldsParams,
+    DiscoveryV2.ListFieldsResponse
+  >(fetchFieldsParams, null, searchClient.listFields, searchClient);
 
   const fetchFields = useCallback(() => setFetchToken({ trigger: true }), [setFetchToken]);
 
@@ -225,11 +224,13 @@ export interface SearchResponseStoreActions {
   /**
    * method to set the parameters to be used with the search API when performSearch is invoked
    */
-  setSearchParameters: React.Dispatch<React.SetStateAction<DiscoveryV2.QueryParams>>;
+  setSearchParameters: React.Dispatch<
+    React.SetStateAction<DiscoveryV2.QueryParams & { returnFields?: string[] }>
+  >;
   /**
    * method to override the current search response
    */
-  setSearchResponse: (overrideSearchResponse: DiscoveryV2.QueryResponse | null) => void;
+  setSearchResponse: (overrideSearchResponse?: DiscoveryV2.QueryResponse) => void;
   /**
    * method used to invoke the search request with an optional callback to return the response data
    */
@@ -251,10 +252,32 @@ export const useSearchResultsApi = (
   const {
     state: searchState,
     parameters: currentSearchParameters,
-    setParameters: setSearchParameters,
+    setParameters: setSearchParametersBackwardsCompatible,
     setData: setSearchResponse,
     setFetchToken
-  } = useDataApi(searchParameters, overrideSearchResults, searchClient.query, searchClient);
+  } = useDataApi<DiscoveryV2.QueryParams, DiscoveryV2.QueryResponse>(
+    searchParameters,
+    overrideSearchResults,
+    searchClient.query,
+    searchClient
+  );
+  const setSearchParameters = (
+    backwardsCompatibleSearchParameters: React.SetStateAction<DiscoveryV2.QueryParams>
+  ) => {
+    // if backwardsCompatibleSearchParameters is a function, we cannot modify the parameters, call it with previous state
+    if (typeof backwardsCompatibleSearchParameters === 'function') {
+      setSearchParametersBackwardsCompatible(prevState => {
+        return deprecateReturnFields(
+          backwardsCompatibleSearchParameters(prevState)
+        ) as DiscoveryV2.QueryParams;
+      });
+    } else {
+      // otherwise just modify the object
+      setSearchParametersBackwardsCompatible(
+        deprecateReturnFields(backwardsCompatibleSearchParameters) as DiscoveryV2.QueryParams
+      );
+    }
+  };
 
   // callback can be passed in here to return back data to the invoker of the search
   // in the specific case here, we need to set our aggregation store after performing a search
@@ -366,12 +389,10 @@ export const useFetchDocumentsApi = (
   searchParameters: DiscoveryV2.QueryParams,
   searchClient: SearchClient
 ): [FetchDocumentsResponseStore, FetchDocumentsActions] => {
-  const { state: searchState, setParameters: setSearchParameters, setFetchToken } = useDataApi(
-    searchParameters,
-    null,
-    searchClient.query,
-    searchClient
-  );
+  const { state: searchState, setParameters: setSearchParameters, setFetchToken } = useDataApi<
+    DiscoveryV2.QueryParams,
+    DiscoveryV2.QueryResponse
+  >(searchParameters, null, searchClient.query, searchClient);
 
   const fetchDocuments = useCallback(
     (filter: string, callback: (result: DiscoveryV2.QueryResponse) => void): void => {
@@ -403,7 +424,7 @@ export interface AutocompleteStore extends ReducerState {
  * autocomplete actions used to interact with the autocomplete API and autocomplete state
  */
 export interface AutocompleteActions {
-  setAutocompletions: (data: DiscoveryV2.Completions | null) => void;
+  setAutocompletions: (data?: DiscoveryV2.Completions) => void;
   /**
    * method used to invoke the async autocomplete request
    */
@@ -428,7 +449,7 @@ export const useAutocompleteApi = (
     setParameters: setAutocompleteParameters,
     setData: setAutocompletions,
     setFetchToken
-  } = useDataApi(
+  } = useDataApi<DiscoveryV2.GetAutocompletionParams, DiscoveryV2.Completions>(
     autocompleteParmeters,
     overrideAutocompletions,
     searchClient.getAutocompletion,

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -86,9 +86,9 @@ interface FetchToken {
  */
 const useDataApi = <T, U>(
   initialParameters: T,
-  initialData: U | null,
   searchClientMethod: (params: T, callback?: any) => void | Promise<any>,
-  searchClient: SearchClient
+  searchClient: SearchClient,
+  initialData?: U
 ): UseDataApiReturn<T, U> => {
   // useRef stores state without rerenders
   // token to pass by reference instead of by value to keep track of cancellation state on unmount
@@ -196,7 +196,7 @@ export const useFieldsApi = (
   const { state: fieldsState, setData: setFieldsResponse, setFetchToken } = useDataApi<
     DiscoveryV2.ListFieldsParams,
     DiscoveryV2.ListFieldsResponse
-  >(fetchFieldsParams, null, searchClient.listFields, searchClient);
+  >(fetchFieldsParams, searchClient.listFields, searchClient);
 
   const fetchFields = useCallback(() => setFetchToken({ trigger: true }), [setFetchToken]);
 
@@ -246,8 +246,8 @@ export interface SearchResponseStoreActions {
  */
 export const useSearchResultsApi = (
   searchParameters: DiscoveryV2.QueryParams,
-  overrideSearchResults: DiscoveryV2.QueryResponse | null,
-  searchClient: SearchClient
+  searchClient: SearchClient,
+  overrideSearchResults?: DiscoveryV2.QueryResponse
 ): [SearchResponseStore, SearchResponseStoreActions] => {
   const {
     state: searchState,
@@ -257,9 +257,9 @@ export const useSearchResultsApi = (
     setFetchToken
   } = useDataApi<DiscoveryV2.QueryParams, DiscoveryV2.QueryResponse>(
     searchParameters,
-    overrideSearchResults,
     searchClient.query,
-    searchClient
+    searchClient,
+    overrideSearchResults
   );
   const setSearchParameters = (
     backwardsCompatibleSearchParameters: React.SetStateAction<DiscoveryV2.QueryParams>
@@ -318,9 +318,7 @@ export interface GlobalAggregationsStoreActions {
   /**
    * method to override the current aggregations
    */
-  setGlobalAggregationsResponse: (
-    aggregationsResponse: DiscoveryV2.QueryAggregation[] | null
-  ) => void;
+  setGlobalAggregationsResponse: (aggregationsResponse?: DiscoveryV2.QueryAggregation[]) => void;
   /**
    * method used to invoke the aggregations request with an optional callback to return the response data
    */
@@ -331,8 +329,8 @@ export interface GlobalAggregationsStoreActions {
 
 export const useGlobalAggregationsApi = (
   searchParameters: DiscoveryV2.QueryParams,
-  overrideAggregationResults: DiscoveryV2.QueryAggregation[] | null,
-  searchClient: SearchClient
+  searchClient: SearchClient,
+  overrideAggregationResults?: DiscoveryV2.QueryAggregation[]
 ): [GlobalAggregationsResponseStore, GlobalAggregationsStoreActions] => {
   const {
     state: aggregationState,
@@ -340,7 +338,12 @@ export const useGlobalAggregationsApi = (
     setParameters: setGlobalAggregationParameters,
     setData: setGlobalAggregationsResponse,
     setFetchToken
-  } = useDataApi(searchParameters, overrideAggregationResults, searchClient.query, searchClient);
+  } = useDataApi<DiscoveryV2.QueryParams, DiscoveryV2.QueryAggregation[]>(
+    searchParameters,
+    searchClient.query,
+    searchClient,
+    overrideAggregationResults
+  );
 
   const fetchGlobalAggregations = useCallback(
     (callback?: (result: DiscoveryV2.QueryAggregation[] | null) => void): void =>
@@ -392,7 +395,7 @@ export const useFetchDocumentsApi = (
   const { state: searchState, setParameters: setSearchParameters, setFetchToken } = useDataApi<
     DiscoveryV2.QueryParams,
     DiscoveryV2.QueryResponse
-  >(searchParameters, null, searchClient.query, searchClient);
+  >(searchParameters, searchClient.query, searchClient);
 
   const fetchDocuments = useCallback(
     (filter: string, callback: (result: DiscoveryV2.QueryResponse) => void): void => {
@@ -434,14 +437,14 @@ export interface AutocompleteActions {
 /**
  * concrete usage of the useDataApi helper method for fetching autocompletions
  * @param autocompleteParmeters - initial autocomplete parameters to set
- * @param overrideAutocompletions - initial autocomplete results to set
  * @param searchClient - search client used to perform requests
+ * @param overrideAutocompletions - initial autocomplete results to set
  * @return a 2-element array containing the autocomplete store data and autocomplete-specific store actions
  */
 export const useAutocompleteApi = (
   autocompleteParmeters: DiscoveryV2.GetAutocompletionParams,
-  overrideAutocompletions: DiscoveryV2.Completions | null,
-  searchClient: SearchClient
+  searchClient: SearchClient,
+  overrideAutocompletions?: DiscoveryV2.Completions
 ): [AutocompleteStore, AutocompleteActions] => {
   const {
     state: autocompletionsState,
@@ -451,9 +454,9 @@ export const useAutocompleteApi = (
     setFetchToken
   } = useDataApi<DiscoveryV2.GetAutocompletionParams, DiscoveryV2.Completions>(
     autocompleteParmeters,
-    overrideAutocompletions,
     searchClient.getAutocompletion,
-    searchClient
+    searchClient,
+    overrideAutocompletions
   );
 
   const fetchAutocompletions = useCallback(

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -261,23 +261,24 @@ export const useSearchResultsApi = (
     searchClient,
     overrideSearchResults
   );
-  const setSearchParameters = (
-    backwardsCompatibleSearchParameters: React.SetStateAction<DiscoveryV2.QueryParams>
-  ) => {
-    // if backwardsCompatibleSearchParameters is a function, we cannot modify the parameters, call it with previous state
-    if (typeof backwardsCompatibleSearchParameters === 'function') {
-      setSearchParametersBackwardsCompatible(prevState => {
-        return deprecateReturnFields(
-          backwardsCompatibleSearchParameters(prevState)
-        ) as DiscoveryV2.QueryParams;
-      });
-    } else {
-      // otherwise just modify the object
-      setSearchParametersBackwardsCompatible(
-        deprecateReturnFields(backwardsCompatibleSearchParameters) as DiscoveryV2.QueryParams
-      );
-    }
-  };
+  const setSearchParameters = useCallback(
+    (backwardsCompatibleSearchParameters: React.SetStateAction<DiscoveryV2.QueryParams>) => {
+      // if backwardsCompatibleSearchParameters is a function, we cannot modify the parameters, call it with previous state
+      if (typeof backwardsCompatibleSearchParameters === 'function') {
+        setSearchParametersBackwardsCompatible(prevState => {
+          return deprecateReturnFields(
+            backwardsCompatibleSearchParameters(prevState)
+          ) as DiscoveryV2.QueryParams;
+        });
+      } else {
+        // otherwise just modify the object
+        setSearchParametersBackwardsCompatible(
+          deprecateReturnFields(backwardsCompatibleSearchParameters) as DiscoveryV2.QueryParams
+        );
+      }
+    },
+    [setSearchParametersBackwardsCompatible]
+  );
 
   // callback can be passed in here to return back data to the invoker of the search
   // in the specific case here, we need to set our aggregation store after performing a search

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -245,7 +245,7 @@ export interface SearchResponseStoreActions {
  * @return a 2-element array containing the search store data and search-specific store actions
  */
 export const useSearchResultsApi = (
-  searchParameters: DiscoveryV2.QueryParams,
+  searchParameters: DiscoveryV2.QueryParams & { returnFields?: string[] },
   searchClient: SearchClient,
   overrideSearchResults?: DiscoveryV2.QueryResponse
 ): [SearchResponseStore, SearchResponseStoreActions] => {
@@ -256,7 +256,7 @@ export const useSearchResultsApi = (
     setData: setSearchResponse,
     setFetchToken
   } = useDataApi<DiscoveryV2.QueryParams, DiscoveryV2.QueryResponse>(
-    searchParameters,
+    deprecateReturnFields(searchParameters) as DiscoveryV2.QueryParams,
     searchClient.query,
     searchClient,
     overrideSearchResults

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,11 +3436,6 @@
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.0.tgz#14264692a9d6e2fa4db3df5e56e94b5e25647ac0"
   integrity sha512-iIgQNzCm0v7QMhhe4Jjn9uRh+I6GoPmt03CbEtwx3ao8/EfoQcmgtqH4vQ5Db/lxiIGaWDv6nwvunuh0RyX0+A==
 
-"@types/async@^2.4.2":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@types/async/-/async-2.4.2.tgz#9b33d5c9fcebff17139521753eaf992ed5ace8e4"
-  integrity sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww==
-
 "@types/async@^3.2.5":
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.5.tgz#febca3166039b8946eb162a14a91e8de9a373ebc"
@@ -3509,7 +3504,7 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
-"@types/extend@^3.0.1", "@types/extend@~3.0.0":
+"@types/extend@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/extend/-/extend-3.0.1.tgz#923dc2d707d944382433e01d6cc0c69030ab2c75"
   integrity sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw==
@@ -3631,11 +3626,6 @@
   version "14.14.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
   integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
-
-"@types/node@^11.9.4":
-  version "11.15.40"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.15.40.tgz#66b17b7a9b06fe2689a77afeaa6f432779018b28"
-  integrity sha512-pGIHnyS9XYo7uSV6YHWSsXlqZ1NanfsxMCreJX94T963sA9733Ctsjo2VIq74MvKx3+i4t50HQPfuLfNuZSo4g==
 
 "@types/node@^12.7.3":
   version "12.19.9"
@@ -3899,7 +3889,7 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/websocket@^1.0.0", "@types/websocket@^1.0.1":
+"@types/websocket@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.1.tgz#039272c196c2c0e4868a0d8a1a27bbb86e9e9138"
   integrity sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==
@@ -4987,14 +4977,6 @@ axios-cookiejar-support@^1.0.0:
   dependencies:
     is-redirect "^1.0.0"
     pify "^5.0.0"
-
-axios@^0.18.0:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
 
 axios@^0.19.2:
   version "0.19.2"
@@ -10424,31 +10406,6 @@ husky@^3.0.5:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-ibm-cloud-sdk-core@^1.0.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-1.3.1.tgz#c111343350a7949d15c45123a23a0604fdfe28a2"
-  integrity sha512-fGaJxJeXWGjHQ478vPUm2RSxUXjNEaoy3mpaUG4iQvJ6Yi29Mw/qtz6IoNEzoowSKvsW/whqblVEqiOBGRTrog==
-  dependencies:
-    "@types/extend" "~3.0.0"
-    "@types/file-type" "~5.2.1"
-    "@types/isstream" "^0.1.0"
-    "@types/node" "~10.14.19"
-    axios "^0.18.0"
-    camelcase "^5.3.1"
-    debug "^4.1.1"
-    dotenv "^6.2.0"
-    extend "~3.0.2"
-    file-type "^7.7.1"
-    form-data "^2.3.3"
-    isstream "~0.1.2"
-    jsonwebtoken "^8.5.1"
-    lodash.isempty "^4.4.0"
-    mime-types "~2.1.18"
-    object.omit "~3.0.0"
-    object.pick "~1.3.0"
-    semver "^6.2.0"
-    vcap_services "~0.3.4"
-
 ibm-cloud-sdk-core@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.7.1.tgz#326c42972db338bf0471ecac8bf170ff237e70d8"
@@ -10475,24 +10432,6 @@ ibm-cloud-sdk-core@^2.7.1:
     object.pick "~1.3.0"
     semver "^6.2.0"
     tough-cookie "^4.0.0"
-
-ibm-watson@5.2.0-alpha-1:
-  version "5.2.0-alpha-1"
-  resolved "https://registry.yarnpkg.com/ibm-watson/-/ibm-watson-5.2.0-alpha-1.tgz#6aa75252fed3bc3002f4dbdc71d0994b896d1d1d"
-  integrity sha512-6FgDrfAQxSnt2bHq1UBSNam4OHwrdmj+sLksji2VqGgTY5zgYEw8flDXsmUb2NAIieABTqeNlEqnSkW/zxaJew==
-  dependencies:
-    "@types/async" "^2.4.2"
-    "@types/extend" "^3.0.1"
-    "@types/isstream" "^0.1.0"
-    "@types/node" "^11.9.4"
-    "@types/websocket" "^1.0.0"
-    async "^2.6.2"
-    axios "^0.18.0"
-    camelcase "^5.3.1"
-    extend "~3.0.2"
-    ibm-cloud-sdk-core "^1.0.0"
-    isstream "~0.1.2"
-    websocket "^1.0.28"
 
 ibm-watson@^6.0.2:
   version "6.0.2"
@@ -10957,7 +10896,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.2:
+is-buffer@^2.0.0:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -19359,11 +19298,6 @@ vary@^1, vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vcap_services@~0.3.4:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/vcap_services/-/vcap_services-0.3.4.tgz#154bf940402512acca23df2263fc60ef66845ada"
-  integrity sha1-FUv5QEAlEqzKI98iY/xg72aEWto=
-
 vendors@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.4.tgz#e2b800a53e7a29b93506c3cf41100d16c4c4ad8e"
@@ -19761,7 +19695,7 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-websocket@^1.0.28, websocket@^1.0.33:
+websocket@^1.0.33:
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
   integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4978,13 +4978,6 @@ axios-cookiejar-support@^1.0.0:
     is-redirect "^1.0.0"
     pify "^5.0.0"
 
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
-
 axios@^0.21.1:
   version "0.21.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
@@ -7264,7 +7257,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0, debug@=3.1.0:
+debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
@@ -9203,13 +9196,6 @@ focus-lock@^0.8.1:
   integrity sha512-/LFZOIo82WDsyyv7h7oc0MJF9ACOvDRdx9rWPZ2pgMfNWu/z8hQDBtOchuB/0BVLmuFOZjV02YwUVzNsWx/EzA==
   dependencies:
     tslib "^1.9.3"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"
@@ -11871,7 +11857,7 @@ jest@24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
-joi@^17.1.1:
+joi@^17.3.0:
   version "17.3.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
   integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
@@ -17145,7 +17131,7 @@ rx-lite@*, rx-lite@^4.0.8:
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
   integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.5, rxjs@^6.6.0:
+rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
@@ -17899,10 +17885,10 @@ stack-utils@^2.0.2:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-start-server-and-test@^1.10.0:
-  version "1.11.6"
-  resolved "https://registry.yarnpkg.com/start-server-and-test/-/start-server-and-test-1.11.6.tgz#d1ddc41bc49a61302829eecc7b799ca98562ee9f"
-  integrity sha512-+0T83W/R7CVgIE2HJcrpJDleLt7Skc2Xj8jWWsItRGdpZwenAv0YtIpBEKoL64pwUtPAPoHuYUtvWUOfCRoVjg==
+start-server-and-test@^1.11.7:
+  version "1.11.7"
+  resolved "https://registry.yarnpkg.com/start-server-and-test/-/start-server-and-test-1.11.7.tgz#3026bc6020e41edd4efad231bedf00a6a051f22a"
+  integrity sha512-91hA8mddcHSS3R7xRrVS9FT4qdRDvHlOEbI+mAA/sAW+31e78ptFmWWj+PJHFUKJrxtIkQ3ZeejPxCdesktULg==
   dependencies:
     bluebird "3.7.2"
     check-more-types "2.24.0"
@@ -17910,7 +17896,7 @@ start-server-and-test@^1.10.0:
     execa "3.4.0"
     lazy-ass "1.6.0"
     ps-tree "1.2.0"
-    wait-on "5.2.0"
+    wait-on "5.2.1"
 
 state-toggle@^1.0.0:
   version "1.0.3"
@@ -19405,16 +19391,16 @@ wait-for-expect@^3.0.2:
   resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
   integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
 
-wait-on@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.2.0.tgz#6711e74422523279714a36d52cf49fb47c9d9597"
-  integrity sha512-U1D9PBgGw2XFc6iZqn45VBubw02VsLwnZWteQ1au4hUVHasTZuFSKRzlTB2dqgLhji16YVI8fgpEpwUdCr8B6g==
+wait-on@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/wait-on/-/wait-on-5.2.1.tgz#05b66fcb4d7f5da01537f03e7cf96e8836422996"
+  integrity sha512-H2F986kNWMU9hKlI9l/ppO6tN8ZSJd35yBljMLa1/vjzWP++Qh6aXyt77/u7ySJFZQqBtQxnvm/xgG48AObXcw==
   dependencies:
-    axios "^0.19.2"
-    joi "^17.1.1"
-    lodash "^4.17.19"
+    axios "^0.21.1"
+    joi "^17.3.0"
+    lodash "^4.17.20"
     minimist "^1.2.5"
-    rxjs "^6.5.5"
+    rxjs "^6.6.3"
 
 walkdir@^0.4.1:
   version "0.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1651,7 +1651,7 @@
     "@hapi/hoek" "^9.0.0"
 
 "@ibm-watson/discovery-react-components@file:packages/discovery-react-components":
-  version "1.3.1-beta.0"
+  version "1.3.1-beta.1"
   dependencies:
     classnames "^2.2.6"
     debounce "^1.2.0"
@@ -3441,6 +3441,11 @@
   resolved "https://registry.yarnpkg.com/@types/async/-/async-2.4.2.tgz#9b33d5c9fcebff17139521753eaf992ed5ace8e4"
   integrity sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww==
 
+"@types/async@^3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@types/async/-/async-3.2.5.tgz#febca3166039b8946eb162a14a91e8de9a373ebc"
+  integrity sha512-fdtHUdfIxSfU6crUgUOEb6vxdquAOa75bh1sQVL/ePkmQDNo8Aj1056eGGI9cPls5tLRhnAyfoXljEk+hmhbxg==
+
 "@types/babel__core@^7.1.0":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -3637,6 +3642,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.19.9.tgz#990ad687ad8b26ef6dcc34a4f69c33d40c95b679"
   integrity sha512-yj0DOaQeUrk3nJ0bd3Y5PeDRJ6W0r+kilosLA+dzF3dola/o9hxhMSg2sFvVcA2UHS5JSOsZp4S0c1OEXc4m1Q==
 
+"@types/node@^13.13.39":
+  version "13.13.40"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.40.tgz#f655ef327362cc83912f2e69336ddc62a24a9f88"
+  integrity sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ==
+
 "@types/node@~10.14.19":
   version "10.14.22"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.22.tgz#34bcdf6b6cb5fc0db33d24816ad9d3ece22feea4"
@@ -3793,6 +3803,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
+"@types/stack-utils@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
+  integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+
 "@types/tapable@*", "@types/tapable@^1.0.5":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
@@ -3835,6 +3850,11 @@
     "@types/react-dom" "*"
     "@types/testing-library__dom" "*"
     pretty-format "^25.1.0"
+
+"@types/tough-cookie@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.0.tgz#fef1904e4668b6e5ecee60c52cc6a078ffa6697d"
+  integrity sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
 
 "@types/uglify-js@*":
   version "3.11.1"
@@ -3879,7 +3899,7 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/websocket@^1.0.0":
+"@types/websocket@^1.0.0", "@types/websocket@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.1.tgz#039272c196c2c0e4868a0d8a1a27bbb86e9e9138"
   integrity sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==
@@ -4960,6 +4980,14 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.1.1.tgz#70a7855888e287f7add66002211a423937063eaf"
   integrity sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==
 
+axios-cookiejar-support@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/axios-cookiejar-support/-/axios-cookiejar-support-1.0.1.tgz#7b32af7d932508546c68b1fc5ba8f562884162e1"
+  integrity sha512-IZJxnAJ99XxiLqNeMOqrPbfR7fRyIfaoSLdPUf4AMQEGkH8URs0ghJK/xtqBsD+KsSr3pKl4DEQjCn834pHMig==
+  dependencies:
+    is-redirect "^1.0.0"
+    pify "^5.0.0"
+
 axios@^0.18.0:
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
@@ -4974,6 +5002,13 @@ axios@^0.19.2:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
 
 axobject-query@^2.0.2, axobject-query@^2.2.0:
   version "2.2.0"
@@ -5929,6 +5964,11 @@ camelcase@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
+
+camelcase@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 can-use-dom@^0.1.0:
   version "0.1.0"
@@ -7590,6 +7630,11 @@ diff-sequences@^24.9.0:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-24.9.0.tgz#5715d6244e2aa65f48bba0bc972db0b0b11e95b5"
   integrity sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==
 
+diff-sequences@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
+  integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -8670,6 +8715,18 @@ expect@^24.9.0:
     jest-message-util "^24.9.0"
     jest-regex-util "^24.9.0"
 
+expect@^26.1.0:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-26.6.2.tgz#c6b996bf26bf3fe18b67b2d0f51fc981ba934417"
+  integrity sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
+  dependencies:
+    "@jest/types" "^26.6.2"
+    ansi-styles "^4.0.0"
+    jest-get-type "^26.3.0"
+    jest-matcher-utils "^26.6.2"
+    jest-message-util "^26.6.2"
+    jest-regex-util "^26.0.0"
+
 express@^4.17.0, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
@@ -8728,7 +8785,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.2:
+extend@^3.0.0, extend@^3.0.2, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -9172,7 +9229,7 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
   integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
@@ -9807,7 +9864,7 @@ good-listener@^1.2.2:
   dependencies:
     delegate "^3.1.2"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -10392,6 +10449,33 @@ ibm-cloud-sdk-core@^1.0.0:
     semver "^6.2.0"
     vcap_services "~0.3.4"
 
+ibm-cloud-sdk-core@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-2.7.1.tgz#326c42972db338bf0471ecac8bf170ff237e70d8"
+  integrity sha512-JQrZWYWl9ORxboUu7AbwY1CJKpV8G8/F8sGNL0i1D47jeOWQUEMO11gqlaofS7BoaAEEBeFoRS6JtFhyWEQKPA==
+  dependencies:
+    "@types/file-type" "~5.2.1"
+    "@types/isstream" "^0.1.0"
+    "@types/node" "~10.14.19"
+    "@types/tough-cookie" "^4.0.0"
+    axios "^0.21.1"
+    axios-cookiejar-support "^1.0.0"
+    camelcase "^5.3.1"
+    debug "^4.1.1"
+    dotenv "^6.2.0"
+    expect "^26.1.0"
+    extend "^3.0.2"
+    file-type "^7.7.1"
+    form-data "^2.3.3"
+    isstream "~0.1.2"
+    jsonwebtoken "^8.5.1"
+    lodash.isempty "^4.4.0"
+    mime-types "~2.1.18"
+    object.omit "~3.0.0"
+    object.pick "~1.3.0"
+    semver "^6.2.0"
+    tough-cookie "^4.0.0"
+
 ibm-watson@5.2.0-alpha-1:
   version "5.2.0-alpha-1"
   resolved "https://registry.yarnpkg.com/ibm-watson/-/ibm-watson-5.2.0-alpha-1.tgz#6aa75252fed3bc3002f4dbdc71d0994b896d1d1d"
@@ -10409,6 +10493,23 @@ ibm-watson@5.2.0-alpha-1:
     ibm-cloud-sdk-core "^1.0.0"
     isstream "~0.1.2"
     websocket "^1.0.28"
+
+ibm-watson@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ibm-watson/-/ibm-watson-6.0.2.tgz#323b7f324164181ca0a676162cc94d30a2546d78"
+  integrity sha512-WBJJD3DQwqSHOAiX27rl7HcWcWXn5fk8GkqEk+XuPqXWZYNqoLtpQa7GCtIvVJvNQHL3dbalJcTyYwzjBn4PKw==
+  dependencies:
+    "@types/async" "^3.2.5"
+    "@types/extend" "^3.0.1"
+    "@types/isstream" "^0.1.0"
+    "@types/node" "^13.13.39"
+    "@types/websocket" "^1.0.1"
+    async "^3.2.0"
+    camelcase "^6.2.0"
+    extend "~3.0.2"
+    ibm-cloud-sdk-core "^2.7.1"
+    isstream "~0.1.2"
+    websocket "^1.0.33"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
   version "0.4.24"
@@ -11170,6 +11271,11 @@ is-promise@^2.0.0, is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+  integrity sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=
+
 is-reference@^1.1.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/is-reference/-/is-reference-1.2.1.tgz#8b2dac0b371f4bc994fdeaba9eb542d03002d0b7"
@@ -11455,6 +11561,16 @@ jest-diff@^24.0.0, jest-diff@^24.3.0, jest-diff@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-diff@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.2.tgz#1aa7468b52c3a68d7d5c5fdcdfcd5e49bd164394"
+  integrity sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-docblock@^24.3.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-24.9.0.tgz#7970201802ba560e1c4092cc25cbedf5af5a8ce2"
@@ -11512,6 +11628,11 @@ jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
   integrity sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==
+
+jest-get-type@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
+  integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
 
 jest-haste-map@^24.9.0:
   version "24.9.0"
@@ -11572,6 +11693,16 @@ jest-matcher-utils@^24.0.0, jest-matcher-utils@^24.9.0:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
 
+jest-matcher-utils@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.2.tgz#8e6fd6e863c8b2d31ac6472eeb237bc595e53e7a"
+  integrity sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^26.6.2"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.2"
+
 jest-message-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.9.0.tgz#527f54a1e380f5e202a8d1149b0ec872f43119e3"
@@ -11585,6 +11716,21 @@ jest-message-util@^24.9.0:
     micromatch "^3.1.10"
     slash "^2.0.0"
     stack-utils "^1.0.1"
+
+jest-message-util@^26.6.2:
+  version "26.6.2"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-26.6.2.tgz#58173744ad6fc0506b5d21150b9be56ef001ca07"
+  integrity sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/types" "^26.6.2"
+    "@types/stack-utils" "^2.0.0"
+    chalk "^4.0.0"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.2"
+    pretty-format "^26.6.2"
+    slash "^3.0.0"
+    stack-utils "^2.0.2"
 
 jest-mock@^24.0.0, jest-mock@^24.9.0:
   version "24.9.0"
@@ -11602,6 +11748,11 @@ jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"
   integrity sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==
+
+jest-regex-util@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-26.0.0.tgz#d25e7184b36e39fd466c3bc41be0971e821fee28"
+  integrity sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
 
 jest-resolve-dependencies@^24.9.0:
   version "24.9.0"
@@ -14496,6 +14647,11 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
+pify@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-5.0.0.tgz#1f5eca3f5e87ebec28cc6d54a0e4aaf00acc127f"
+  integrity sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -15575,7 +15731,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
+psl@^1.1.28, psl@^1.1.33:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -17797,6 +17953,13 @@ stack-utils@^1.0.1:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stack-utils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
+  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+  dependencies:
+    escape-string-regexp "^2.0.0"
+
 start-server-and-test@^1.10.0:
   version "1.11.6"
   resolved "https://registry.yarnpkg.com/start-server-and-test/-/start-server-and-test-1.11.6.tgz#d1ddc41bc49a61302829eecc7b799ca98562ee9f"
@@ -18583,6 +18746,15 @@ tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@^2.5.0, tough-cookie@~2.5
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tough-cookie@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
+  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.1.2"
+
 tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -18991,7 +19163,7 @@ universal-user-agent@^6.0.0:
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"
   integrity sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==
 
-universalify@^0.1.0:
+universalify@^0.1.0, universalify@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
@@ -19589,7 +19761,7 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
-websocket@^1.0.28:
+websocket@^1.0.28, websocket@^1.0.33:
   version "1.0.33"
   resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
   integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==


### PR DESCRIPTION
#### What do these changes do/fix?

`axios` had a vulnerability in one of our packages (`ibm-watson`) so we needed to upgrade that. Unfortunately since we had to go up a major version to get it (we were on `alpha`), we had breaking changes detailed in https://github.com/watson-developer-cloud/node-sdk/wiki/v5-Migration-Guide#discovery

- `returnFields` was renamed to `_return`, we added a deprecation warning to anyone who uses this library and still has `returnFields` but copies it over to `_return` while logging a warning.
- `prefix` became required on the `GetAutocompleteParameters` type


Also took the time to clean up some types for `useDataApi` utility and `DiscoverySearch` component to more closely align with reality without breaking any public APIs

#### How do you test/verify these changes?

`lerna run test`

#### Have you documented your changes (if necessary)?

TBD

#### Are there any breaking changes included in this pull request?

no breaking change until next major version
