### PR TITLE
feat: update PDFViewer toolbar style

### DIFF
--- a/packages/discovery-react-components/.storybook/styles.scss
+++ b/packages/discovery-react-components/.storybook/styles.scss
@@ -1,1 +1,4 @@
 @import '~@ibm-watson/discovery-styles/scss/index';
+
+// for document-preview-toolbar story
+@import '~carbon-components/scss/components/overflow-menu/overflow-menu';

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PreviewToolbar/PreviewToolbar.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PreviewToolbar/PreviewToolbar.stories.tsx
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { withKnobs, number, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import { Json24, Document24 } from '@carbon/icons-react';
+import { OverflowMenu, OverflowMenuItem } from 'carbon-components-react';
 
 import { PreviewToolbar, ToolbarAction } from './PreviewToolbar';
 
@@ -39,6 +40,17 @@ const userActions: ToolbarAction[] = [
     renderIcon: Json24,
     iconDescription: 'Json view',
     onClick: action('json')
+  },
+  {
+    id: 'menu',
+    render: () => {
+      return (
+        <OverflowMenu size="sm" flipped>
+          <OverflowMenuItem itemText="Menu item 1" />
+          <OverflowMenuItem itemText="Menu item 2" />
+        </OverflowMenu>
+      );
+    }
   }
 ];
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/messages.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/messages.ts
@@ -2,6 +2,7 @@ export interface Messages {
   noDataMessage?: string;
   errorMessage?: string;
   // toolbar labels
+  formatTotalPages?: (total: number) => string;
   previousPageLabel?: string;
   nextPageLabel?: string;
   zoomInLabel?: string;
@@ -9,10 +10,11 @@ export interface Messages {
   resetZoomLabel?: string;
 }
 
-export const defaultMessages = {
+export const defaultMessages: Required<Messages> = {
   noDataMessage: 'No document data',
   errorMessage: 'Error previewing document',
   // toolbar labels
+  formatTotalPages: total => (total === 1 ? `${total} page` : `${total} pages`),
   previousPageLabel: 'Previous page',
   nextPageLabel: 'Next page',
   zoomInLabel: 'Zoom in',

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview-toolbar.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview-toolbar.scss
@@ -27,6 +27,8 @@
   text-align: center;
   max-width: $layout-lg;
   height: $spacing-07;
+  padding: 0 $spacing-02;
+  margin-left: $spacing-02;
 }
 
 // removes number wheel buttons from input (chrome and safari)


### PR DESCRIPTION
#### What do these changes do/fix?
Update the PDFViewer's toolbar design to match the latest UX.

- Use up/down icon for PDF pagenation
- Add capability of adding `pages` suffix after the number of pages
- Add capability of putting user-defined widget into the toolbar

<img width="766" alt="image" src="https://user-images.githubusercontent.com/19485344/154940270-3d5bf579-5dc0-49f7-9c93-1e959d3163d7.png">


#### How do you test/verify these changes?
- Use DocumentPreview/components/PreviewToolbar/default story http://localhost:9002/?path=/story/documentpreview-components-previewtoolbar--default

#### Have you documented your changes (if necessary)?
no

#### Are there any breaking changes included in this pull request?
no