### PR TITLE
ci: no verify access on lerna publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,11 +59,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Publish Beta (Master)
         if: github.ref == 'refs/heads/master'
-        run: npx lerna publish -y --conventional-prerelease --no-changelog --preid beta --dist-tag beta
+        # must include --no-verify-access for automation tokens https://github.com/lerna/lerna/issues/2788
+        run: npx lerna publish -y --conventional-prerelease --no-changelog --no-verify-access --preid beta --dist-tag beta
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Publish Release Candidate (Release)
         if: contains(github.ref, 'release/')
-        run: npx lerna publish -y --conventional-prerelease --no-changelog --preid rc --dist-tag rc
+        # must include --no-verify-access for automation tokens https://github.com/lerna/lerna/issues/2788
+        run: npx lerna publish -y --conventional-prerelease --no-changelog --no-verify-access --preid rc --dist-tag rc
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
#### What do these changes do/fix?

As part of enabling 2FA for our NPM bot account, we generated an [automation token](https://github.blog/changelog/2020-10-02-npm-automation-tokens/) to continue allowing CI perform the publishing

Unfortunately, `lerna` uses a different API to verify that the token has access to publish that the automation tokens do not have. See https://github.com/lerna/lerna/issues/2788 for more details