### PR TITLE
refactor: change usage of fetchGlobalAggregations

### DIFF
--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -253,7 +253,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   const [
     globalAggregationsResponseStore,
-    { setGlobalAggregationsResponse }
+    { setGlobalAggregationsResponse, fetchGlobalAggregations }
   ] = useGlobalAggregationsApi(
     { ...globalAggregationsResponseStoreDefaults, projectId },
     searchClient,
@@ -265,15 +265,17 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       aggregationResults: QueryAggregationWithName[],
       searchParams: DiscoveryV2.QueryParams
     ) => {
-      const updatedAggQuery = buildAggregationQuery(aggregationResults);
-      const updatedSearchParameters = {
-        ...searchParams,
-        aggregation: updatedAggQuery
-      };
-      const { result } = await searchClient.query(updatedSearchParameters);
-      return result.aggregations;
+      // TODO make this only run if aggregationResults doesn't already have type for top entities aggregation in the results
+      if (isQueryAggregationWithName(aggregationResults)) {
+        const updatedAggQuery = buildAggregationQuery(aggregationResults);
+        const updatedSearchParameters = {
+          ...searchParams,
+          aggregation: updatedAggQuery
+        };
+        fetchGlobalAggregations(updatedSearchParameters);
+      }
     },
-    [searchClient]
+    [fetchGlobalAggregations]
   );
 
   const handleSearch = useCallback(
@@ -289,39 +291,28 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       // don't use the search response if filter is set, just do another search
       if (resetAggregations && searchParameters.filter !== '') {
         aggregationsFetched = true;
-        const response = await searchClient.query({
-          ...searchParameters,
-          ...aggregationQueryDefaults,
-          filter: ''
-        });
-        if (response && response.result && response.result.aggregations) {
-          if (isQueryAggregationWithName(response.result.aggregations)) {
-            const updatedAggregations = await fetchTypeForTopEntitiesAggregation(
-              response.result.aggregations,
-              searchParameters
-            );
-            setGlobalAggregationsResponse(updatedAggregations);
-          } else {
-            setGlobalAggregationsResponse(response.result.aggregations);
+        fetchGlobalAggregations(
+          {
+            ...searchParameters,
+            ...aggregationQueryDefaults,
+            filter: ''
+          },
+          async aggregations => {
+            fetchTypeForTopEntitiesAggregation(aggregations, searchParameters);
           }
-        }
+        );
       }
 
       performSearch(async result => {
         if (!aggregationsFetched && resetAggregations && result && result.aggregations) {
-          const updatedAggregations = await fetchTypeForTopEntitiesAggregation(
-            result.aggregations,
-            searchParameters
-          );
-          setGlobalAggregationsResponse(updatedAggregations);
+          fetchTypeForTopEntitiesAggregation(result.aggregations, searchParameters);
         }
       });
     },
     [
+      fetchGlobalAggregations,
       fetchTypeForTopEntitiesAggregation,
       performSearch,
-      searchClient,
-      setGlobalAggregationsResponse,
       setSearchParameters
     ]
   );
@@ -438,25 +429,11 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
         ...searchParamsWithoutFilter,
         ...aggregationQueryDefaults
       };
-      const { result } = await searchClient.query(searchParametersWithAggregationDefaults);
-      if (result) {
-        const { aggregations } = result;
-        let updatedAggregations = aggregations;
-        if (aggregations && isQueryAggregationWithName(aggregations)) {
-          updatedAggregations = await fetchTypeForTopEntitiesAggregation(
-            aggregations,
-            searchParametersWithAggregationDefaults
-          );
-        }
-        setGlobalAggregationsResponse(updatedAggregations);
-      }
+      fetchGlobalAggregations(searchParametersWithAggregationDefaults, async aggregations => {
+        fetchTypeForTopEntitiesAggregation(aggregations, searchParametersWithAggregationDefaults);
+      });
     },
-    [
-      fetchTypeForTopEntitiesAggregation,
-      searchClient,
-      setGlobalAggregationsResponse,
-      setSearchParameters
-    ]
+    [fetchGlobalAggregations, fetchTypeForTopEntitiesAggregation, setSearchParameters]
   );
 
   const handleSetSelectedResult = (overrideSelectedResult: SelectedResult) => {

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useContext, useEffect, useState, SyntheticEvent } from 'react';
+import React, { FC, useContext, useState, SyntheticEvent } from 'react';
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import { Button } from 'carbon-components-react';
 import { settings } from 'carbon-components';
@@ -91,7 +91,12 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     },
     collectionsResults,
     componentSettings,
-    globalAggregationsResponseStore: { isLoading, isError, data: aggregations }
+    globalAggregationsResponseStore: {
+      isLoading,
+      isError,
+      data: aggregations,
+      parameters: globalAggregationsParameters
+    }
   } = useContext(SearchContext);
 
   const [facetSelectionState, setFacetSelectionState] = useState<SearchFilterFacets>(
@@ -127,15 +132,11 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     (componentSettings && componentSettings.aggregations) ||
     [];
 
-  useEffect(() => {
-    async function fetchData() {
-      await fetchAggregations(searchParameters);
+  useDeepCompareEffect(() => {
+    if (!aggregations && !isError && !isLoading) {
+      fetchAggregations(globalAggregationsParameters);
     }
-
-    if (!aggregations) {
-      fetchData();
-    }
-  }, [fetchAggregations, searchParameters]);
+  }, [fetchAggregations, globalAggregationsParameters, aggregations, isError, isLoading]);
 
   useDeepCompareEffect(() => {
     if (filter === '') {

--- a/packages/discovery-react-components/src/components/SearchFacets/__tests__/SearchFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/__tests__/SearchFacets.test.tsx
@@ -53,6 +53,10 @@ const setup = ({
   const context: Partial<SearchContextIFC> = {
     globalAggregationsResponseStore: {
       ...globalAggregationsResponseStoreDefaults,
+      parameters: {
+        projectId: '',
+        aggregation: '[term(author,count:3),term(subject,count:4)]'
+      },
       data: aggregations,
       ...globalAggregationsResponseStoreOverrides
     },
@@ -62,8 +66,7 @@ const setup = ({
       parameters: {
         projectId: '',
         collectionIds,
-        filter,
-        aggregation: '[term(author,count:3),term(subject,count:4)]'
+        filter
       }
     },
     componentSettings: {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFacetInterfaces.ts
@@ -66,7 +66,7 @@ export interface QueryAggregationWithName extends DiscoveryV2.QueryAggregation {
 export const isQueryAggregationWithName = (
   aggregations?: (DiscoveryV2.QueryAggregation | QueryAggregationWithName)[]
 ): aggregations is QueryAggregationWithName[] => {
-  const { field, path, match } = (aggregations as QueryAggregationWithName[])[0];
+  const { field, path, match } = (aggregations as QueryAggregationWithName[])[0] || {};
   return field !== undefined || path !== undefined || match !== undefined;
 };
 

--- a/packages/discovery-react-components/src/utils/testingUtils.tsx
+++ b/packages/discovery-react-components/src/utils/testingUtils.tsx
@@ -31,7 +31,7 @@ export function createDummyResponse(result: any) {
   };
 }
 
-export function createDummyResponsePromise(result: any) {
+export function createDummyResponsePromise<T>(result: T) {
   return Promise.resolve(createDummyResponse(result));
 }
 

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -88,7 +88,8 @@ const useDataApi = <T, U>(
   initialParameters: T,
   searchClientMethod: (params: T, callback?: any) => void | Promise<any>,
   searchClient: SearchClient,
-  initialData?: U
+  initialData?: U,
+  transformResult?: (result: any) => U
 ): UseDataApiReturn<T, U> => {
   // useRef stores state without rerenders
   // token to pass by reference instead of by value to keep track of cancellation state on unmount
@@ -116,9 +117,13 @@ const useDataApi = <T, U>(
         // before storing the data, make sure the component hasn't been unmounted
         // and make sure this request is the most recent one (discard old requests)
         if (!cancelToken.current && requestId === requestIdRef.current) {
-          dispatch({ type: 'FETCH_SUCCESS', payload: result });
+          let payload = result;
+          if (transformResult) {
+            payload = transformResult(result);
+          }
+          dispatch({ type: 'FETCH_SUCCESS', payload });
           if (callback) {
-            callback(result);
+            callback(payload);
           }
         }
       } catch (error) {
@@ -127,7 +132,7 @@ const useDataApi = <T, U>(
         }
       }
     },
-    [searchClient, searchClientMethod]
+    [searchClient, searchClientMethod, transformResult]
   );
 
   // in order to prevent state updates after component unmount, set the cancel token
@@ -344,7 +349,8 @@ export const useGlobalAggregationsApi = (
     searchParameters,
     searchClient.query,
     searchClient,
-    overrideAggregationResults
+    overrideAggregationResults,
+    (result: DiscoveryV2.QueryResponse) => result.aggregations || []
   );
 
   const fetchGlobalAggregations = useCallback(

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -321,10 +321,11 @@ export interface GlobalAggregationsStoreActions {
    */
   setGlobalAggregationsResponse: (aggregationsResponse?: DiscoveryV2.QueryAggregation[]) => void;
   /**
-   * method used to invoke the aggregations request with an optional callback to return the response data
+   * method used to invoke the aggregations request with search parameters and an optional callback to return the response data
    */
   fetchGlobalAggregations: (
-    callback?: (result: DiscoveryV2.QueryAggregation[] | null) => void
+    searchParameters: DiscoveryV2.QueryParams,
+    callback?: (result: DiscoveryV2.QueryAggregation[]) => void
   ) => void;
 }
 

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -348,9 +348,14 @@ export const useGlobalAggregationsApi = (
   );
 
   const fetchGlobalAggregations = useCallback(
-    (callback?: (result: DiscoveryV2.QueryAggregation[] | null) => void): void =>
-      setFetchToken({ trigger: true, callback }),
-    [setFetchToken]
+    (
+      searchParameters: DiscoveryV2.QueryParams,
+      callback?: (result: DiscoveryV2.QueryAggregation[]) => void
+    ): void => {
+      setGlobalAggregationParameters(searchParameters);
+      setFetchToken({ trigger: true, callback });
+    },
+    [setFetchToken, setGlobalAggregationParameters]
   );
 
   return [


### PR DESCRIPTION
#### What do these changes do/fix?

Updates how we utilize `fetchGlobalAggregations` to handle cases when the response errors to not enter an infinite loop

#### How do you test/verify these changes?

`./runExampleApp.sh` and validate that after setting proper config it doesn't freeze your browser on `/query` 404 errors

#### Have you documented your changes (if necessary)?

N/A

#### Are there any breaking changes included in this pull request?
N/A