### PR TITLE
test: group assertions together in Cypress tests

### DIFF
--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -61,13 +61,10 @@ describe('Multi-Select Facets', () => {
         cy.wait('@postQueryFacetsAmes').as('amesFilterQueryObject');
       });
 
-      it('makes a query for the right facets', () => {
+      it('queries and selects the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
           .should('eq', 'location:"Ames, IA"');
-      });
-
-      it('changes the bubble next to that facet to say 1', () => {
         cy.get('.bx--list-box__selection')
           .contains('1')
           .should('exist');
@@ -84,13 +81,10 @@ describe('Multi-Select Facets', () => {
           cy.wait('@postQueryFacetsAmesOrPittsburgh').as('multiFilterQueryObject');
         });
 
-        it('makes a query for both filters in the facet', () => {
+        it('queries and selects the right facets', () => {
           cy.get('@multiFilterQueryObject')
             .its('requestBody.filter')
             .should('eq', 'location:"Pittsburgh, PA"|"Ames, IA"');
-        });
-
-        it('changes the bubble next to that facet to say 2', () => {
           cy.get('.bx--list-box__selection')
             .contains('2')
             .should('exist');
@@ -119,13 +113,10 @@ describe('Multi-Select Facets', () => {
           cy.wait('@postQueryFacets').as('clearedFacetsQueryObject');
         });
 
-        it('makes a query without any selected facets', () => {
+        it('makes a query without any selected facets and there is no "Clear all" button', () => {
           cy.get('@clearedFacetsQueryObject')
             .its('requestBody.filter')
             .should('eq', '');
-        });
-
-        it('has the "Clear all" button disappear', () => {
           cy.get('button')
             .contains('Clear all')
             .should('not.exist');

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -36,9 +36,8 @@ describe('Single-Select Facets', () => {
       cy.get('@cityFacet').should('exist');
       cy.get('@cuisineFacet').should('exist');
       cy.get('@priceFacet').should('exist');
-    });
 
-    it('has facets displayed as radio buttons', () => {
+      // facets should be radio buttons
       cy.get('@cityFacet')
         .find('.bx--radio-button')
         .should('have.length', 5);
@@ -94,13 +93,10 @@ describe('Single-Select Facets', () => {
           cy.wait('@postQueryFacets').as('clearedFacetsQueryObject');
         });
 
-        it('makes a query without any selected facets', () => {
+        it('makes a query without any selected facets and "Clear all" button disappears', () => {
           cy.get('@clearedFacetsQueryObject')
             .its('requestBody.filter')
             .should('eq', '');
-        });
-
-        it('has the "Clear all" button disappear', () => {
           cy.get('button')
             .contains('Clear all')
             .should('not.exist');


### PR DESCRIPTION
#### What do these changes do/fix?
We don't need to separate out different assertions in our Cypress tests with their own `beforeEach`. This makes tests run slower and I think is part of the cause of the flakiness we're seeing. See Cypress best practices around this, too: https://docs.cypress.io/guides/references/best-practices.html#Creating-%E2%80%9Ctiny%E2%80%9D-tests-with-a-single-assertion

#### How do you test/verify these changes?
See that the build has passed (could be lucky too, so see how it helps going forward).

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
