### PR TITLE
feat: add error to dataapi

### DIFF
--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -148,7 +148,8 @@ export const searchResponseStoreDefaults: SearchResponseStore = {
   },
   data: null,
   isLoading: false,
-  isError: false
+  isError: false,
+  error: null
 };
 
 const aggregationQueryDefaults: Partial<DiscoveryV2.QueryParams> = {
@@ -169,7 +170,8 @@ export const globalAggregationsResponseStoreDefaults: GlobalAggregationsResponse
   },
   data: null,
   isLoading: false,
-  isError: false
+  isError: false,
+  error: null
 };
 
 export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = {
@@ -186,7 +188,8 @@ export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = 
   },
   data: null,
   isLoading: false,
-  isError: false
+  isError: false,
+  error: null
 };
 
 export const autocompletionStoreDefaults: AutocompleteStore = {
@@ -196,7 +199,8 @@ export const autocompletionStoreDefaults: AutocompleteStore = {
   },
   data: null,
   isLoading: false,
-  isError: false
+  isError: false,
+  error: null
 };
 
 const fieldsStoreDefaults: FieldsStore = {
@@ -205,7 +209,8 @@ const fieldsStoreDefaults: FieldsStore = {
   },
   data: null,
   isLoading: false,
-  isError: false
+  isError: false,
+  error: null
 };
 
 export const searchContextDefaults = {

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -149,7 +149,7 @@ export const searchResponseStoreDefaults: SearchResponseStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: ''
+  error: null
 };
 
 const aggregationQueryDefaults: Partial<DiscoveryV2.QueryParams> = {
@@ -171,7 +171,7 @@ export const globalAggregationsResponseStoreDefaults: GlobalAggregationsResponse
   data: null,
   isLoading: false,
   isError: false,
-  error: ''
+  error: null
 };
 
 export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = {
@@ -189,7 +189,7 @@ export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = 
   data: null,
   isLoading: false,
   isError: false,
-  error: ''
+  error: null
 };
 
 export const autocompletionStoreDefaults: AutocompleteStore = {
@@ -200,7 +200,7 @@ export const autocompletionStoreDefaults: AutocompleteStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: ''
+  error: null
 };
 
 const fieldsStoreDefaults: FieldsStore = {
@@ -210,7 +210,7 @@ const fieldsStoreDefaults: FieldsStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: ''
+  error: null
 };
 
 export const searchContextDefaults = {

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -149,7 +149,7 @@ export const searchResponseStoreDefaults: SearchResponseStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: null
+  error: ''
 };
 
 const aggregationQueryDefaults: Partial<DiscoveryV2.QueryParams> = {
@@ -171,7 +171,7 @@ export const globalAggregationsResponseStoreDefaults: GlobalAggregationsResponse
   data: null,
   isLoading: false,
   isError: false,
-  error: null
+  error: ''
 };
 
 export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = {
@@ -189,7 +189,7 @@ export const fetchDocumentsResponseStoreDefaults: FetchDocumentsResponseStore = 
   data: null,
   isLoading: false,
   isError: false,
-  error: null
+  error: ''
 };
 
 export const autocompletionStoreDefaults: AutocompleteStore = {
@@ -200,7 +200,7 @@ export const autocompletionStoreDefaults: AutocompleteStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: null
+  error: ''
 };
 
 const fieldsStoreDefaults: FieldsStore = {
@@ -210,7 +210,7 @@ const fieldsStoreDefaults: FieldsStore = {
   data: null,
   isLoading: false,
   isError: false,
-  error: null
+  error: ''
 };
 
 export const searchContextDefaults = {

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -58,7 +58,11 @@ class AggregationResultSearchClient extends BaseSearchClient {
 
 class ErrorSearchClient extends BaseSearchClient {
   public async query(): Promise<any> {
-    return Promise.reject();
+    return Promise.reject(
+      new Error(
+        '"status_code":429,"errors":[{"code":"query_rate_limit","message":"Your query cannot be run because there are too many concurrent requests. Reduce the number of concurrent queries and try again.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
+      )
+    );
   }
 
   public async listFields(): Promise<any> {
@@ -212,6 +216,9 @@ describe('useSearchResultsApi', () => {
         result.getByTestId('searchResponseStore').textContent || '{}'
       );
       expect(json.isError).toEqual(true);
+      expect(json.error).toEqual(
+        '"status_code":429,"errors":[{"code":"query_rate_limit","message":"Your query cannot be run because there are too many concurrent requests. Reduce the number of concurrent queries and try again.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
+      );
     });
 
     test('sets the search results', async () => {

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -60,7 +60,7 @@ class ErrorSearchClient extends BaseSearchClient {
   public async query(): Promise<any> {
     return Promise.reject(
       new Error(
-        '"status_code":429,"errors":[{"code":"query_rate_limit","message":"Your query cannot be run because there are too many concurrent requests. Reduce the number of concurrent queries and try again.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
+        '"status_code":400,"errors":[{"code":"query_daily_limit","message":"You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
       )
     );
   }
@@ -217,7 +217,7 @@ describe('useSearchResultsApi', () => {
       );
       expect(json.isError).toEqual(true);
       expect(json.error).toEqual(
-        '"status_code":429,"errors":[{"code":"query_rate_limit","message":"Your query cannot be run because there are too many concurrent requests. Reduce the number of concurrent queries and try again.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
+        '"status_code":400,"errors":[{"code":"query_daily_limit","message":"You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
       );
     });
 

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -58,11 +58,20 @@ class AggregationResultSearchClient extends BaseSearchClient {
 
 class ErrorSearchClient extends BaseSearchClient {
   public async query(): Promise<any> {
-    return Promise.reject(
-      new Error(
-        '"status_code":400,"errors":[{"code":"query_daily_limit","message":"You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
-      )
-    );
+    const error = new Error();
+    error.message =
+      'You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.';
+    error.body = {
+      status_code: 400,
+      errors: [
+        {
+          code: 'query_daily_limit',
+          message:
+            'You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.'
+        }
+      ]
+    };
+    return Promise.reject(error);
   }
 
   public async listFields(): Promise<any> {
@@ -216,9 +225,20 @@ describe('useSearchResultsApi', () => {
         result.getByTestId('searchResponseStore').textContent || '{}'
       );
       expect(json.isError).toEqual(true);
-      expect(json.error).toEqual(
-        '"status_code":400,"errors":[{"code":"query_daily_limit","message":"You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.","more_info":"https://cloud.ibm.com/docs/discovery-data"}],"trace":"TOOLING-9947g26q0x1x9"}'
-      );
+      expect(json.error).toEqual({
+        message:
+          'You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.',
+        body: {
+          status_code: 400,
+          errors: [
+            {
+              code: 'query_daily_limit',
+              message:
+                'You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.'
+            }
+          ]
+        }
+      });
     });
 
     test('sets the search results', async () => {

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -176,7 +176,7 @@ interface ReducerState {
   data: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parameters: any;
-  error: Error;
+  error: Error | null;
 }
 
 /**

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -108,7 +108,7 @@ const useDataApi = <T, U>(
     isLoading: false,
     isError: false,
     data: initialData,
-    error: null
+    error: ''
   });
 
   const setData = (data?: U): void => {
@@ -174,7 +174,7 @@ interface ReducerState {
   data: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parameters: any;
-  error: string | null;
+  error: string;
 }
 
 /**

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -27,7 +27,8 @@ const dataFetchReducer = (state: any, action: any) => {
       return {
         ...state,
         isLoading: false,
-        isError: true
+        isError: true,
+        error: action.error?.message || ''
       };
     default:
       throw new Error();
@@ -106,7 +107,8 @@ const useDataApi = <T, U>(
   const [state, dispatch] = useReducer(dataFetchReducer, {
     isLoading: false,
     isError: false,
-    data: initialData
+    data: initialData,
+    error: null
   });
 
   const setData = (data?: U): void => {
@@ -134,7 +136,7 @@ const useDataApi = <T, U>(
         }
       } catch (error) {
         if (!cancelToken.current) {
-          dispatch({ type: 'FETCH_FAILURE' });
+          dispatch({ type: 'FETCH_FAILURE', error });
         }
       }
     },
@@ -172,6 +174,7 @@ interface ReducerState {
   data: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parameters: any;
+  error: string | null;
 }
 
 /**

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -14,13 +14,15 @@ const dataFetchReducer = (state: any, action: any) => {
       return {
         ...state,
         isLoading: true,
-        isError: false
+        isError: false,
+        error: null
       };
     case 'FETCH_SUCCESS':
       return {
         ...state,
         isLoading: false,
         isError: false,
+        error: null,
         data: action.payload
       };
     case 'FETCH_FAILURE':

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -28,7 +28,7 @@ const dataFetchReducer = (state: any, action: any) => {
         ...state,
         isLoading: false,
         isError: true,
-        error: action.error?.message || ''
+        error: action.error || null
       };
     default:
       throw new Error();
@@ -108,7 +108,7 @@ const useDataApi = <T, U>(
     isLoading: false,
     isError: false,
     data: initialData,
-    error: ''
+    error: null
   });
 
   const setData = (data?: U): void => {
@@ -174,7 +174,7 @@ interface ReducerState {
   data: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   parameters: any;
-  error: string;
+  error: Error;
 }
 
 /**


### PR DESCRIPTION
#### What do these changes do/fix?
This adds the `error` encountered to the state in `useDataApi`. This is so that it can be used in Discovery tooling.

#### How do you test/verify these changes?
Check that the tests look good. Can link with tooling and run tests added with the related changes there too.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
no
