### PR TITLE
ci: more publishing requirements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ env:
   CI: true
 jobs:
   build:
+    if: "!contains(github.event.head_commit.message, 'ci skip')"
     name: build
     runs-on: ubuntu-18.04
     steps:
@@ -49,6 +50,10 @@ jobs:
       - name: Publish Beta (Master)
         if: github.ref == 'refs/heads/master'
         run: npx lerna publish -y --conventional-prerelease --no-changelog --preid beta --dist-tag beta
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Publish Release Candidate (Release)
         if: contains(github.ref, 'release/')
         run: npx lerna publish -y --conventional-prerelease --no-changelog --preid rc --dist-tag rc
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### What do these changes do/fix?

apparently lerna only works if you define a `GH_TOKEN` environment var https://github.com/lerna/lerna/tree/main/commands/version

also adds the skip ci check so we don't trigger double runs on every release

#### How do you test/verify these changes?

check on `master` after merged