### PR TITLE
fix: fix broken pdf rendering

### DIFF
--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -18,7 +18,7 @@
     "eslint": "yarn run g:eslint --quiet '{src,.storybook}/**/*.{js,jsx,ts,tsx}'",
     "lint": "yarn run circular && yarn run eslint",
     "start": "rollup -c -w",
-    "storybook": "start-storybook --ci --port=9002",
+    "storybook": "start-storybook --ci --port=9002 -s ../../node_modules/pdfjs-dist",
     "storybook:build": "build-storybook",
     "storybook:build:release": "cross-env STORYBOOK_BUILD_MODE=production build-storybook -o ../../docs/storybook",
     "analyze": "yarn run g:analyze 'dist/index.js'",

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -180,6 +180,7 @@ function _renderPage(
 ): PDFRenderTask | null {
   const canvasContext = canvas.getContext('2d');
   if (canvasContext) {
+    canvasContext.resetTransform();
     return pdfPage.render({ canvasContext, viewport: canvasInfo.viewport });
   }
   return null;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { storiesOf } from '@storybook/react';
-import { withKnobs, radios, number, select } from '@storybook/addon-knobs';
+import { withKnobs, radios, number, select, files } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 import PdfViewerWithHighlight from './PdfViewerWithHighlight';
 import { flatten } from 'lodash';
@@ -38,6 +38,16 @@ const zoomKnob = {
     'Zoom in (150%)': '1.5'
   },
   defaultValue: '1'
+};
+
+const pdfFileKnob = {
+  label: 'PDF file',
+  accept: '.pdf'
+};
+
+const documentFileKnob = {
+  label: 'Document JSON file',
+  accept: '.json'
 };
 
 const EMPTY: DocumentFieldHighlight[] = [];
@@ -275,6 +285,47 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         scale={scale}
         setLoading={setLoadingAction}
         document={documentJa}
+        highlights={EMPTY}
+        setCurrentPage={setCurrentPage}
+      />
+    );
+  })
+  .add("with user's PDF and JSON", () => {
+    const pdfFile = files(pdfFileKnob.label, pdfFileKnob.accept);
+    const documentFile = files(documentFileKnob.label, documentFileKnob.accept);
+    const page = number(pageKnob.label, pageKnob.defaultValue, pageKnob.options);
+    const zoom = radios(zoomKnob.label, zoomKnob.options, zoomKnob.defaultValue);
+    const scale = parseFloat(zoom);
+    const setLoadingAction = action('setLoading');
+    const setCurrentPage = action('setCurrentPage');
+
+    if (pdfFile.length === 0) {
+      return <div>Select PDF file</div>;
+    }
+
+    const document = documentFile[0]
+      ? JSON.parse(
+          Buffer.from(
+            documentFile[0].substring('data:application/json;base64,'.length),
+            'base64'
+          ).toString('utf-8')
+        )
+      : {
+          document_id: 'test-document-id',
+          result_metadata: {
+            collection_id: 'test-collection-id'
+          },
+          text: ''
+        };
+
+    const file = atob(pdfFile[0].substring('data:application/pdf;base64,'.length));
+    return (
+      <WithTextSelection
+        file={{ data: file, cMapPacked: true, cMapUrl: '/cmaps/' }}
+        page={page}
+        scale={scale}
+        setLoading={setLoadingAction}
+        document={document}
         highlights={EMPTY}
         setCurrentPage={setCurrentPage}
       />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.23, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.24, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2218,7 +2218,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^1.5.0-beta.21, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^1.5.0-beta.24, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10664,8 +10664,8 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.23
-    "@ibm-watson/discovery-styles": ^1.5.0-beta.21
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.24
+    "@ibm-watson/discovery-styles": ^1.5.0-beta.24
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
     body-parser: ^1.19.0


### PR DESCRIPTION
#### What do these changes do/fix?
Fix #314 . Reset canvas' transformation before drawing PDF page to fix https://github.com/watson-developer-cloud/discovery-components/issues/314#issuecomment-1055055545.

#### How do you test/verify these changes?
The issue can be reproduced by switching pages quickly. I added a new storybook `DocumentPreview / components / PdfViewerWithHighlight / with user's PDF and JSON` so that we can test PDF viewer using user-provided PDF and JSON.

You can use the story to test a problematic PDF.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
no
