### PR TITLE
fix: mitigate overlapped or segmented highlight on PDF

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.4, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.5, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2305,7 +2305,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^1.5.0-beta.4, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^1.5.0-beta.5, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10260,8 +10260,8 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.4
-    "@ibm-watson/discovery-styles": ^1.5.0-beta.4
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.5
+    "@ibm-watson/discovery-styles": ^1.5.0-beta.5
     body-parser: ^1.19.0
     carbon-components: ^10.6.0
     carbon-components-react: ^7.7.0


### PR DESCRIPTION
#### What do these changes do/fix?

Highlighting on PDF could be overlapped or segmented for a single span. The following screenshots shows them.  It depends on how _text content items_ are stored in PDF. This PR is to fix them by merging highlight boxes next to each other.

**overlapped**
![image](https://user-images.githubusercontent.com/19485344/145529064-918db799-a4ab-4ba1-8540-b58f60058568.png)

**segmented** in a line even when highlighting a single span.
![image](https://user-images.githubusercontent.com/19485344/145529089-f596e827-f9a7-46e4-993b-34f51da1bc77.png)

##### fixed
![image](https://user-images.githubusercontent.com/19485344/145529252-e3c3948b-8c4b-40f3-8c78-7f32df0f8c96.png)


#### How do you test/verify these changes?
Please use the storybook to verify this. Select various text ranges in the _PdfViewerWithHighlight/with text selection_ storybook.

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
