### PR TITLE
fix: fix PDF highlight misalignment issue

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerHighlight/PdfViewerHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerHighlight/PdfViewerHighlight.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo, useEffect } from 'react';
+import React, { FC, useMemo } from 'react';
 import cx from 'classnames';
 import { settings } from 'carbon-components';
 import { QueryResult } from 'ibm-watson/discovery/v2';

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerHighlight/PdfViewerHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerHighlight/PdfViewerHighlight.tsx
@@ -48,21 +48,18 @@ const PdfViewerHighlight: FC<Props> = ({
     textMappings: parsedDocument?.textMappings,
     processedDoc: _useHtmlBbox ? parsedDocument?.processedDoc : undefined,
     pdfRenderedText: (_usePdfTextItem && pdfRenderedText) || undefined,
-    pageNum: page
+    pageNum: page,
+    isReady: !!(parsedDocument && (!_usePdfTextItem || pdfRenderedText?.page === page))
   });
 
   const { textDivs } = pdfRenderedText || {};
-  useEffect(() => {
-    if (highlighter) {
-      highlighter.setTextContentDivs(textDivs);
-    }
-  }, [highlighter, textDivs]);
 
   const highlightBoxes = useMemo(() => {
+    highlighter?.setTextContentDivs(textDivs);
     return highlights.map(highlight => {
       return highlighter?.getHighlight(highlight);
     });
-  }, [highlighter, highlights]);
+  }, [highlighter, highlights, textDivs]);
 
   return (
     <div className={cx(`${settings.prefix}--document-preview-pdf-viewer-highlight`, className)}>
@@ -102,16 +99,18 @@ const useHighlighter = ({
   textMappings,
   processedDoc,
   pdfRenderedText,
-  pageNum
+  pageNum,
+  isReady
 }: {
   document: QueryResult;
   textMappings?: TextMappings;
   processedDoc?: ProcessedDoc;
   pdfRenderedText?: PdfRenderedText;
   pageNum: number;
+  isReady: boolean;
 }) => {
   return useMemo(() => {
-    if (textMappings) {
+    if (isReady && textMappings) {
       return new Highlighter({
         document,
         textMappings,
@@ -125,7 +124,7 @@ const useHighlighter = ({
       });
     }
     return null;
-  }, [document, pageNum, pdfRenderedText, processedDoc, textMappings]);
+  }, [document, isReady, pageNum, pdfRenderedText, processedDoc, textMappings]);
 };
 
 export default PdfViewerHighlight;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.5, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.6, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10260,7 +10260,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.5
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.6
     "@ibm-watson/discovery-styles": ^1.5.0-beta.5
     body-parser: ^1.19.0
     carbon-components: ^10.6.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.4, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.5, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2305,7 +2305,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^1.5.0-beta.4, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^1.5.0-beta.5, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10260,8 +10260,8 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.4
-    "@ibm-watson/discovery-styles": ^1.5.0-beta.4
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.5
+    "@ibm-watson/discovery-styles": ^1.5.0-beta.5
     body-parser: ^1.19.0
     carbon-components: ^10.6.0
     carbon-components-react: ^7.7.0


### PR DESCRIPTION
#### What do these changes do/fix?
On PDFViewer with highlight, after you switch PDF pages, highlights on PDF gets misaligned.  This PR is to fix it.

In the screenshot, `documented acceptance` should be highlighted, but not in PDF view.
![image](https://user-images.githubusercontent.com/19485344/145542099-234c05fa-950f-4b42-b72e-8738d6f20702.png)

**Steps**
1. Open the storybook
2. Select the `documented acceptance` in the right pane. The text is highlighted on PDF
3. Move to page 2 using Knob
4. Move page back to 1
5. You see misaligned highlight

The issue comes from incorrect dependencies of a React hook. Also, the calculation of highlight rectangle starts before all the data is gathered.

#### How do you test/verify these changes?
Run the scenario using the storybook. Highlight shouldn't be misaligned even after moving pages back and force.

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
No
