### PR TITLE
fix: fix console error on showing DocumentPreview component

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -52,9 +52,11 @@ export const HtmlView: FC<Props> = ({
   const contentRef = useRef<HTMLDivElement>(null);
   const highlightRef = useRef<HTMLDivElement>(null);
 
-  if (setHideToolbarControls) {
-    setHideToolbarControls(true);
-  }
+  useEffect(() => {
+    if (setHideToolbarControls) {
+      setHideToolbarControls(true);
+    }
+  }, [setHideToolbarControls]);
 
   const [html, setHtml] = useState<string | null>(null);
   const [processedDoc, setProcessedDoc] = useState<ProcessedDoc | null>(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.21, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.22, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.21
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.22
     "@ibm-watson/discovery-styles": ^1.5.0-beta.21
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

Eliminate the following console out on showing `DocumentPreview`.
```
Warning: Cannot update a component (`DocumentPreview`) while rendering a different component (`HtmlView`). To locate the bad setState() call inside `HtmlView`, follow the stack trace as described in https://reactjs.org/link/setstate-in-render
    at HtmlView (http://localhost:9002/main.39ae2b585ef0315cf79f.bundle.js:5019:23)
    at PreviewDocument (http://localhost:9002/main.39ae2b585ef0315cf79f.bundle.js:4415:19)
    at div
    at div
    at DocumentPreview (http://localhost:9002/main.39ae2b585ef0315cf79f.bundle.js:4339:23)
    at WithErrorBoundary (http://localhost:9002/main.39ae2b585ef0315cf79f.bundle.js:16154:36)
```

#### How do you test/verify these changes?
- Open "Document Preview / default" storybook,
   - Clear console, and then reload the window
   - Verify that the warning message is NOT shown in browser console.

#### Have you documented your changes (if necessary)?
n/a

#### Are there any breaking changes included in this pull request?
no
