### PR TITLE
ci: add fetch-depth

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,9 @@ jobs:
       # https://github.com/actions/checkout
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # https://github.com/actions/checkout/issues/217
+          fetch-depth: 0
       # https://github.com/actions/checkout/issues/217 pulls all tags (needed for lerna to correctly version)
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
       # https://github.com/actions/setup-node


### PR DESCRIPTION
#### What do these changes do/fix?

lerna was still reporting `Assuming all packages changed` which indicates it doesn't have access to the diffs to compute whether a new version needs to be released

#### How do you test/verify these changes?
publish job on `master` succeeds