### PR TITLE
fix: fix build error

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.3, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10260,7 +10260,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.2
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.3
     "@ibm-watson/discovery-styles": ^1.5.0-beta.2
     body-parser: ^1.19.0
     carbon-components: ^10.6.0


### PR DESCRIPTION
#### What do these changes do/fix?

Fix build error caused after merging #237
https://github.com/watson-developer-cloud/discovery-components/runs/4426288121?check_suite_focus=true

```
YN0028: │ The lockfile would have been modified by this install, which is explicitly forbidden.
```

#### How do you test/verify these changes?
Successful CI build.

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No
