### PR TITLE
chore: refactor to make util function to detect preview type

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/types.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/types.ts
@@ -1,3 +1,5 @@
+import { QueryResult } from 'ibm-watson/discovery/v2';
+
 export interface TextMappings {
   pages: Page[];
   text_mappings: Cell[];
@@ -42,4 +44,13 @@ export interface StyledCell extends CellPage {
   id: string;
   className?: string;
   content: string;
+}
+
+export type PreviewType = 'PDF' | 'HTML' | 'SIMPLE';
+
+export interface DiscoveryDocument extends QueryResult {
+  extracted_metadata?: {
+    file_type?: 'pdf' | 'html' | 'json' | 'csv' | 'text';
+    text_mappings?: string; // exists when custom SDU model or OOB (CI) model enabled
+  };
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -1,4 +1,4 @@
-import { getTextMappings, isCsvFile, isJsonFile } from '../documentData';
+import { getTextMappings, isCsvFile, isJsonFile, detectPreviewType } from '../documentData';
 import jsonDoc from '../../__fixtures__/Art Effects Koya Creative Base TSA 2008.pdf.json';
 
 describe('documentData', () => {
@@ -102,5 +102,106 @@ describe('documentData', () => {
   it('returns false if there is no file type provided', () => {
     const falseDocType = isCsvFile(noMetadata);
     expect(falseDocType).toEqual(false);
+  });
+
+  describe('detectPreviewType', () => {
+    const commonData = { document_id: 'doc-1', result_metadata: { collection_id: 'col-1' } };
+
+    describe('pdf', () => {
+      it('return PDF when document has text_mappings', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf', text_mappings: '{}' },
+            document_passages: [{ passage_text: 'passage' }],
+            html: '<html></html>'
+          },
+          'file'
+        );
+        expect(previewType).toEqual('PDF');
+      });
+
+      it('return PDF when no text_mappings and passage_text', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf' },
+            html: '<html></html>'
+          },
+          'file'
+        );
+        expect(previewType).toEqual('PDF');
+      });
+
+      it('return SIMPLE when document does not have text_mappings but have passage_text', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf' },
+            document_passages: [{ passage_text: 'passage' }]
+          },
+          'file'
+        );
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when no file', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf', text_mappings: '{}' }
+          },
+          undefined
+        );
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
+
+    describe('html', () => {
+      it('return HTML when document has html', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'html' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('HTML');
+      });
+
+      it('return SIMPLE when no html', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'html' }
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
+
+    describe('other types', () => {
+      it('return SIMPLE when json type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'json' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when csv type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'csv' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when text type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'text' }
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
   });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
 import { QueryResult } from 'ibm-watson/discovery/v2';
-import { TextMappings } from '../types';
+import { TextMappings, PreviewType, DiscoveryDocument } from '../types';
 
 /**
  * Get `text_mappings` document property as an object. Usually, this
@@ -37,4 +37,31 @@ export function isCsvFile(doc: QueryResult | null | undefined): boolean {
  */
 export function isJsonFile(doc: QueryResult | null | undefined): boolean {
   return get(doc, 'extracted_metadata.file_type') === 'json';
+}
+
+/**
+ * Returns the preview type for document
+ */
+export function detectPreviewType(document: DiscoveryDocument, file?: string): PreviewType {
+  const fileType = document.extracted_metadata?.file_type;
+  const hasPassage = !!document.document_passages?.[0]?.passage_text;
+
+  // if we have PDF data, render that
+  // otherwise, render fallback document view
+  if (fileType === 'pdf' && file) {
+    const hasTextMappings = !!document.extracted_metadata?.text_mappings;
+    // when hasTextMappings is true, that means the custom SDU model or OOB (CI) model is enabled
+    // otherwise, that means the fast path
+    if (hasTextMappings || !hasPassage) {
+      return 'PDF';
+    }
+  }
+
+  const isJsonType = isJsonFile(document);
+  const isCsvType = isCsvFile(document);
+  if (document.html && !isJsonType && !isCsvType) {
+    return 'HTML';
+  }
+
+  return 'SIMPLE';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2267,7 +2267,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.7, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.8, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2306,7 +2306,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^1.5.0-beta.5, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^1.5.0-beta.8, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10261,8 +10261,8 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.7
-    "@ibm-watson/discovery-styles": ^1.5.0-beta.5
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.8
+    "@ibm-watson/discovery-styles": ^1.5.0-beta.8
     body-parser: ^1.19.0
     carbon-components: ^10.6.0
     carbon-components-react: ^7.7.0


### PR DESCRIPTION
#### What do these changes do/fix?
Made an util function to detect the document preview type, which will be used when choosing what component should be used for rendering. This is to easily ensure preview type described in the ADR.

#### How do you test/verify these changes?
- Making unit test
- Manual test

#### Have you documented your changes (if necessary)?
n/a

#### Are there any breaking changes included in this pull request?
no
