### PR TITLE
fix: fix preview type displayed in DocumentPreview

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -1,4 +1,12 @@
-import React, { ComponentProps, FC, ReactElement, useContext, useEffect, useState } from 'react';
+import React, {
+  ComponentProps,
+  FC,
+  ReactElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useState
+} from 'react';
 import { SkeletonText } from 'carbon-components-react';
 import { settings } from 'carbon-components';
 import { QueryResult, QueryResultPassage, QueryTableResult } from 'ibm-watson/discovery/v2';
@@ -167,11 +175,15 @@ function PreviewDocument({
   setCurrentPage,
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
+  const previewType = useMemo(
+    () => (document ? detectPreviewType(document, file) : null),
+    [document, file]
+  );
+
   if (!document) {
     return null;
   }
 
-  const previewType = detectPreviewType(document, file);
   switch (previewType) {
     case 'PDF':
       return (
@@ -196,7 +208,7 @@ function PreviewDocument({
           setLoading={setLoading}
         />
       );
-    case 'SIMPLE':
+    case 'TEXT':
       return (
         <SimpleDocument
           document={document}

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -9,7 +9,7 @@ import withErrorBoundary, { WithErrorBoundaryProps } from 'utils/hoc/withErrorBo
 import { defaultMessages, Messages } from './messages';
 import HtmlView from './components/HtmlView/HtmlView';
 import PdfViewerWithHighlight from './components/PdfViewerWithHighlight/PdfViewerWithHighlight';
-import { isCsvFile, isJsonFile } from './utils/documentData';
+import { detectPreviewType } from './utils/documentData';
 
 const { ZOOM_IN, ZOOM_OUT } = PreviewToolbar;
 
@@ -167,28 +167,27 @@ function PreviewDocument({
   setCurrentPage,
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
-  // if we have PDF data, render that
-  // otherwise, render fallback document view
-  if (file) {
-    return (
-      <PdfViewerWithHighlight
-        file={file}
-        document={document}
-        page={currentPage}
-        scale={scale}
-        setPageCount={setPdfPageCount}
-        setLoading={setLoading}
-        setHideToolbarControls={setHideToolbarControls}
-        highlight={highlight}
-        setCurrentPage={setCurrentPage}
-      />
-    );
+  if (!document) {
+    return null;
   }
 
-  if (document) {
-    const isJsonType = isJsonFile(document);
-    const isCsvType = isCsvFile(document);
-    if (document.html && !isJsonType && !isCsvType) {
+  const previewType = detectPreviewType(document, file);
+  switch (previewType) {
+    case 'PDF':
+      return (
+        <PdfViewerWithHighlight
+          file={file!} // PDF preview type ensures that file is not null
+          document={document}
+          page={currentPage}
+          scale={scale}
+          setPageCount={setPdfPageCount}
+          setLoading={setLoading}
+          setHideToolbarControls={setHideToolbarControls}
+          highlight={highlight}
+          setCurrentPage={setCurrentPage}
+        />
+      );
+    case 'HTML':
       return (
         <HtmlView
           document={document}
@@ -197,21 +196,21 @@ function PreviewDocument({
           setLoading={setLoading}
         />
       );
-    }
-    return (
-      <SimpleDocument
-        document={document}
-        highlight={highlight}
-        hideToolbarControls={hideToolbarControls}
-        setHideToolbarControls={setHideToolbarControls}
-        loading={loading}
-        setLoading={setLoading}
-        fallbackComponent={fallbackComponent}
-      />
-    );
+    case 'SIMPLE':
+      return (
+        <SimpleDocument
+          document={document}
+          highlight={highlight}
+          hideToolbarControls={hideToolbarControls}
+          setHideToolbarControls={setHideToolbarControls}
+          loading={loading}
+          setLoading={setLoading}
+          fallbackComponent={fallbackComponent}
+        />
+      );
+    default:
+      return null;
   }
-
-  return null;
 }
 
 //Replace any with a proper TS check

--- a/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
@@ -30,7 +30,7 @@ storiesOf('DocumentPreview', module)
     );
   })
   .add('passage highlighting', () => {
-    const [file, doc] = docSelection(['pdf', 'pdf-no-mapping', 'html', 'text']);
+    const [file, doc] = docSelection(['pdf', 'pdf-fast-path', 'html', 'text']);
     const usedPassage = doc.extracted_metadata.file_type === 'json' ? jsonPassages : passages;
     const docWithPassage = passageSelection(doc, usedPassage);
     const highlight = (docWithPassage.document_passages as unknown as QueryResultPassage[])[0];
@@ -77,7 +77,7 @@ function docSelection(items = ['pdf', 'html', 'text']): [string | undefined, Que
   const options = pickBy(
     {
       PDF: 'pdf',
-      'PDF without text location data': 'pdf-no-mapping',
+      'PDF without text location data': 'pdf-fast-path',
       'Document with `html` property and structure data': 'html',
       'Document with only text': 'text'
     },
@@ -93,9 +93,9 @@ function docSelection(items = ['pdf', 'html', 'text']): [string | undefined, Que
       file = atob(docPDF);
       doc = docArtEffects;
       break;
-    case 'pdf-no-mapping':
+    case 'pdf-fast-path':
       file = atob(docPDF);
-      doc = omit(docArtEffects, 'extracted_metadata.text_mappings');
+      doc = omit(docArtEffects, 'html', 'extracted_metadata.text_mappings');
       break;
     case 'html':
       doc = docArtEffects;

--- a/packages/discovery-react-components/src/components/DocumentPreview/types.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/types.ts
@@ -1,3 +1,5 @@
+import { QueryResult } from 'ibm-watson/discovery/v2';
+
 export interface TextMappings {
   pages: Page[];
   text_mappings: Cell[];
@@ -42,4 +44,13 @@ export interface StyledCell extends CellPage {
   id: string;
   className?: string;
   content: string;
+}
+
+export type PreviewType = 'PDF' | 'HTML' | 'SIMPLE' | 'NONE';
+
+export interface DiscoveryDocument extends QueryResult {
+  extracted_metadata?: {
+    file_type?: 'pdf' | 'html' | 'json' | 'csv' | 'text' | string;
+    text_mappings?: string; // exists when custom SDU model or OOB (CI) model enabled
+  };
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/types.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/types.ts
@@ -46,7 +46,7 @@ export interface StyledCell extends CellPage {
   content: string;
 }
 
-export type PreviewType = 'PDF' | 'HTML' | 'SIMPLE' | 'NONE';
+export type PreviewType = 'PDF' | 'HTML' | 'TEXT';
 
 export interface DiscoveryDocument extends QueryResult {
   extracted_metadata?: {

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -1,4 +1,4 @@
-import { getTextMappings, isCsvFile, isJsonFile } from '../documentData';
+import { detectPreviewType, getTextMappings, isCsvFile, isJsonFile } from '../documentData';
 import jsonDoc from '../../__fixtures__/Art Effects Koya Creative Base TSA 2008.pdf.json';
 
 describe('documentData', () => {
@@ -102,5 +102,106 @@ describe('documentData', () => {
   it('returns false if there is no file type provided', () => {
     const falseDocType = isCsvFile(noMetadata);
     expect(falseDocType).toEqual(false);
+  });
+
+  describe('detectPreviewType', () => {
+    const commonData = { document_id: 'doc-1', result_metadata: { collection_id: 'col-1' } };
+
+    describe('pdf', () => {
+      it('return PDF when document has text_mappings', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf', text_mappings: '{}' },
+            document_passages: [{ passage_text: 'passage' }],
+            html: '<html></html>'
+          },
+          'file'
+        );
+        expect(previewType).toEqual('PDF');
+      });
+
+      it('return PDF when no text_mappings and passage_text', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf' },
+            html: '<html></html>'
+          },
+          'file'
+        );
+        expect(previewType).toEqual('PDF');
+      });
+
+      it('return SIMPLE when document does not have text_mappings but have passage_text', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf' },
+            document_passages: [{ passage_text: 'passage' }]
+          },
+          'file'
+        );
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when no file', () => {
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'pdf', text_mappings: '{}' }
+          },
+          undefined
+        );
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
+
+    describe('html', () => {
+      it('return HTML when document has html', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'html' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('HTML');
+      });
+
+      it('return SIMPLE when no html', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'html' }
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
+
+    describe('other types', () => {
+      it('return SIMPLE when json type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'json' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when csv type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'csv' },
+          html: '<html></html>'
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+
+      it('return SIMPLE when text type', () => {
+        const previewType = detectPreviewType({
+          ...commonData,
+          extracted_metadata: { file_type: 'text' }
+        });
+        expect(previewType).toEqual('SIMPLE');
+      });
+    });
   });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -133,7 +133,7 @@ describe('documentData', () => {
         expect(previewType).toEqual('PDF');
       });
 
-      it('return SIMPLE when document does not have text_mappings but have passage_text', () => {
+      it('return TEXT when document does not have text_mappings but have passage_text', () => {
         const previewType = detectPreviewType(
           {
             ...commonData,
@@ -142,10 +142,10 @@ describe('documentData', () => {
           },
           'file'
         );
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
 
-      it('return SIMPLE when no file', () => {
+      it('return TEXT when no file', () => {
         const previewType = detectPreviewType(
           {
             ...commonData,
@@ -153,7 +153,7 @@ describe('documentData', () => {
           },
           undefined
         );
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
     });
 
@@ -167,40 +167,40 @@ describe('documentData', () => {
         expect(previewType).toEqual('HTML');
       });
 
-      it('return SIMPLE when no html', () => {
+      it('return TEXT when no html', () => {
         const previewType = detectPreviewType({
           ...commonData,
           extracted_metadata: { file_type: 'html' }
         });
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
     });
 
     describe('other types', () => {
-      it('return SIMPLE when json type', () => {
+      it('return TEXT when json type', () => {
         const previewType = detectPreviewType({
           ...commonData,
           extracted_metadata: { file_type: 'json' },
           html: '<html></html>'
         });
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
 
-      it('return SIMPLE when csv type', () => {
+      it('return TEXT when csv type', () => {
         const previewType = detectPreviewType({
           ...commonData,
           extracted_metadata: { file_type: 'csv' },
           html: '<html></html>'
         });
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
 
-      it('return SIMPLE when text type', () => {
+      it('return TEXT when text type', () => {
         const previewType = detectPreviewType({
           ...commonData,
           extracted_metadata: { file_type: 'text' }
         });
-        expect(previewType).toEqual('SIMPLE');
+        expect(previewType).toEqual('TEXT');
       });
     });
   });

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -46,8 +46,7 @@ export function detectPreviewType(document: DiscoveryDocument, file?: string): P
   const fileType = document.extracted_metadata?.file_type;
   const hasPassage = !!document.document_passages?.[0]?.passage_text;
 
-  // if we have PDF data, render that
-  // otherwise, render fallback document view
+  // only render PDF if we have text mappings data
   if (fileType === 'pdf' && file) {
     const hasTextMappings = !!document.extracted_metadata?.text_mappings;
     // when hasTextMappings is true, that means the custom SDU model or OOB (CI) model is enabled

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -63,5 +63,5 @@ export function detectPreviewType(document: DiscoveryDocument, file?: string): P
     return 'HTML';
   }
 
-  return 'SIMPLE';
+  return 'TEXT';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.18, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.19, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10669,7 +10669,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.18
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.19
     "@ibm-watson/discovery-styles": ^1.5.0-beta.17
     "@testing-library/cypress": ^7.0.7
     body-parser: ^1.19.0


### PR DESCRIPTION
#### What do these changes do/fix?
Currently, there's small gap with the type (PDF/HTML/TEXT) of the preview displayed for a document in `DocumentPreivew`. Specifically, when we have a PDF file and a passage, but not `text_mappings`, the TEXT view is expected.

To fix the behavior,
- I extracted a function for determining preview type, then
- Make the function work as expected.
- I also added the scenario to the storybook

#### How do you test/verify these changes?
Please use the updated storybook, and check if new tests in CI passes
<img width="1083" alt="image" src="https://user-images.githubusercontent.com/19485344/153125885-ab709f0f-2e12-4204-92d9-6e4eabb8eb77.png">

#### Have you documented your changes (if necessary)?
n/a
#### Are there any breaking changes included in this pull request?
no