### PR TITLE
fix: escape field names before building aggregation string

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
@@ -9,14 +9,6 @@ export const configurationWithOneField: DiscoveryV2.QueryTermAggregation[] = [
   }
 ];
 
-export const configurationWithOneFieldWithSpecialChars: DiscoveryV2.QueryTermAggregation[] = [
-  {
-    type: 'term',
-    field: 's:o~m<e|t^h*i[n(g)]>',
-    count: 10
-  }
-];
-
 export const configurationWithTwoFields: DiscoveryV2.QueryTermAggregation[] = [
   {
     type: 'term',
@@ -27,6 +19,19 @@ export const configurationWithTwoFields: DiscoveryV2.QueryTermAggregation[] = [
     type: 'term',
     field: 'author',
     count: 5
+  }
+];
+
+export const configurationWithTwoFielsdWithSpecialChars: DiscoveryV2.QueryTermAggregation[] = [
+  {
+    type: 'term',
+    field: 's:o~m<e|t^h*i[n(g)]>',
+    count: 10
+  },
+  {
+    type: 'term',
+    field: 'enriched_s:o~m<e|t^h*i[n(g)]>.entities.text',
+    count: 10
   }
 ];
 

--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
@@ -117,3 +117,29 @@ export const configurationWithFilterQueryAggregation: QueryAggregationWithName[]
     ]
   }
 ];
+
+export const configurationWithFilterQueryAggregationWithSpecialCharacters: QueryAggregationWithName[] = [
+  {
+    type: 'term',
+    field: 'enriched_text.entities.text',
+    count: 12,
+    name: 'entities'
+  },
+  {
+    type: 'term',
+    field: 'author'
+  },
+  {
+    type: 'filter',
+    match: 'enriched_t\\(ext\\).entities.model_name:"Dictionary:.my_dict"',
+    matching_results: 0,
+    aggregations: [
+      {
+        type: 'term',
+        field: 'enriched_t(ext).entities.text',
+        count: 4,
+        name: 'dict_yqYQPpM8OljE'
+      }
+    ]
+  }
+];

--- a/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/__fixtures__/configuration.ts
@@ -9,6 +9,14 @@ export const configurationWithOneField: DiscoveryV2.QueryTermAggregation[] = [
   }
 ];
 
+export const configurationWithOneFieldWithSpecialChars: DiscoveryV2.QueryTermAggregation[] = [
+  {
+    type: 'term',
+    field: 's:o~m<e|t^h*i[n(g)]>',
+    count: 10
+  }
+];
+
 export const configurationWithTwoFields: DiscoveryV2.QueryTermAggregation[] = [
   {
     type: 'term',

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
@@ -1,6 +1,7 @@
 import { buildAggregationQuery } from '../buildAggregationQuery';
 import {
   configurationWithOneField,
+  configurationWithOneFieldWithSpecialChars,
   configurationWithTwoFields,
   configurationWithoutCounts,
   configurationWithTopEntities,
@@ -43,5 +44,10 @@ describe('BuildAggregationQuery', () => {
     expect(aggParam).toEqual(
       '[nested(enriched_text.entities).term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_text.entities.enriched_text.entities.text).filter(enriched_text.entities.enriched_text.entities.model_name:"Dictionary:.test").term(enriched_text.entities.enriched_text.entities.text,count:4,name:dict_yqYQPpM8OljE)]'
     );
+  });
+
+  test('it converts configuration with one term that contains special characters to expected aggregation parameter', () => {
+    const aggParam = buildAggregationQuery(configurationWithOneFieldWithSpecialChars);
+    expect(aggParam).toEqual('[term(s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>,count:10)]');
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
@@ -1,8 +1,8 @@
 import { buildAggregationQuery } from '../buildAggregationQuery';
 import {
   configurationWithOneField,
-  configurationWithOneFieldWithSpecialChars,
   configurationWithTwoFields,
+  configurationWithTwoFielsdWithSpecialChars,
   configurationWithoutCounts,
   configurationWithTopEntities,
   configurationWithFilterQueryAggregation,
@@ -47,7 +47,9 @@ describe('BuildAggregationQuery', () => {
   });
 
   test('it converts configuration with one term that contains special characters to expected aggregation parameter', () => {
-    const aggParam = buildAggregationQuery(configurationWithOneFieldWithSpecialChars);
-    expect(aggParam).toEqual('[term(s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>,count:10)]');
+    const aggParam = buildAggregationQuery(configurationWithTwoFielsdWithSpecialChars);
+    expect(aggParam).toEqual(
+      '[term(s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>,count:10),nested(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities).term(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities.text,count:10).term(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities.type,count:1)]'
+    );
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/buildAggregationQuery.test.ts
@@ -6,6 +6,7 @@ import {
   configurationWithoutCounts,
   configurationWithTopEntities,
   configurationWithFilterQueryAggregation,
+  configurationWithFilterQueryAggregationWithSpecialCharacters,
   configurationWithNestedQueryAggregation
 } from 'components/SearchFacets/__fixtures__/configuration';
 
@@ -50,6 +51,15 @@ describe('BuildAggregationQuery', () => {
     const aggParam = buildAggregationQuery(configurationWithTwoFielsdWithSpecialChars);
     expect(aggParam).toEqual(
       '[term(s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>,count:10),nested(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities).term(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities.text,count:10).term(enriched_s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>.entities.type,count:1)]'
+    );
+  });
+
+  test('it converts configuration with filter query aggregation to expected aggregation parameter', () => {
+    const aggParam = buildAggregationQuery(
+      configurationWithFilterQueryAggregationWithSpecialCharacters
+    );
+    expect(aggParam).toEqual(
+      '[nested(enriched_text.entities).term(enriched_text.entities.text,count:12,name:entities).term(enriched_text.entities.type,count:1),term(author),nested(enriched_t\\(ext\\).entities.text).filter(enriched_t\\(ext\\).entities.model_name:"Dictionary:.my_dict").term(enriched_t\\(ext\\).entities.text,count:4,name:dict_yqYQPpM8OljE)]'
     );
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
@@ -1,0 +1,8 @@
+import { escapeFieldName } from '../escapeFieldName';
+
+describe('escapeFieldName', () => {
+  test('correctly escapes special characters in a field name', () => {
+    const escapedFieldName = escapeFieldName('s:o~m<e|t^h*i[n(g)]>');
+    expect(escapedFieldName).toEqual('s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>');
+  });
+});

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
@@ -1,8 +1,13 @@
 import { escapeFieldName } from '../escapeFieldName';
 
 describe('escapeFieldName', () => {
-  test('correctly escapes special characters in a field name', () => {
+  test('correctly escapes special characters', () => {
     const escapedFieldName = escapeFieldName('s:o~m<e|t^h*i[n(g)]>');
     expect(escapedFieldName).toEqual('s\\:o\\~m\\<e\\|t\\^h\\*i\\[n\\(g\\)\\]\\>');
+  });
+
+  test('does not escape already escaped characters', () => {
+    const escapedFieldName = escapeFieldName('t\\(ext)');
+    expect(escapedFieldName).toEqual('t\\(ext\\)');
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -8,18 +8,16 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
         const escapedFieldName = escapeFieldName(field);
         const termCount = count ? ',count:' + count : '';
         const termName = name ? ',name:' + name : '';
-        let nestedTypeTermAgg = '';
-
-        let query = `term(${escapedFieldName}${termCount}${termName})${nestedTypeTermAgg}`;
+        const termAggField = `term(${escapedFieldName}${termCount}${termName})`;
 
         if (field.includes('enriched_') && field.includes('entities.text')) {
           const topLevelTermEntityField = field.split('.')[0];
           const topLevelNestedField = field.slice(0, field.lastIndexOf('.'));
-          nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
-          query = `nested(${topLevelNestedField}).${query}`;
+          const nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
+          return `nested(${topLevelNestedField}).${termAggField}${nestedTypeTermAgg}`;
         }
 
-        return query;
+        return termAggField;
       }
 
       // This supports nested and filter aggregations, including dictionary aggregations

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -1,41 +1,48 @@
+import { escapeFieldName } from './escapeFieldName';
 import { QueryAggregationWithName } from './searchFacetInterfaces';
 
 export const buildAggregationQuery = (configuration: QueryAggregationWithName[]): string => {
   const aggregation = configuration.map(
     ({ type, count, name, field, aggregations, match, path }) => {
       if (type === 'term' && field) {
+        const escapedFieldName = escapeFieldName(field);
         const termCount = count ? ',count:' + count : '';
         const termName = name ? ',name:' + name : '';
         let nestedTypeTermAgg = '';
+
+        let query = `term(${escapedFieldName}${termCount}${termName})${nestedTypeTermAgg}`;
+
         if (field.includes('enriched_') && field.includes('entities.text')) {
           const topLevelTermEntityField = field.split('.')[0];
           const topLevelNestedField = field.slice(0, field.lastIndexOf('.'));
           nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
-          return `nested(${topLevelNestedField}).term(${field}${termCount}${termName})${nestedTypeTermAgg}`;
+          query = `nested(${topLevelNestedField}).${query}`;
         }
-        return 'term(' + field + termCount + termName + ')' + nestedTypeTermAgg;
-        // This supports nested and filter aggregations, including dictionary aggregations
-      } else {
-        let nestedOrFilterAgg = '';
-        if (aggregations && aggregations[0]) {
-          nestedOrFilterAgg += 'nested(';
-          const initialNested = path ? path : aggregations[0].field;
-          const matchAgg = match ? match : aggregations[0].match;
-          nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
-          let termAggregation;
-          if (aggregations[0].aggregations) {
-            termAggregation = aggregations[0].aggregations[0];
-          } else {
-            termAggregation = aggregations[0];
-          }
-          const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
-          const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
-          nestedOrFilterAgg =
-            nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
-        }
-        return nestedOrFilterAgg;
+
+        return query;
       }
+
+      // This supports nested and filter aggregations, including dictionary aggregations
+      let nestedOrFilterAgg = '';
+      if (aggregations && aggregations[0]) {
+        nestedOrFilterAgg += 'nested(';
+        const initialNested = path ? path : aggregations[0].field;
+        const matchAgg = match ? match : aggregations[0].match;
+        nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
+        let termAggregation;
+        if (aggregations[0].aggregations) {
+          termAggregation = aggregations[0].aggregations[0];
+        } else {
+          termAggregation = aggregations[0];
+        }
+        const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
+        const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
+        nestedOrFilterAgg =
+          nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
+      }
+      return nestedOrFilterAgg;
     }
   );
+
   return '[' + aggregation.toString() + ']';
 };

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -11,8 +11,8 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
         const termAggField = `term(${escapedFieldName}${termCount}${termName})`;
 
         if (field.includes('enriched_') && field.includes('entities.text')) {
-          const topLevelTermEntityField = field.split('.')[0];
-          const topLevelNestedField = field.slice(0, field.lastIndexOf('.'));
+          const topLevelTermEntityField = escapeFieldName(field.split('.')[0]);
+          const topLevelNestedField = escapeFieldName(field.slice(0, field.lastIndexOf('.')));
           const nestedTypeTermAgg = `.term(${topLevelTermEntityField}.entities.type,count:1)`;
           return `nested(${topLevelNestedField}).${termAggField}${nestedTypeTermAgg}`;
         }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/buildAggregationQuery.ts
@@ -24,7 +24,7 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
       let nestedOrFilterAgg = '';
       if (aggregations && aggregations[0]) {
         nestedOrFilterAgg += 'nested(';
-        const initialNested = path ? path : aggregations[0].field;
+        const initialNested = escapeFieldName(path ? path : aggregations[0].field || '');
         const matchAgg = match ? match : aggregations[0].match;
         nestedOrFilterAgg = nestedOrFilterAgg + initialNested + ').filter(' + matchAgg + ')';
         let termAggregation;
@@ -36,7 +36,12 @@ export const buildAggregationQuery = (configuration: QueryAggregationWithName[])
         const termCount = termAggregation.count ? ',count:' + termAggregation.count : '';
         const termName = termAggregation.name ? ',name:' + termAggregation.name : '';
         nestedOrFilterAgg =
-          nestedOrFilterAgg + '.term(' + termAggregation.field + termCount + termName + ')';
+          nestedOrFilterAgg +
+          '.term(' +
+          escapeFieldName(termAggregation.field || '') +
+          termCount +
+          termName +
+          ')';
       }
       return nestedOrFilterAgg;
     }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
@@ -1,0 +1,9 @@
+/**
+ * Before field names can be used as part of an aggregation query, the following
+ * characters within the name must be escaped: ^ ~ > < : ! , | ( ) [ ] *
+ * @param fieldName
+ * @returns escaped field name string
+ */
+export function escapeFieldName(fieldName: string): string {
+  return (fieldName || '').replace(/[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
+}

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
@@ -1,9 +1,11 @@
 /**
  * Before field names can be used as part of an aggregation query, the following
  * characters within the name must be escaped: ^ ~ > < : ! , | ( ) [ ] *
+ * Note: this method does not escape already escaped chars.
+ *
  * @param fieldName
  * @returns escaped field name string
  */
 export function escapeFieldName(fieldName: string): string {
-  return (fieldName || '').replace(/[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
+  return (fieldName || '').replace(/(?<!\\)[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
 }

--- a/packages/discovery-react-components/src/index.tsx
+++ b/packages/discovery-react-components/src/index.tsx
@@ -1,3 +1,4 @@
+// components
 export {
   default as DiscoverySearch,
   SearchApi,
@@ -14,4 +15,7 @@ export {
 } from './components/DocumentPreview/components/HtmlView/HtmlView';
 export { CIDocument, canRenderCIDocument } from './components/CIDocument/CIDocument';
 export { default as StructuredQuery } from './components/StructuredQuery/StructuredQuery';
+
+// utility methods
 export { getDocumentTitle } from './utils/getDocumentTitle';
+export { escapeFieldName } from './components/SearchFacets/utils/escapeFieldName';


### PR DESCRIPTION
#### What do these changes do/fix?

Certain characters are not supported for field names when generating an aggregation string -- if present, will result in a query error. Escape field names to prevent such a failure.

Implements https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/8437

#### How do you test/verify these changes?

Run tests

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
