### PR TITLE
fix: add missing prop to doc provider interface

### DIFF
--- a/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/types.ts
@@ -12,7 +12,8 @@ export type SearchParams = Omit<DiscoveryV2.QueryParams, 'projectId' | 'headers'
   returnFields?: string[];
 };
 
-export interface DocumentProviderProps extends Pick<QueryResult, 'document_id' | 'metadata'> {
+export interface DocumentProviderProps
+  extends Pick<QueryResult, 'document_id' | 'metadata' | 'result_metadata'> {
   extracted_metadata?: JsonObject;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,7 +2124,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.14, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.15, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10545,7 +10545,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.14
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.15
     "@ibm-watson/discovery-styles": ^1.5.0-beta.14
     body-parser: ^1.19.0
     carbon-components: ^10.6.0


### PR DESCRIPTION
#### What do these changes do/fix?

Add `result_metadata` prop type to `DocumentProviderProps` interface

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
