### PR TITLE
fix: fix PDFViewer rendering issue

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.scss
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.scss
@@ -1,0 +1,7 @@
+// Carbon highlight color for white theme
+// https://www.carbondesignsystem.com/guidelines/color/usage/
+$ui-01: #f4f4f4;
+
+.pdf-viewer-stories__gray-background {
+  background-color: $ui-01;
+}

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
@@ -4,6 +4,7 @@ import { withKnobs, radios, number } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import PdfViewer from './PdfViewer';
 import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Effects.pdf';
+import './PdfViewer.stories.scss';
 
 const pageKnob = {
   label: 'Page',
@@ -38,12 +39,14 @@ storiesOf('DocumentPreview/components/PdfViewer', module)
     const setRenderedTextAction = action('setRenderedText');
 
     return (
-      <PdfViewer
-        file={atob(doc)}
-        page={page}
-        scale={scale}
-        setLoading={setLoadingAction}
-        setRenderedText={setRenderedTextAction}
-      />
+      <div className="pdf-viewer-stories__gray-background">
+        <PdfViewer
+          file={atob(doc)}
+          page={page}
+          scale={scale}
+          setLoading={setLoadingAction}
+          setRenderedText={setRenderedTextAction}
+        />
+      </div>
     );
   });

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -1,12 +1,6 @@
 import React, { FC, useEffect, useRef, useMemo, useCallback } from 'react';
 import cx from 'classnames';
-import PdfjsLib, {
-  PDFDocumentProxy,
-  PDFPageProxy,
-  PDFPageViewport,
-  PDFPromise,
-  PDFRenderTask
-} from 'pdfjs-dist';
+import PdfjsLib, { PDFDocumentProxy, PDFPageProxy, PDFPromise, PDFRenderTask } from 'pdfjs-dist';
 import PdfjsWorkerAsText from 'pdfjs-dist/build/pdf.worker.min.js';
 import { settings } from 'carbon-components';
 import useAsyncFunctionCall from 'utils/useAsyncFunctionCall';
@@ -79,25 +73,21 @@ const PdfViewer: FC<Props> = ({
     )
   );
 
-  const [viewport, canvasInfo] = useMemo(() => {
-    const viewport = loadedPage?.getViewport({ scale });
-    const canvasInfo = viewport ? getCanvasInfo(viewport) : undefined;
-    return [viewport, canvasInfo];
-  }, [loadedPage, scale]);
+  const canvasInfo = useMemo(() => getCanvasInfo(loadedPage, scale), [loadedPage, scale]);
 
   // render page
   useAsyncFunctionCall(
     useCallback(
       async (abortSignal: AbortSignal) => {
-        if (loadedPage && !(loadedPage as any).then && viewport && canvasInfo) {
-          const task = _renderPage(loadedPage, canvasRef.current!, viewport, canvasInfo);
+        if (loadedPage && !(loadedPage as any).then && canvasInfo) {
+          const task = _renderPage(loadedPage, canvasRef.current!, canvasInfo);
           abortSignal.addEventListener('abort', () => task?.cancel());
           await task?.promise;
 
           setLoading(false);
         }
       },
-      [canvasInfo, loadedPage, setLoading, viewport]
+      [canvasInfo, loadedPage, setLoading]
     )
   );
 
@@ -182,14 +172,11 @@ function _loadPage(file: PDFDocumentProxy, page: number) {
 function _renderPage(
   pdfPage: PDFPageProxy,
   canvas: HTMLCanvasElement,
-  viewport: PDFPageViewport,
   canvasInfo: CanvasInfo
 ): PDFRenderTask | null {
   const canvasContext = canvas.getContext('2d');
   if (canvasContext) {
-    canvasContext.resetTransform();
-    canvasContext.scale(canvasInfo.canvasScale, canvasInfo.canvasScale);
-    return pdfPage.render({ canvasContext, viewport });
+    return pdfPage.render({ canvasContext, viewport: canvasInfo.viewport });
   }
   return null;
 }
@@ -212,17 +199,22 @@ type CanvasInfo = {
   height: number;
   canvasWidth: number;
   canvasHeight: number;
-  canvasScale: number;
+  viewport: PdfjsLib.PDFPageViewport;
 };
 
-function getCanvasInfo(viewport: any): CanvasInfo {
-  const { width, height } = viewport;
-
+function getCanvasInfo(
+  loadedPage: PdfjsLib.PDFPageProxy | null | undefined,
+  scale: number
+): CanvasInfo | null {
   const canvasScale = window.devicePixelRatio ?? 1;
-  const canvasWidth = Math.ceil(width * canvasScale);
-  const canvasHeight = Math.ceil(height * canvasScale);
-
-  return { width, height, canvasWidth, canvasHeight, canvasScale };
+  const viewport = loadedPage?.getViewport({ scale: scale * canvasScale });
+  if (viewport) {
+    const { width: canvasWidth, height: canvasHeight } = viewport;
+    const width = Math.ceil(canvasWidth / canvasScale);
+    const height = Math.ceil(canvasHeight / canvasScale);
+    return { width, height, canvasWidth, canvasHeight, viewport };
+  }
+  return null;
 }
 
 export type PdfViewerProps = Props;


### PR DESCRIPTION
#### What do these changes do/fix?
This PR fixes an issue in PDF rendered by PdfViewer component.

The current PdfViewer doesn't work properly with browser's Zoom settings. When a browser's zoom is 80%, the background of the PDF is not fully rendered. When user moves to the next page, old text remains in the new page.
![image](https://user-images.githubusercontent.com/19485344/149720662-f8fe8d94-283d-4847-9ac6-dde22797a96f.png)

It's due to incorrect calculation of `viewport` passed to PDF rendering. The existing code uses the original viewport size and scale it using SVG canvas' scale. In this code, the code is refactored to use the scaled viewport and not to do anything in SVG canvas.

#### How do you test/verify these changes?
The storybook `DocumentPreview / components / PdfViewer / default` now have the background color to see if PDF page is fully rendered. Please use the storybook and check if PDF pages are rendered correctly with various browser Zoom settings (and device pixel ratio if possible).

#### Have you documented your changes (if necessary)?
no

#### Are there any breaking changes included in this pull request?
no
