### PR TITLE
Update ResultsPagination after Carbon update

### DIFF
--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -131,15 +131,13 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
             totalItems={matchingResults}
             pageSize={actualPageSize}
             pageSizes={pageSizes}
-            // onChange={handleOnChange} // see PageSelector for why this is commented out
+            onChange={handleOnChange}
             itemRangeText={handleItemRangeText}
             itemsPerPageText={mergedMessages.itemsPerPageText}
             pageRangeText={handlePageRangeText}
             pageText={handlePageText}
             {...inputProps}
-          >
-            {(props: PageSelectorProps) => <PageSelector {...props} onChange={handleOnChange} />}
-          </CarbonPagination>
+          />
         )}
       </>
     );
@@ -147,48 +145,6 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
 
   return null;
 };
-
-// XXX Slight hack. unstabled_Pagination doesn't currently emit an `onChange`
-// event, so we create a fake "page selector" child which gets the updates we
-// need. We can then call the original `handleOnChange` with the updated values.
-type PageSelectorProps = {
-  currentPage: number;
-  currentPageSize: number;
-  onSetPage: Function;
-  onChange: Function;
-};
-
-function PageSelector({ currentPage, currentPageSize, onSetPage, onChange }: PageSelectorProps) {
-  const [page, setPage] = useState(currentPage);
-  const [pageSize, setPageSize] = useState(currentPageSize);
-
-  useEffect(() => {
-    if (currentPageSize !== pageSize) {
-      setPageSize(currentPageSize);
-      setPage(1);
-
-      onChange({
-        page: 1,
-        pageSize: currentPageSize
-      });
-      // update unstable_Pagination state
-      onSetPage(1);
-    } else if (currentPage !== page) {
-      setPage(currentPage);
-
-      onChange({
-        page: currentPage,
-        pageSize: pageSize
-      });
-    }
-  }, [currentPage, currentPageSize, onChange, onSetPage, page, pageSize]);
-
-  return (
-    <span className={`${settings.prefix}--unstable-pagination__text`} data-testid="current-page">
-      {currentPage}
-    </span>
-  );
-}
 
 export default withErrorBoundary(
   ResultsPagination,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.6, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.7, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10260,7 +10260,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.6
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.7
     "@ibm-watson/discovery-styles": ^1.5.0-beta.5
     body-parser: ^1.19.0
     carbon-components: ^10.6.0


### PR DESCRIPTION
Update ResultsPagination to use onChange again, as it is now required in unstable_Pagination in the newly updated Carbon

(https://github.com/carbon-design-system/carbon/blob/main/packages/react/src/components/Pagination/experimental/Pagination.js#L56)

#### What do these changes do/fix?

<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
