### PR TITLE
fix: use "unstable" Carbon Pagination to avoid performance hang

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@storybook/react": "^5.3.21",
     "@storybook/source-loader": "^5.3.21",
     "@svgr/rollup": "^4.3.2",
-    "@testing-library/cypress": "^7.0.3",
+    "@testing-library/cypress": "^7.0.6",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/react-hooks": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^16.9.2",
     "@types/react-dom": "^16.9.0",
     "@types/react-resize-detector": "^4.2.0",
-    "@types/react-virtualized": "^9.21.2",
+    "@types/react-virtualized": "^9.21.11",
     "@types/seedrandom": "^2.4.28",
     "@types/testing-library__cypress": "^5.0.8",
     "@types/uuid": "^3.4.5",

--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -58,7 +58,7 @@
     "pdfjs-dist": "^2.2.228",
     "react-error-boundary": "^1.2.5",
     "react-resize-detector": "^4.2.1",
-    "react-virtualized": "^9.22.3"
+    "react-virtualized": "9.21.1"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -58,7 +58,7 @@
     "pdfjs-dist": "^2.2.228",
     "react-error-boundary": "^1.2.5",
     "react-resize-detector": "^4.2.1",
-    "react-virtualized": "^9.21.1"
+    "react-virtualized": "^9.22.3"
   },
   "jest": {
     "transformIgnorePatterns": [

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__fixtures__/shortenedContract.json
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__fixtures__/shortenedContract.json
@@ -1,5 +1,8 @@
 {
-  "id": "903461f8843ef9f10daecd2a14994308",
+  "document_id": "903461f8843ef9f10daecd2a14994308",
+  "result_metadata": {
+    "collection_id": "b7a6d2a5-dbb8-70f0-0000-016e9594e413"
+  },
   "metadata": {
     "parent_document_id": "a7f6bd77d4c9d73ce72b12247f662755"
   },

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -83,7 +83,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
     }
   }, [currentPage, searchParameters.count, searchParameters.offset]);
 
-  const matchingResults = (searchResponse && searchResponse.matching_results) || 0;
+  const matchingResults = (searchResponse && searchResponse.matching_results) || undefined;
   const actualPageSize = searchParameters.count || 10;
   // the default behavior of Carbon is to discard pageSize if it is not included in pageSizes,
   // we instead choose to make it so that pageSize is appended to pageSizes if it is not already included.
@@ -114,13 +114,13 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
     );
   };
 
-  const handleItemRangeText = (min: number, max: number, total: number) => {
-    return formatMessage(mergedMessages.itemRangeText, { min, max, total }, false);
-  };
+  const handleItemRangeText = (min: number, max: number, total: number) =>
+    formatMessage(mergedMessages.itemRangeText, { min, max, total }, false);
 
-  const handlePageRangeText = (_current: number, total: number) => {
-    return formatMessage(mergedMessages.pageRangeText, { total }, false);
-  };
+  const handlePageRangeText = (_current: number, total: number) =>
+    formatMessage(mergedMessages.pageRangeText, { total }, false);
+
+  const handlePageText = (page: number) => formatMessage(mergedMessages.pageText, { page }, false);
 
   if (!!componentSettings) {
     return (
@@ -136,6 +136,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
             itemRangeText={handleItemRangeText}
             itemsPerPageText={mergedMessages.itemsPerPageText}
             pageRangeText={handlePageRangeText}
+            pageText={handlePageText}
             {...inputProps}
           >
             {(props: PageSelectorProps) => <PageSelector {...props} onChange={handleOnChange} />}
@@ -183,7 +184,11 @@ function PageSelector({ currentPage, currentPageSize, onSetPage, onChange }: Pag
     }
   }, [currentPage, currentPageSize, onChange, onSetPage, page, pageSize]);
 
-  return <span className={`${settings.prefix}--unstable-pagination__text`}>{currentPage}</span>;
+  return (
+    <span className={`${settings.prefix}--unstable-pagination__text`} data-testid="current-page">
+      {currentPage}
+    </span>
+  );
 }
 
 export default withErrorBoundary(

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useContext, useState, useEffect } from 'react';
-import { Pagination as CarbonPagination } from 'carbon-components-react';
+import { unstable_Pagination as CarbonPagination } from 'carbon-components-react';
 import { SearchApi, SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import get from 'lodash/get';
@@ -115,11 +115,11 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
   };
 
   const handleItemRangeText = (min: number, max: number, total: number) => {
-    return formatMessage(mergedMessages.itemRangeText, { min: min, max: max, total: total }, false);
+    return formatMessage(mergedMessages.itemRangeText, { min, max, total }, false);
   };
 
-  const handlePageRangeText = (_current: number, total: number) => {
-    return formatMessage(mergedMessages.pageRangeText, { total: total }, false);
+  const handlePageRangeText = (current: number, total: number) => {
+    return formatMessage(mergedMessages.pageRangeText, { current, total }, false);
   };
 
   if (!!componentSettings) {
@@ -128,7 +128,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
         {!isResultsPaginationComponentHidden && (
           <CarbonPagination
             className={classNames.join(' ')}
-            page={currentPage}
+            initialPage={currentPage}
             totalItems={matchingResults}
             pageSize={actualPageSize}
             pageSizes={pageSizes}

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -2,7 +2,6 @@ import React, { FC, useContext, useState, useEffect } from 'react';
 import { unstable_Pagination as CarbonPagination } from 'carbon-components-react';
 import { SearchApi, SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
-import get from 'lodash/get';
 import { settings } from 'carbon-components';
 import { withErrorBoundary } from 'react-error-boundary';
 import { FallbackComponent } from 'utils/FallbackComponent';
@@ -50,7 +49,7 @@ interface ResultsPaginationEvent {
 const ResultsPagination: FC<ResultsPaginationProps> = ({
   page = 1,
   pageSizes = [10, 20, 30, 40, 50],
-  pageSize = 10,
+  pageSize,
   showPageSizeSelector = true,
   messages = defaultMessages,
   onChange,
@@ -64,7 +63,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
     isResultsPaginationComponentHidden
   } = useContext(SearchContext);
   const [currentPage, setCurrentPage] = useState(page);
-  const resultsPerPage = get(componentSettings, 'results_per_page', 10);
+  const resultsPerPage = componentSettings?.results_per_page ?? 10;
 
   useEffect(() => {
     if (!!pageSize || !!resultsPerPage) {

--- a/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
@@ -14,8 +14,8 @@ interface Setup extends RenderResult {
   setSearchParametersMock: jest.Mock<any>;
   onChangeMock: jest.Mock;
   pageSizeSelect: Promise<HTMLElement>;
+  nextButton: Promise<HTMLElement>;
   fullTree: React.ReactElement;
-  pageNumberSelect: Promise<HTMLElement>;
 }
 
 const setup = (
@@ -50,22 +50,22 @@ const setup = (
   const paginationComponent = render(fullTree);
 
   const pageSizeSelect = paginationComponent.findByLabelText('Items per page:');
-  const pageNumberSelect = paginationComponent.findByLabelText(/Page number, of [0-9]+ pages/);
+  const nextButton = paginationComponent.findByLabelText('Next page');
 
   return {
     performSearchMock,
     setSearchParametersMock,
     onChangeMock,
     pageSizeSelect,
-    pageNumberSelect,
     fullTree,
+    nextButton,
     ...paginationComponent
   };
 };
 
 describe('ResultsPaginationComponent', () => {
   test('uses count from search parameter', () => {
-    const { performSearchMock, pageNumberSelect, onChangeMock } = setup(
+    const { performSearchMock, nextButton, onChangeMock } = setup(
       {},
       {
         searchResponseStore: {
@@ -79,8 +79,8 @@ describe('ResultsPaginationComponent', () => {
     );
 
     // Have to return here or else failed expectations aren't reported
-    return pageNumberSelect.then(numberSelect => {
-      fireEvent.change(numberSelect, { target: { value: 2 } });
+    return nextButton.then(nextButton => {
+      fireEvent.click(nextButton);
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
@@ -99,12 +99,12 @@ describe('ResultsPaginationComponent', () => {
 
   describe('page size select', () => {
     test('calls onUpdateResultsPagination from first page', () => {
-      const { performSearchMock, pageSizeSelect, pageNumberSelect, onChangeMock } = setup();
+      const { performSearchMock, pageSizeSelect, nextButton, onChangeMock } = setup();
 
       // Have to return here or else failed expectations aren't reported
-      return Promise.all([pageSizeSelect, pageNumberSelect]).then(([sizeSelect, numberSelect]) => {
+      return Promise.all([pageSizeSelect, nextButton]).then(([sizeSelect, nextButton]) => {
         fireEvent.change(sizeSelect, { target: { value: 20 } });
-        fireEvent.change(numberSelect, { target: { value: 2 } });
+        fireEvent.click(nextButton);
 
         expect(performSearchMock).toBeCalledTimes(2);
         expect(performSearchMock).toBeCalledWith(

--- a/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
+++ b/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
@@ -12,10 +12,15 @@ export interface Messages {
    * override the default text showing where the current page is out of the total pages
    */
   pageRangeText: string;
+  /**
+   * override the default text showing the current page if total items is unknown
+   */
+  pageText: string;
 }
 
 export const defaultMessages: Messages = {
   itemRangeText: '{min}–{max} of {total} results',
   itemsPerPageText: 'Items per page:',
-  pageRangeText: 'of {total} pages'
+  pageRangeText: 'of {total} pages',
+  pageText: 'Page {page}'
 };

--- a/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
+++ b/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
@@ -17,5 +17,5 @@ export interface Messages {
 export const defaultMessages: Messages = {
   itemRangeText: '{min}–{max} of {total} results',
   itemsPerPageText: 'Items per page:',
-  pageRangeText: 'of {total} pages'
+  pageRangeText: '{current} of {total} pages'
 };

--- a/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
+++ b/packages/discovery-react-components/src/components/ResultsPagination/messages.ts
@@ -17,5 +17,5 @@ export interface Messages {
 export const defaultMessages: Messages = {
   itemRangeText: '{min}–{max} of {total} results',
   itemsPerPageText: 'Items per page:',
-  pageRangeText: '{current} of {total} pages'
+  pageRangeText: 'of {total} pages'
 };

--- a/packages/discovery-styles/scss/carbon-components.scss
+++ b/packages/discovery-styles/scss/carbon-components.scss
@@ -35,7 +35,7 @@ $css--use-layer: true !default;
 @import '~carbon-components/scss/components/tabs/tabs';
 
 // results-pagination
-@import '~carbon-components/scss/components/pagination/pagination';
+@import '~carbon-components/scss/components/pagination/_unstable_pagination';
 
 // search-facets
 @import '~carbon-components/scss/components/modal/modal';

--- a/packages/discovery-styles/scss/components/results-pagination/_results-pagination.scss
+++ b/packages/discovery-styles/scss/components/results-pagination/_results-pagination.scss
@@ -1,5 +1,5 @@
 .#{$prefix}--pagination__page-size-selector--hidden {
-  .#{$prefix}--pagination__left {
+  .#{$prefix}--unstable-pagination__left {
     padding: 0;
 
     label,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3324,10 +3324,10 @@
     "@svgr/plugin-svgo" "^4.3.1"
     loader-utils "^1.2.3"
 
-"@testing-library/cypress@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-7.0.3.tgz#1f4bcf992d0a0ff55da13b80f6f785c976ef9c0d"
-  integrity sha512-JOYW4VSSyHxaZDUhrS5N7tZA8jhr3ISx73WnLPpNkPqDCLUIJpo8ZQihti68Q4Qv5hVuA+I2rUI2glORaEFPaA==
+"@testing-library/cypress@^7.0.6":
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/@testing-library/cypress/-/cypress-7.0.6.tgz#5445dac4f4852c26901c356e9d3a69371bd20ccf"
+  integrity sha512-atnjqlkEt6spU4Mv7evvpA8fMXeRw7AN2uTKOR1dP6WBvBixVwAYMZY+1fMOaZULWAj9vGLCXXvmw++u3TxuCQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^7.28.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,7 +1594,7 @@
     pdfjs-dist "^2.2.228"
     react-error-boundary "^1.2.5"
     react-resize-detector "^4.2.1"
-    react-virtualized "^9.21.1"
+    react-virtualized "^9.22.3"
 
 "@ibm-watson/discovery-styles@file:packages/discovery-styles":
   version "1.3.1-beta.2"
@@ -3714,10 +3714,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-virtualized@^9.21.2":
-  version "9.21.10"
-  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.10.tgz#cd072dc9c889291ace2c4c9de8e8c050da8738b7"
-  integrity sha512-f5Ti3A7gGdLkPPFNHTrvKblpsPNBiQoSorOEOD+JPx72g/Ng2lOt4MYfhvQFQNgyIrAro+Z643jbcKafsMW2ag==
+"@types/react-virtualized@^9.21.11":
+  version "9.21.11"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized/-/react-virtualized-9.21.11.tgz#8eb60ed12ef0b2625769819f9fd10ad4bb1bdce0"
+  integrity sha512-ngNe2AY/2CHuZQstOS0Jo5jnSjeyKTdSgqrXCQEltRMXLp9rwPUpJdgkoWzES6wn427Z8zo8dkBN8Sx7hlRmig==
   dependencies:
     "@types/prop-types" "*"
     "@types/react" "*"
@@ -5963,15 +5963,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001165:
-  version "1.0.30001170"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001170.tgz#0088bfecc6a14694969e391cc29d7eb6362ca6a7"
-  integrity sha512-Dd4d/+0tsK0UNLrZs3CvNukqalnVTRrxb5mcQm8rHL49t7V5ZaTygwXkrq+FB+dVDf++4ri8eJnFEJAB8332PA==
-
-caniuse-lite@^1.0.30001125:
-  version "1.0.30001223"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001223.tgz#39b49ff0bfb3ee3587000d2f66c47addc6e14443"
-  integrity sha512-k/RYs6zc/fjbxTjaWZemeSmOjO0JJV+KguOBA3NwPup8uzxM1cMhR2BD9XmO86GuqaqTCO8CgkgH9Rz//vdDiA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001165:
+  version "1.0.30001241"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz"
+  integrity sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -6318,7 +6313,7 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-clsx@^1.0.1:
+clsx@^1.0.4:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -7728,17 +7723,18 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
-"dom-helpers@^2.4.0 || ^3.0.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
-  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-
 dom-helpers@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
   integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
+
+dom-helpers@^5.1.3:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
@@ -12401,11 +12397,6 @@ libnpmpublish@^4.0.0:
     semver "^7.1.3"
     ssri "^8.0.1"
 
-linear-layout-vector@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
-  integrity sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA=
-
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -12766,7 +12757,7 @@ loglevelnext@^1.0.1:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -16473,17 +16464,16 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized@^9.21.1:
-  version "9.21.1"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
-  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
+react-virtualized@^9.22.3:
+  version "9.22.3"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
+  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
   dependencies:
-    babel-runtime "^6.26.0"
-    clsx "^1.0.1"
-    dom-helpers "^2.4.0 || ^3.0.0"
-    linear-layout-vector "0.0.1"
-    loose-envify "^1.3.0"
-    prop-types "^15.6.0"
+    "@babel/runtime" "^7.7.2"
+    clsx "^1.0.4"
+    dom-helpers "^5.1.3"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
     react-lifecycles-compat "^3.0.4"
 
 react@^16.4.1, react@^16.8.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1594,7 +1594,7 @@
     pdfjs-dist "^2.2.228"
     react-error-boundary "^1.2.5"
     react-resize-detector "^4.2.1"
-    react-virtualized "^9.22.3"
+    react-virtualized "9.21.1"
 
 "@ibm-watson/discovery-styles@file:packages/discovery-styles":
   version "1.3.1-beta.2"
@@ -6313,7 +6313,7 @@ clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
-clsx@^1.0.4:
+clsx@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -7723,18 +7723,17 @@ dom-converter@^0.2:
   dependencies:
     utila "~0.4"
 
+"dom-helpers@^2.4.0 || ^3.0.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
+  integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 dom-helpers@^5.0.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.0.tgz#57fd054c5f8f34c52a3eeffdb7e7e93cd357d95b"
   integrity sha512-Ru5o9+V8CpunKnz5LGgWXkmrH/20cGKwcHwS4m73zIvs54CN9epEmT/HLqFJW3kXpakAFkEdzgy1hzlJe3E4OQ==
-  dependencies:
-    "@babel/runtime" "^7.8.7"
-    csstype "^3.0.2"
-
-dom-helpers@^5.1.3:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
-  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
   dependencies:
     "@babel/runtime" "^7.8.7"
     csstype "^3.0.2"
@@ -12397,6 +12396,11 @@ libnpmpublish@^4.0.0:
     semver "^7.1.3"
     ssri "^8.0.1"
 
+linear-layout-vector@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/linear-layout-vector/-/linear-layout-vector-0.0.1.tgz#398114d7303b6ecc7fd6b273af7b8401d8ba9c70"
+  integrity sha1-OYEU1zA7bsx/1rJzr3uEAdi6nHA=
+
 lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
@@ -12757,7 +12761,7 @@ loglevelnext@^1.0.1:
     es6-symbol "^3.1.1"
     object.assign "^4.1.0"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -16464,16 +16468,17 @@ react-transition-group@^4.3.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtualized@^9.22.3:
-  version "9.22.3"
-  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.22.3.tgz#f430f16beb0a42db420dbd4d340403c0de334421"
-  integrity sha512-MKovKMxWTcwPSxE1kK1HcheQTWfuCxAuBoSTf2gwyMM21NdX/PXUhnoP8Uc5dRKd+nKm8v41R36OellhdCpkrw==
+react-virtualized@9.21.1:
+  version "9.21.1"
+  resolved "https://registry.yarnpkg.com/react-virtualized/-/react-virtualized-9.21.1.tgz#4dbbf8f0a1420e2de3abf28fbb77120815277b3a"
+  integrity sha512-E53vFjRRMCyUTEKuDLuGH1ld/9TFzjf/fFW816PE4HFXWZorESbSTYtiZz1oAjra0MminaUU1EnvUxoGuEFFPA==
   dependencies:
-    "@babel/runtime" "^7.7.2"
-    clsx "^1.0.4"
-    dom-helpers "^5.1.3"
-    loose-envify "^1.4.0"
-    prop-types "^15.7.2"
+    babel-runtime "^6.26.0"
+    clsx "^1.0.1"
+    dom-helpers "^2.4.0 || ^3.0.0"
+    linear-layout-vector "0.0.1"
+    loose-envify "^1.3.0"
+    prop-types "^15.6.0"
     react-lifecycles-compat "^3.0.4"
 
 react@^16.4.1, react@^16.8.3:


### PR DESCRIPTION
#### What do these changes do/fix?

Carbon's `Pagination` component does not work well if there are a large number of items, resulting in app hanging or crashing (see https://github.com/carbon-design-system/carbon/issues/5546).

This PR changes us to use the "unstable" `Pagination` component from Carbon, which will get promoted to the official one in Carbon v11. By doing so, this no longer renders a select control to pick the current page (which is of dubious usability for search results), and avoids the performance issue.

New component:
![Screen Shot 2021-07-01 at 3 48 39 PM](https://user-images.githubusercontent.com/711365/124187691-d0961600-da83-11eb-8302-3fdfb6d246b9.png)


#### How do you test/verify these changes?

Easiest way to see the underlying issue is to load https://react.carbondesignsystem.com/?path=/story/components-pagination--pagination and enter a large number like `400000` for `totalItems` (in "Knobs" tab at bottom of page). Browser page will hang.

To see fix, run our Storybook with this PR and load `ResultsPagination`. Notice that there is no longer a select control for the current page (on right-hand side of pagination bar).

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
