### PR TITLE
fix: safari regex lookbehind

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
@@ -7,7 +7,10 @@ describe('escapeFieldName', () => {
   });
 
   test('does not escape already escaped characters', () => {
-    const escapedFieldName = escapeFieldName('t\\(ext)');
+    let escapedFieldName = escapeFieldName('t\\(ext)');
     expect(escapedFieldName).toEqual('t\\(ext\\)');
+
+    escapedFieldName = escapeFieldName('\\(text)');
+    expect(escapedFieldName).toEqual('\\(text\\)');
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
@@ -7,5 +7,12 @@
  * @returns escaped field name string
  */
 export function escapeFieldName(fieldName: string): string {
-  return (fieldName || '').replace(/(?<!\\)[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
+  // Originally used the following code, with regex lookbehind. However, that's
+  // not supported by Safari (yet?).
+  // @see https://caniuse.com/js-regexp-lookbehind
+  // return (fieldName || '').replace(/(?<!\\)[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
+  return (fieldName || '').replace(
+    /(\\)?([\^~><:!,|()[\]* ])/g,
+    (str: string, p1: string, p2: string) => (p1 ? str : `\\${p2}`)
+  );
 }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
@@ -13,6 +13,7 @@ export function escapeFieldName(fieldName: string): string {
   // return (fieldName || '').replace(/(?<!\\)[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
   return (fieldName || '').replace(
     /(\\)?([\^~><:!,|()[\]* ])/g,
+    // don't escape if character (`p2`) was already escaped (`p1`)
     (str: string, p1: string, p2: string) => (p1 ? str : `\\${p2}`)
   );
 }


### PR DESCRIPTION
#### What do these changes do/fix?

Safari doesn't support regex lookbehind (https://caniuse.com/js-regexp-lookbehind). Use JS instead to determine if a character has already been escaped.

Implements https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/8709

#### How do you test/verify these changes?

- Run tests.
- Link into Tooling and load in Safari

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
