### PR TITLE
fix: escape/unescape field name in search filters

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/escapeFieldNames.test.ts
@@ -1,4 +1,4 @@
-import { escapeFieldName } from '../escapeFieldName';
+import { escapeFieldName, unescapeFieldName } from '../escapeFieldName';
 
 describe('escapeFieldName', () => {
   test('correctly escapes special characters', () => {
@@ -12,5 +12,17 @@ describe('escapeFieldName', () => {
 
     escapedFieldName = escapeFieldName('\\(text)');
     expect(escapedFieldName).toEqual('\\(text\\)');
+  });
+});
+
+describe('unescapeFieldName', () => {
+  test('correctly unescapes special characters in an already escaped string', () => {
+    const unescapedFieldName = unescapeFieldName('t\\(ext\\)');
+    expect(unescapedFieldName).toEqual('t(ext)');
+  });
+
+  test('does not affect string without special characters', () => {
+    const unescapedFieldName = unescapeFieldName('here\\is_something.com');
+    expect(unescapedFieldName).toEqual('here\\is_something.com');
   });
 });

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -58,12 +58,29 @@ const weirdAggs = [
         selected: true
       }
     ]
+  },
+  {
+    type: 'term',
+    field: 't(ext)',
+    results: [
+      {
+        key: 'something normal',
+        matching_results: 293668,
+        selected: true
+      },
+      {
+        key: 'nospaces',
+        matching_results: 2968,
+        selected: true
+      }
+    ]
   }
 ];
 const weirdFilters =
   'extracted_stuff.weirdAggs:"this | that"|"1:30"|"1,200"|"double \\" quote",' +
   'extracted_stuff.oddAggs:"something, new"|"blah|junk",' +
-  'extracted_stuff.normalAggs:"something normal"|"nospaces"';
+  'extracted_stuff.normalAggs:"something normal"|"nospaces",' +
+  't\\(ext\\):"something normal"|"nospaces"';
 
 describe('QueryTermAggregation array to filter string', () => {
   test('it properly handles aggregations with reserved characters', () => {
@@ -93,6 +110,7 @@ describe('Filter string to QueryTermAggregation array', () => {
       }
     ]);
   });
+
   test('it properly handles aggregations with reserved characters', () => {
     expect(SearchFilterTransform.fromString(weirdFilters).filterFields).toEqual([
       {
@@ -115,6 +133,14 @@ describe('Filter string to QueryTermAggregation array', () => {
       {
         type: 'term',
         field: 'extracted_stuff.normalAggs',
+        results: expect.arrayContaining([
+          expect.objectContaining({ key: 'something normal', selected: true }),
+          expect.objectContaining({ key: 'nospaces', selected: true })
+        ])
+      },
+      {
+        type: 'term',
+        field: 't(ext)',
         results: expect.arrayContaining([
           expect.objectContaining({ key: 'something normal', selected: true }),
           expect.objectContaining({ key: 'nospaces', selected: true })

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/escapeFieldName.ts
@@ -1,3 +1,7 @@
+const SPECIAL_CHARS = '[\\^~><:!,|()[\\]* ]';
+const RE_SPECIAL_CHARS_LOOKBEHIND = new RegExp(`(\\\\)?(${SPECIAL_CHARS})`, 'g'); // /(\\)?([\^~><:!,|()[\]* ])/g
+const RE_SPECIAL_CHARS_ESCAPED = new RegExp(`(\\\\${SPECIAL_CHARS})`, 'g');
+
 /**
  * Before field names can be used as part of an aggregation query, the following
  * characters within the name must be escaped: ^ ~ > < : ! , | ( ) [ ] *
@@ -12,8 +16,17 @@ export function escapeFieldName(fieldName: string): string {
   // @see https://caniuse.com/js-regexp-lookbehind
   // return (fieldName || '').replace(/(?<!\\)[\^~><:!,|()[\]* ]/g, (char: string) => `\\${char}`);
   return (fieldName || '').replace(
-    /(\\)?([\^~><:!,|()[\]* ])/g,
+    RE_SPECIAL_CHARS_LOOKBEHIND,
     // don't escape if character (`p2`) was already escaped (`p1`)
     (str: string, p1: string, p2: string) => (p1 ? str : `\\${p2}`)
   );
+}
+
+/**
+ * Unescaped any string returned from `escapeFieldName`
+ * @param fieldName
+ * @returns unescaped field name string
+ */
+export function unescapeFieldName(fieldName: string): string {
+  return (fieldName || '').replace(RE_SPECIAL_CHARS_ESCAPED, (str: string) => str.substr(1, 1));
 }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
 import partition from 'lodash/partition';
+import { escapeFieldName, unescapeFieldName } from './escapeFieldName';
 import {
   SearchFilterFacets,
   InternalQueryTermAggregation,
@@ -42,7 +43,7 @@ export class SearchFilterTransform {
 
       return {
         type: 'term',
-        field,
+        field: unescapeFieldName(field),
         results
       };
     });
@@ -78,7 +79,7 @@ export class SearchFilterTransform {
       const results = get(facet, 'results', []);
       const keys = this.quoteSelectedFacets(results, 'key');
       if (keys.length) {
-        filterStrings.push(`${field}:${keys.join('|')}`);
+        filterStrings.push(`${escapeFieldName(field)}:${keys.join('|')}`);
       }
     });
     return filterStrings.join(',');


### PR DESCRIPTION
#### What do these changes do/fix?

Continuation of #207. Also escape field names in search filters.

#### How do you test/verify these changes?

Run tests

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
