### PR TITLE
fix: do not set count on search params for fetchAggregations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,11 @@ jobs:
         run: npx lerna run test --stream
       - name: Archive test artifacts
         uses: actions/upload-artifact@v2
+        if: failure()
         with:
           name: cypress
           path: |
-            examples/cypress/screenshots
+            examples/discovery-search-app/cypress/screenshots
       - name: NPM Identity
         if: github.ref == 'refs/heads/master' || contains(github.ref, 'release/')
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,12 @@ jobs:
         run: npx lerna run build:app --parallel
       - name: Test
         run: npx lerna run test --stream
+      - name: Archive test artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: cypress
+          path: |
+            examples/cypress/screenshots
       - name: NPM Identity
         if: github.ref == 'refs/heads/master' || contains(github.ref, 'release/')
         run: |

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -294,6 +294,8 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       ) as DiscoveryV2.QueryParams;
       setSearchParameters(searchParameters);
 
+      // TODO proper fix is to have any caller of handleSearch that needs aggregations
+      // to call handleFetchAggregations instead
       if (resetAggregations) {
         const aggregationSearchParams = {
           ...searchParameters,

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -259,7 +259,11 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   const [
     globalAggregationsResponseStore,
-    { setGlobalAggregationsResponse, fetchGlobalAggregations }
+    {
+      setGlobalAggregationsResponse,
+      fetchGlobalAggregations,
+      fetchGlobalAggregationsWithoutStoring
+    }
   ] = useGlobalAggregationsApi(
     { ...globalAggregationsResponseStoreDefaults.parameters, projectId },
     searchClient,
@@ -299,7 +303,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       // to call handleFetchAggregations instead
       if (resetAggregations && searchParameters.filter !== '') {
         aggregationsFetched = true;
-        fetchGlobalAggregations(
+        fetchGlobalAggregationsWithoutStoring(
           {
             ...searchParameters,
             ...aggregationQueryDefaults,
@@ -318,7 +322,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       });
     },
     [
-      fetchGlobalAggregations,
+      fetchGlobalAggregationsWithoutStoring,
       fetchTypeForTopEntitiesAggregation,
       performSearch,
       setSearchParameters
@@ -440,11 +444,11 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
       setSearchParameters(prevSearchParams => {
         return { ...prevSearchParams, filter: '' };
       });
-      fetchGlobalAggregations(aggregationsSearchParameters, async aggregations => {
+      fetchGlobalAggregationsWithoutStoring(aggregationsSearchParameters, async aggregations => {
         fetchTypeForTopEntitiesAggregation(aggregations, aggregationsSearchParameters);
       });
     },
-    [fetchGlobalAggregations, fetchTypeForTopEntitiesAggregation, setSearchParameters]
+    [fetchGlobalAggregationsWithoutStoring, fetchTypeForTopEntitiesAggregation, setSearchParameters]
   );
 
   const handleSetSelectedResult = (overrideSelectedResult: SelectedResult) => {

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -296,7 +296,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
       // TODO proper fix is to have any caller of handleSearch that needs aggregations
       // to call handleFetchAggregations instead
-      if (resetAggregations) {
+      if (resetAggregations && searchParameters.filter !== '') {
         const aggregationSearchParams = {
           ...searchParameters,
           ...aggregationQueryDefaults

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -286,16 +286,32 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   const handleSearch = useCallback(
     async (
-      backwardsCompatibleQueryParams: DiscoveryV2.QueryParams & { returnFields?: string[] }
+      backwardsCompatibleQueryParams: DiscoveryV2.QueryParams & { returnFields?: string[] },
+      resetAggregations = true
     ): Promise<void> => {
       const searchParameters = deprecateReturnFields(
         backwardsCompatibleQueryParams
       ) as DiscoveryV2.QueryParams;
       setSearchParameters(searchParameters);
 
+      if (resetAggregations) {
+        const aggregationSearchParams = {
+          ...searchParameters,
+          ...aggregationQueryDefaults
+        };
+        fetchGlobalAggregations(aggregationSearchParams, async aggregations => {
+          fetchTypeForTopEntitiesAggregation(aggregations, aggregationSearchParams);
+        });
+      }
+
       performSearch();
     },
-    [performSearch, setSearchParameters]
+    [
+      fetchGlobalAggregations,
+      fetchTypeForTopEntitiesAggregation,
+      performSearch,
+      setSearchParameters
+    ]
   );
 
   const [autocompletionStore, { fetchAutocompletions, setAutocompletions }] = useAutocompleteApi(

--- a/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
@@ -275,7 +275,7 @@ describe('DiscoverySearch', () => {
       await wait(); // wait for component to finish rendering (prevent "act" warning)
     });
 
-    it('can call performSearch twice with resetAggregations = true and filter set', async () => {
+    it('can call performSearch once with resetAggregations = true and filter set', async () => {
       const tree = (
         <SearchApi.Consumer>
           {({ performSearch }) => (
@@ -295,7 +295,7 @@ describe('DiscoverySearch', () => {
       expect(spy).not.toHaveBeenCalled();
       fireEvent.click(getByText('Action'));
       await wait(); // wait for component to finish rendering (prevent "act" warning)
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('can call fetchDocuments', async () => {

--- a/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
@@ -275,7 +275,7 @@ describe('DiscoverySearch', () => {
       await wait(); // wait for component to finish rendering (prevent "act" warning)
     });
 
-    it('can call performSearch once with resetAggregations = true and filter set', async () => {
+    it('can call performSearch twice with resetAggregations = true and filter set', async () => {
       const tree = (
         <SearchApi.Consumer>
           {({ performSearch }) => (
@@ -295,7 +295,7 @@ describe('DiscoverySearch', () => {
       expect(spy).not.toHaveBeenCalled();
       fireEvent.click(getByText('Action'));
       await wait(); // wait for component to finish rendering (prevent "act" warning)
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(2);
     });
 
     it('can call fetchDocuments', async () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -219,7 +219,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     performSearch({ ...searchParameters, collectionIds: [], offset: 0, filter: '' }, false);
   };
 
-  if (isLoading && !aggregations) {
+  if (isLoading) {
     return null;
   } else if (isError) {
     const errorNode =

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -219,7 +219,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     performSearch({ ...searchParameters, collectionIds: [], offset: 0, filter: '' }, false);
   };
 
-  if (isLoading && !(shouldShowFields || shouldShowCollections)) {
+  if (isLoading && !shouldShowFields && !shouldShowCollections) {
     return null;
   } else if (isError) {
     const errorNode =

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -219,7 +219,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     performSearch({ ...searchParameters, collectionIds: [], offset: 0, filter: '' }, false);
   };
 
-  if (isLoading) {
+  if (isLoading && !aggregations) {
     return null;
   } else if (isError) {
     const errorNode =

--- a/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/SearchFacets.tsx
@@ -219,7 +219,7 @@ const SearchFacets: FC<SearchFacetsProps> = ({
     performSearch({ ...searchParameters, collectionIds: [], offset: 0, filter: '' }, false);
   };
 
-  if (isLoading && !aggregations) {
+  if (isLoading && !(shouldShowFields || shouldShowCollections)) {
     return null;
   } else if (isError) {
     const errorNode =

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -996,6 +996,14 @@ describe('useGlobalAggregationsApi', () => {
             globalAggregationsApi.fetchGlobalAggregations(globalAggregationsStore.parameters)
           }
         />
+        <button
+          data-testid="fetchGlobalAggregationsWithoutStoring"
+          onClick={() =>
+            globalAggregationsApi.fetchGlobalAggregationsWithoutStoring(
+              globalAggregationsStore.parameters
+            )
+          }
+        />
         <div data-testid="globalAggregationsStore">{JSON.stringify(globalAggregationsStore)}</div>
       </>
     );
@@ -1055,6 +1063,25 @@ describe('useGlobalAggregationsApi', () => {
         result.getByTestId('globalAggregationsStore').textContent || '{}'
       );
       expect(json.data).toEqual([{ type: 'term' }]);
+    });
+  });
+
+  describe('when calling fetchGlobalAggregationsWithoutStoring', () => {
+    test('does not update the store with a payload', async () => {
+      const result = render(
+        <TestGlobalAggregationsStoreComponent searchClient={new AggregationResultSearchClient()} />
+      );
+      const fetchGlobalAggregationsWithoutStoringButton = result.getByTestId(
+        'fetchGlobalAggregationsWithoutStoring'
+      );
+
+      fireEvent.click(fetchGlobalAggregationsWithoutStoringButton);
+      await waitForDomChange({ container: result.container });
+      const json: GlobalAggregationsResponseStore = JSON.parse(
+        result.getByTestId('globalAggregationsStore').textContent || '{}'
+      );
+      expect(json.isLoading).toEqual(false);
+      expect(json.data).toEqual([]);
     });
   });
 });

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -1076,7 +1076,6 @@ describe('useGlobalAggregationsApi', () => {
       );
 
       fireEvent.click(fetchGlobalAggregationsWithoutStoringButton);
-      await waitForDomChange({ container: result.container });
       const json: GlobalAggregationsResponseStore = JSON.parse(
         result.getByTestId('globalAggregationsStore').textContent || '{}'
       );

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -1067,7 +1067,7 @@ describe('useGlobalAggregationsApi', () => {
   });
 
   describe('when calling fetchGlobalAggregationsWithoutStoring', () => {
-    test('does not update the store with a payload', async () => {
+    test('does not update the store with a payload and keeps isLoading true', async () => {
       const result = render(
         <TestGlobalAggregationsStoreComponent searchClient={new AggregationResultSearchClient()} />
       );
@@ -1080,7 +1080,7 @@ describe('useGlobalAggregationsApi', () => {
       const json: GlobalAggregationsResponseStore = JSON.parse(
         result.getByTestId('globalAggregationsStore').textContent || '{}'
       );
-      expect(json.isLoading).toEqual(false);
+      expect(json.isLoading).toEqual(true);
       expect(json.data).toEqual([]);
     });
   });

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -23,12 +23,6 @@ const dataFetchReducer = (state: any, action: any) => {
         isError: false,
         data: action.payload
       };
-    case 'FETCH_COMPLETE':
-      return {
-        ...state,
-        isLoading: false,
-        isError: false
-      };
     case 'FETCH_FAILURE':
       return {
         ...state,
@@ -133,8 +127,6 @@ const useDataApi = <T, U>(
           }
           if (storeResult) {
             dispatch({ type: 'FETCH_SUCCESS', payload });
-          } else {
-            dispatch({ type: 'FETCH_COMPLETE' });
           }
           if (callback) {
             callback(payload);

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -385,6 +385,8 @@ export const useGlobalAggregationsApi = (
     [setFetchToken, setGlobalAggregationParameters]
   );
 
+  // allow us to chain the result without storing in our reducer state
+  // used alongside the fetchTypeForTopEntitiesAggregation
   const fetchGlobalAggregationsWithoutStoring = useCallback(
     (
       searchParameters: DiscoveryV2.QueryParams,


### PR DESCRIPTION
#### What do these changes do/fix?

need to prevent setting the searchParameters for the search response store when doing aggregation fetches. this was setting the count to `0` due to defaults

#### How do you test/verify these changes?

`/runExampleApp.sh` and perform a bunch of searches (empty) and validate you continue to get results back (albeit slow ones at times)

#### Have you documented your changes (if necessary)?
No

#### Are there any breaking changes included in this pull request?
No