### PR TITLE
fix: PdfViewer scale parameter issue

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -103,9 +103,7 @@ const PdfViewer: SFC<Props> = ({
 
   return (
     <canvas
-      style={{
-        transform: `scale(${scale})`
-      }}
+      style={{}}
       ref={canvasRef}
       className={`${settings.prefix}--document-preview-pdf-viewer`}
     />

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -101,13 +101,7 @@ const PdfViewer: SFC<Props> = ({
     }
   }, [setHideToolbarControls]);
 
-  return (
-    <canvas
-      style={{}}
-      ref={canvasRef}
-      className={`${settings.prefix}--document-preview-pdf-viewer`}
-    />
-  );
+  return <canvas ref={canvasRef} className={`${settings.prefix}--document-preview-pdf-viewer`} />;
 };
 
 PdfViewer.defaultProps = {


### PR DESCRIPTION
From #229, moved the source to a local branch. 

#### What do these changes do/fix?

When you specify `scale` props to `PdfViewer` componenet, the PDF image on the screen scales by the square of the `scale` value.

For example, when you specify `1.5` to the value, the width of the image gets `1.5 * 1.5 = 2.25` times of the original. That's because the `canvas` size is determined with `scale` and the `scale` is again used to scale the `canvas` by `scale`.

#### How do you test/verify these changes?
Use an existing storybook.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
no
