### PR TITLE
fix: use carbon's built-in label for MultiSelect

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/components/CollectionFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/CollectionFacets.tsx
@@ -1,14 +1,9 @@
 import React, { FC, useContext } from 'react';
 import get from 'lodash/get';
 import { Messages } from '../messages';
-import {
-  collectionFacetIdPrefix
-  // labelClasses,
-  // labelAndSelectionContainerClass
-} from '../cssClasses';
+import { collectionFacetIdPrefix } from '../cssClasses';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import { MultiSelect as CarbonMultiSelect } from 'carbon-components-react';
-// import { settings } from 'carbon-components';
 import { Collection } from 'ibm-watson/discovery/v2';
 import { CollectionItem, SelectedCollectionItems } from '../utils/searchFacetInterfaces';
 

--- a/packages/discovery-react-components/src/components/SearchFacets/components/CollectionFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/CollectionFacets.tsx
@@ -2,13 +2,13 @@ import React, { FC, useContext } from 'react';
 import get from 'lodash/get';
 import { Messages } from '../messages';
 import {
-  collectionFacetIdPrefix,
-  labelClasses,
-  labelAndSelectionContainerClass
+  collectionFacetIdPrefix
+  // labelClasses,
+  // labelAndSelectionContainerClass
 } from '../cssClasses';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import { MultiSelect as CarbonMultiSelect } from 'carbon-components-react';
-import { settings } from 'carbon-components';
+// import { settings } from 'carbon-components';
 import { Collection } from 'ibm-watson/discovery/v2';
 import { CollectionItem, SelectedCollectionItems } from '../utils/searchFacetInterfaces';
 
@@ -49,20 +49,14 @@ export const CollectionFacets: FC<CollectionFacetsProps> = ({
   // TODO: figure out why MultiSelect doesn't set initialSelectedItems on subsequent renders
   if (collectionItems.length > 0) {
     return (
-      <fieldset className={`${settings.prefix}--fieldset`}>
-        <legend className={labelClasses.join(' ')}>
-          <div className={labelAndSelectionContainerClass}>
-            {messages.collectionSelectTitleText}
-          </div>
-        </legend>
-        <CarbonMultiSelect
-          id={`${collectionFacetIdPrefix}select`}
-          items={collectionItems}
-          initialSelectedItems={initialSelectedCollections}
-          label={messages.collectionSelectLabel}
-          onChange={handleCollectionToggle}
-        />
-      </fieldset>
+      <CarbonMultiSelect
+        id={`${collectionFacetIdPrefix}select`}
+        items={collectionItems}
+        initialSelectedItems={initialSelectedCollections}
+        label={messages.collectionSelectLabel}
+        onChange={handleCollectionToggle}
+        titleText={messages.collectionSelectTitleText}
+      />
     );
   }
   return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,7 +1582,7 @@
     "@hapi/hoek" "^9.0.0"
 
 "@ibm-watson/discovery-react-components@file:packages/discovery-react-components":
-  version "1.4.0-beta.2"
+  version "1.4.0-beta.3"
   dependencies:
     classnames "^2.2.6"
     debounce "^1.2.0"
@@ -1597,7 +1597,7 @@
     react-virtualized "9.21.1"
 
 "@ibm-watson/discovery-styles@file:packages/discovery-styles":
-  version "1.3.1-beta.2"
+  version "1.4.0-beta.3"
 
 "@icons/material@^0.2.4":
   version "0.2.4"


### PR DESCRIPTION
#### What do these changes do/fix?
The IBM accessibility checker found a violation in our CollectionFacet component. The dropdown element said it was labeled, but no element with that id existed in the dom. Turns out, Carbon already had a property built into the component that would do that for us. So, I removed our custom label elements and passed the text into that property.

This component before (on Storybook, so ignore the background color change):
<img width="293" alt="Screen Shot 2021-08-04 at 3 46 55 PM" src="https://user-images.githubusercontent.com/11284492/128253150-29e8380b-55fc-4571-b93a-c7a5b4952b59.png">

This component after:
<img width="335" alt="Screen Shot 2021-08-04 at 3 46 13 PM" src="https://user-images.githubusercontent.com/11284492/128253198-a193b4a4-ad5f-4a9b-895f-30331b7a9325.png">


There did appear to be a slight font color change along with this, but it's not setting off any additional a11y violations, and in my mind this will most likely unify us across other Carbon components within Tooling. If someone yells at me, though, I can try to change the text color back.
<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
1. Run the example app
2. Run the accessibility checker (install [here](https://chrome.google.com/webstore/detail/ibm-equal-access-accessib/lkcagbfjnkomcinoddgooolagloogehp) if you haven't)
3. See that we aren't getting this violation:
  
![image](https://user-images.githubusercontent.com/11284492/128253429-6ca3c496-6a27-4900-a0f3-a24df121e399.png)

#### Have you documented your changes (if necessary)?
Not necessary

#### Are there any breaking changes included in this pull request?
Nope 
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
