### PR TITLE
build: simplify release automation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,14 +42,14 @@ jobs:
           path: |
             examples/discovery-search-app/cypress/screenshots
       - name: NPM Identity
-        if: github.ref == 'refs/heads/master' || contains(github.ref, 'release/')
+        if: github.ref == 'refs/heads/master'
         run: |
           echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
           npm whoami
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Github Identity
-        if: github.ref == 'refs/heads/master' || contains(github.ref, 'release/')
+        if: github.ref == 'refs/heads/master'
         run: |
           git config --global push.default simple
           git config --global user.email "watdevex@us.ibm.com"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,15 +57,9 @@ jobs:
           git config remote.origin.url https://x-access-token:$GH_TOKEN@github.com/$GITHUB_REPOSITORY
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Publish Beta (Master)
+      - name: Publish
         if: github.ref == 'refs/heads/master'
         # must include --no-verify-access for automation tokens https://github.com/lerna/lerna/issues/2788
-        run: npx lerna publish -y --conventional-prerelease --no-changelog --no-verify-access --preid beta --dist-tag beta
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-      - name: Publish Release Candidate (Release)
-        if: contains(github.ref, 'release/')
-        # must include --no-verify-access for automation tokens https://github.com/lerna/lerna/issues/2788
-        run: npx lerna publish -y --conventional-prerelease --no-changelog --no-verify-access --preid rc --dist-tag rc
+        run: npx lerna publish -y --no-verify-access --create-release github
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -496,7 +496,13 @@ Steps in the automation can be set in `.github/workflows/ci.yml`, located in the
 
 ### Branching and Releasing
 
-- `master` is an eternal branch with latest stable code
+- `master` is an eternal branch with latest stable code that will have automated releases on using the continuous integration described above
+- for hotfix/patch-style releases, perform the following steps:
+  1. `git checkout -b hotfix/1.4.0-patch-1 v1.4.0-beta.2` (checks out a new branch from the tag needing the hotfix)
+  2. make changes and push changes to `hotfix/1.4.0-patch-1` as usual
+  3. ensure you have access to publish the package `npm login && npm whoami && npm access ls-collaborators` (must have `read-write`)
+  4. `npx lerna publish 1.4.0-patch-1.0 --dist-tag patch-1 --allow-branch hotfix/1.4.0` (see [lerna publish](https://github.com/lerna/lerna/tree/master/commands/publish))
+  5. `git checkout master && git merge hotfix/1.4.0 || git mergetool && git push origin master` (merge changes/tags back to `master`, resolving merge conflicts by taking `lerna.json` version from `master` branch)
 
 The only branch permitted for releasing is `master`
 

--- a/README.md
+++ b/README.md
@@ -488,29 +488,17 @@ To start the example app server and run all Cypress tests, use `yarn workspace d
 
 #### Continuous integration
 
-[Travis CI](https://travis-ci.org/) is used to continuously run integration tests against this repository, and any PRs that are made against it.
+[Github Actions](https://github.com/watson-developer-cloud/discovery-components/actions) is used to continuously run integration tests against this repository, and any PRs that are made against it.
 
-When triggered, Travis will build the project, then run the test scripts, and output the pass/fail to whichever branch/PR triggered the build.
+When triggered, Github Actions will build the project, then run the test scripts, and output the pass/fail to whichever branch/PR triggered the build.
 
-Steps in the automation can be set in `.travis.yml`, located in the root directory.
+Steps in the automation can be set in `.github/workflows/ci.yml`, located in the root directory.
 
 ### Branching and Releasing
 
-- `master` is an eternal branch - bleeding edge, reviewed but not necessarily released code
-- `release/x.x.x` is a temporary branch created for beginning a production release. this contains all the features needed for the release and will only receive bugfixes. Once the release is complete, this branch is tagged and merged back into `master`. example steps:
-  - `git checkout release/2.3.0`
-  - add a "Begin Release" commit (otherwise "ci skip" will prevent travis from building)
-  - if we want to publish a release candidate (not final build):
-    - `npx lerna publish --conventional-prerelease --preid rc --dist-tag rc`
-    - (after we find out the `rc` is good to go) `npx lerna publish --create-release github --conventional-graduate` [docs](https://github.com/lerna/lerna/blob/master/commands/version/README.md#--conventional-graduate)
-  - otherwise for the official release:
-    - `npx lerna publish --create-release github`
-  - `git checkout master`
-  - `git merge release/2.3.0`
-  - `git push --tags origin master`
-  - `git branch -d release/2.3.0`
+- `master` is an eternal branch with latest stable code
 
-The only branches permitted for release are `release/*`, `hotfix/*`, and `master`
+The only branch permitted for releasing is `master`
 
 More information about the `lerna publish` command can be found in the README for [lerna publish](https://github.com/lerna/lerna/tree/master/commands/publish)
 

--- a/README.md
+++ b/README.md
@@ -500,11 +500,11 @@ Steps in the automation can be set in `.github/workflows/ci.yml`, located in the
 - for hotfix/patch-style releases, perform the following steps:
   1. `git checkout -b hotfix/1.4.0-patch-1 v1.4.0-beta.2` (checks out a new branch from the tag needing the hotfix)
   2. make changes and push changes to `hotfix/1.4.0-patch-1` as usual
-  3. ensure you have access to publish the package `npm login && npm whoami && npm access ls-collaborators` (must have `read-write`)
+  3. ensure you have access to publish the package `npm login && npm whoami && npm access ls-collaborators` (must have `read-write`, contact someone from https://www.npmjs.com/settings/ibm-watson/members to gain access)
   4. `npx lerna publish 1.4.0-patch-1.0 --dist-tag patch-1 --allow-branch hotfix/1.4.0` (see [lerna publish](https://github.com/lerna/lerna/tree/master/commands/publish))
   5. `git checkout master && git merge hotfix/1.4.0 || git mergetool && git push origin master` (merge changes/tags back to `master`, resolving merge conflicts by taking `lerna.json` version from `master` branch)
 
-The only branch permitted for releasing is `master`
+The only branch permitted for automatic releasing on CI is `master`
 
 More information about the `lerna publish` command can be found in the README for [lerna publish](https://github.com/lerna/lerna/tree/master/commands/publish)
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,24 +1,16 @@
 {
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "version": "1.4.0-beta.2",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
     "publish": {
       "conventionalCommits": true,
-      "allowBranch": [
-        "master",
-        "release/*",
-        "hotfix/*"
-      ]
+      "allowBranch": ["master"]
     },
     "version": {
       "message": "chore: publish %s [ci skip]",
-      "ignoreChanges": [
-        "examples/**"
-      ]
+      "ignoreChanges": ["examples/**"]
     }
   }
 }


### PR DESCRIPTION
#### What do these changes do/fix?

Simplifies the release logic to always publish from `master` and no longer have `beta` or `rc` dist tags. Should generate changelogs + github releases based on conventional commits syntax

downsides include not knowing which version of these packages match with which versions of cp4d deployments of discovery

#### How do you test/verify these changes?

`npx lerna publish --no-git-tag-version --no-push --create-release github`

^ should do all the steps necessary without making changes to the npm package or pushing to github

#### Have you documented your changes (if necessary)?

Yes

#### Are there any breaking changes included in this pull request?

No
