### PR TITLE
fix: correct query filter string generation

### DIFF
--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -64,7 +64,7 @@ describe('Multi-Select Facets', () => {
         it('queries and selects the right facets', () => {
           cy.get('@multiFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Pittsburgh, PA"|"Ames, IA"');
+            .should('eq', 'location:"Pittsburgh, PA"|location:"Ames, IA"');
           cy.get('.bx--list-box__selection').contains('2').should('exist');
         });
       });

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -938,7 +938,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text"pittsburgh"',
+              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -275,7 +275,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"Animals"|"People"'
+          filter: 'subject:"Animals"|subject:"People"'
         }),
         false
       );
@@ -485,7 +485,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in the same category', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff"|"News Staff"' });
+        setupData = setup({ filter: 'author:"ABMN Staff"|author:"News Staff"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -615,7 +615,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"ABMN Staff"|"News Staff",subject:"People"',
+          filter: 'author:"ABMN Staff"|author:"News Staff",subject:"People"',
           offset: 0
         }),
         false
@@ -892,7 +892,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"us"|"pittsburgh"',
+              filter: 'enriched_text.entities.text:"us"|enriched_text.entities:"pittsburgh"',
               offset: 0
             }),
             false
@@ -938,7 +938,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"ibm"|"pittsburgh"',
+              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text"pittsburgh"',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -892,7 +892,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"us"|enriched_text.entities:"pittsburgh"',
+              filter: 'enriched_text.entities.text:"us"|enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -113,11 +113,6 @@ describe('Filter string to QueryTermAggregation array', () => {
   });
 
   test('it properly handles aggregations with reserved characters', () => {
-    //TODO: failing
-    console.log(
-      'Received filters value: ',
-      SearchFilterTransform.fromString(weirdFilters).filterFields[1]
-    );
     expect(SearchFilterTransform.fromString(weirdFilters).filterFields).toEqual([
       {
         type: 'term',

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -77,10 +77,10 @@ const weirdAggs = [
   }
 ];
 const weirdFilters =
-  'extracted_stuff.weirdAggs:"this | that"|"1:30"|"1,200"|"double \\" quote",' +
-  'extracted_stuff.oddAggs:"something, new"|"blah|junk",' +
-  'extracted_stuff.normalAggs:"something normal"|"nospaces",' +
-  't\\(ext\\):"something normal"|"nospaces"';
+  'extracted_stuff.weirdAggs:"this | that"|extracted_stuff.weirdAggs:"1:30"|extracted_stuff.weirdAggs:"1,200"|extracted_stuff.weirdAggs:"double \\" quote",' +
+  'extracted_stuff.oddAggs:"something, new"|extracted_stuff.oddAggs:"blah|junk",' +
+  'extracted_stuff.normalAggs:"something normal"|extracted_stuff.normalAggs:"nospaces",' +
+  't\\(ext\\):"something normal"|t\\(ext\\):"nospaces"';
 
 describe('QueryTermAggregation array to filter string', () => {
   test('it properly handles aggregations with reserved characters', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -91,7 +91,8 @@ describe('QueryTermAggregation array to filter string', () => {
 describe('Filter string to QueryTermAggregation array', () => {
   test('it properly handles unquoted terms', () => {
     expect(
-      SearchFilterTransform.fromString('field:term|two words,field2:blah\\"stuff').filterFields
+      SearchFilterTransform.fromString('field:term|field:two words,field2:blah\\"stuff')
+        .filterFields
     ).toEqual([
       {
         type: 'term',
@@ -112,6 +113,11 @@ describe('Filter string to QueryTermAggregation array', () => {
   });
 
   test('it properly handles aggregations with reserved characters', () => {
+    //TODO: failing
+    console.log(
+      'Received filters value: ',
+      SearchFilterTransform.fromString(weirdFilters).filterFields[1]
+    );
     expect(SearchFilterTransform.fromString(weirdFilters).filterFields).toEqual([
       {
         type: 'term',
@@ -119,7 +125,8 @@ describe('Filter string to QueryTermAggregation array', () => {
         results: expect.arrayContaining([
           expect.objectContaining({ key: 'this | that', selected: true }),
           expect.objectContaining({ key: '1:30', selected: true }),
-          expect.objectContaining({ key: '1,200', selected: true })
+          expect.objectContaining({ key: '1,200', selected: true }),
+          expect.objectContaining({ key: 'double " quote', selected: true })
         ])
       },
       {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -79,7 +79,7 @@ export class SearchFilterTransform {
       const results = get(facet, 'results', []);
       const keys = this.quoteSelectedFacets(results, 'key');
       if (keys.length) {
-        filterStrings.push(`${escapeFieldName(field)}:${keys.join('|')}`);
+        filterStrings.push(`${escapeFieldName(field)}:(${keys.join('|')})`);
       }
     });
     return filterStrings.join(',');

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -12,6 +12,7 @@ export class SearchFilterTransform {
   static SPLIT_UNQUOTED_COMMAS = /,(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
   static SPLIT_UNQUOTED_COLONS = /:(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
   static SPLIT_UNQUOTED_PIPES = /\|(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
+  static SPLIT_UNQUOTED_PIPES_OR_COLONS = /(\||:)(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
 
   static fromString(filterString: string): SearchFilterFacets {
     if (filterString === '') {
@@ -27,10 +28,13 @@ export class SearchFilterTransform {
       filter => colonRegex.test(filter)
     );
     const fields = filterFacets[0].map(facetField => {
-      const facetSplit = facetField.split(SearchFilterTransform.SPLIT_UNQUOTED_COLONS);
-      const field = facetSplit[0];
-      const results = facetSplit[1]
-        .split(SearchFilterTransform.SPLIT_UNQUOTED_PIPES)
+      const facets = facetField.split(SearchFilterTransform.SPLIT_UNQUOTED_PIPES);
+      const field = facets[0].split(SearchFilterTransform.SPLIT_UNQUOTED_COLONS)[0];
+      const results = facets
+        .map(facet => {
+          const facetPair = facet.split(SearchFilterTransform.SPLIT_UNQUOTED_COLONS);
+          return facetPair[1];
+        })
         .sort()
         .map(result => {
           const unquotedResult = this.unquoteString(result);

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -12,7 +12,6 @@ export class SearchFilterTransform {
   static SPLIT_UNQUOTED_COMMAS = /,(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
   static SPLIT_UNQUOTED_COLONS = /:(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
   static SPLIT_UNQUOTED_PIPES = /\|(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
-  static SPLIT_UNQUOTED_PIPES_OR_COLONS = /(\||:)(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
 
   static fromString(filterString: string): SearchFilterFacets {
     if (filterString === '') {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -79,7 +79,7 @@ export class SearchFilterTransform {
       const results = get(facet, 'results', []);
       const keys = this.quoteSelectedFacets(results, 'key');
       if (keys.length) {
-        filterStrings.push(`${escapeFieldName(field)}:(${keys.join('|')})`);
+        filterStrings.push(keys.map(key => `${escapeFieldName(field)}:${key}`).join('|'));
       }
     });
     return filterStrings.join(',');


### PR DESCRIPTION
#### What do these changes do/fix?
Implements: https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/9339

Fixes the default logic assembling query filter string anytime that facets are applied to a search.

~This change should add parens ( ) around the values for any fields in the filter param. That way, if there are multiple values for one facet, they are correctly bundled together. Hopefully, it should look something like `facet-name:("value1"|"value2"|"value3"),facet-2-name:("value4"), . . .`.~

The parens I tried to add were getting stripped out by a followup step that gets rid of special characters. Instead, I opted to stack the facet-name/value pairs. They should now look like this:
```
filter: facet-name:"value1"|facet-name:"value2"|facet-name:"value3",facet-2-name:"value4", . . .
```
<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
1. Start the example app
2. Perform a search
3. Filter results with the facets panel
4. See that the query request that gets sent out when you change facets has the correctly formatted `filter` string
#### Have you documented your changes (if necessary)?
N/A
#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
