### PR TITLE
feat: use device pixel ratio to render PDF

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, radios, number } from '@storybook/addon-knobs';
+import { withKnobs, radios, number, boolean } from '@storybook/addon-knobs';
 import PdfViewer from './PdfViewer';
 import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Effects.pdf';
 
@@ -32,6 +32,15 @@ storiesOf('DocumentPreview/components/PdfViewer', module)
 
     const zoom = radios(zoomKnob.label, zoomKnob.options, zoomKnob.defaultValue);
     const scale = parseFloat(zoom);
+    const useDeviceResolution = boolean('Use device resolution', true);
 
-    return <PdfViewer file={atob(doc)} page={page} scale={scale} setLoading={(): void => {}} />;
+    return (
+      <PdfViewer
+        file={atob(doc)}
+        page={page}
+        scale={scale}
+        useDeviceResolution={useDeviceResolution}
+        setLoading={(): void => {}}
+      />
+    );
   });


### PR DESCRIPTION
#### What do these changes do/fix?

Currently, PDFViewer doesn't consider device pixcel ratio and rendered PDF pages are not clear on Mac. This PR is to consider device pixcel ratio to render PDF image.

Before
![image](https://user-images.githubusercontent.com/19485344/139006522-a31f4351-1785-463f-b1ad-bc23d5ecd987.png)
After
![image](https://user-images.githubusercontent.com/19485344/139006864-bdf067f3-6a42-448f-a597-5085ce88a270.png)


#### How do you test/verify these changes?
Verify the rendered PDF on Storybook. _Use device resolution_ options is added to the storybook for the previous behavior.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
