### PR TITLE
ci: fix publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: NPM Identity
         if: github.ref == 'refs/heads/master' || contains(github.ref, 'release/')
         run: |
-          echo "registry=//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
           npm whoami
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Discovery Components
 
-![ci](https://github.com/watson-developer-cloud/discovery-components/workflows/ci/badge.svg)
+![ci](https://github.com/watson-developer-cloud/discovery-components/workflows/ci/badge.svg)(https://github.com/watson-developer-cloud/discovery-components/actions?query=branch%3Amaster)
 [![Apache-2.0 license](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](https://github.com/watson-developer-cloud/discovery-components/blob/master/LICENSE)
 [![Lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/watson-developer-cloud/discovery-components/blob/master/.github/CONTRIBUTING.md)


### PR DESCRIPTION
#### What do these changes do/fix?
`~/.npmrc` doesn't like `registry=` -> removing that to see if publishing works now