### PR TITLE
feat: add state change event to DocumentPreview component

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -54,6 +54,10 @@ interface Props extends WithErrorBoundaryProps {
    * React component rendered as a fallback when no preview is available
    */
   fallbackComponent?: ComponentProps<typeof SimpleDocument>['fallbackComponent'];
+  /**
+   * Callback to receive changes in document preview state
+   */
+  onPreviewStateChange?: (state: { currentPage?: number }) => void;
 }
 
 const SCALE_FACTOR = 1.2;
@@ -66,7 +70,8 @@ const DocumentPreview: FC<Props> = ({
   highlight,
   messages = defaultMessages,
   didCatch,
-  fallbackComponent
+  fallbackComponent,
+  onPreviewStateChange
 }) => {
   const { selectedResult } = useContext(SearchContext);
 
@@ -95,6 +100,11 @@ const DocumentPreview: FC<Props> = ({
   }, [doc]);
 
   const [pdfPageCount, setPdfPageCount] = useState(0);
+
+  // notify state change
+  useEffect(() => {
+    onPreviewStateChange?.({ currentPage });
+  }, [currentPage, onPreviewStateChange]);
 
   const base = `${settings.prefix}--document-preview`;
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -57,7 +57,7 @@ interface Props extends WithErrorBoundaryProps {
   /**
    * Callback to receive changes in document preview state
    */
-  onPreviewStateChange?: (state: { currentPage?: number }) => void;
+  onChange?: (state: { currentPage?: number }) => void;
 }
 
 const SCALE_FACTOR = 1.2;
@@ -71,7 +71,7 @@ const DocumentPreview: FC<Props> = ({
   messages = defaultMessages,
   didCatch,
   fallbackComponent,
-  onPreviewStateChange
+  onChange
 }) => {
   const { selectedResult } = useContext(SearchContext);
 
@@ -103,8 +103,8 @@ const DocumentPreview: FC<Props> = ({
 
   // notify state change
   useEffect(() => {
-    onPreviewStateChange?.({ currentPage });
-  }, [currentPage, onPreviewStateChange]);
+    onChange?.({ currentPage });
+  }, [currentPage, onChange]);
 
   const base = `${settings.prefix}--document-preview`;
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
@@ -1,6 +1,7 @@
 import React, { ComponentType, FC } from 'react';
 import { storiesOf } from '@storybook/react';
 import { radios, boolean, number } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { QueryResult, QueryResultPassage } from 'ibm-watson/discovery/v2';
 import { SearchContext } from 'components/DiscoverySearch/DiscoverySearch';
 import DocumentPreview from '../DocumentPreview';
@@ -26,7 +27,11 @@ storiesOf('DocumentPreview', module)
     const [file, doc] = docSelection();
     return (
       <Wrapper>
-        <DocumentPreview document={doc} file={file} />
+        <DocumentPreview
+          document={doc}
+          file={file}
+          onPreviewStateChange={action('preview-state-change')}
+        />
       </Wrapper>
     );
   })
@@ -38,7 +43,12 @@ storiesOf('DocumentPreview', module)
 
     return (
       <Wrapper>
-        <DocumentPreview document={docWithPassage} highlight={highlight} file={file} />
+        <DocumentPreview
+          document={docWithPassage}
+          highlight={highlight}
+          file={file}
+          onPreviewStateChange={action('preview-state-change')}
+        />
       </Wrapper>
     );
   })
@@ -49,7 +59,12 @@ storiesOf('DocumentPreview', module)
 
     return (
       <Wrapper>
-        <DocumentPreview file={file} document={docWithTable} highlight={highlight} />
+        <DocumentPreview
+          file={file}
+          document={docWithTable}
+          highlight={highlight}
+          onPreviewStateChange={action('preview-state-change')}
+        />
       </Wrapper>
     );
   })
@@ -92,7 +107,11 @@ storiesOf('DocumentPreview', module)
             } as any
           }
         >
-          <DocumentPreview document={docArtEffects} fileFetchTimeout={fileFetchTimeout} />
+          <DocumentPreview
+            document={docArtEffects}
+            fileFetchTimeout={fileFetchTimeout}
+            onPreviewStateChange={action('preview-state-change')}
+          />
         </SearchContext.Provider>
       </Wrapper>
     );

--- a/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
@@ -27,11 +27,7 @@ storiesOf('DocumentPreview', module)
     const [file, doc] = docSelection();
     return (
       <Wrapper>
-        <DocumentPreview
-          document={doc}
-          file={file}
-          onPreviewStateChange={action('preview-state-change')}
-        />
+        <DocumentPreview document={doc} file={file} onChange={action('change')} />
       </Wrapper>
     );
   })
@@ -47,7 +43,7 @@ storiesOf('DocumentPreview', module)
           document={docWithPassage}
           highlight={highlight}
           file={file}
-          onPreviewStateChange={action('preview-state-change')}
+          onChange={action('change')}
         />
       </Wrapper>
     );
@@ -63,7 +59,7 @@ storiesOf('DocumentPreview', module)
           file={file}
           document={docWithTable}
           highlight={highlight}
-          onPreviewStateChange={action('preview-state-change')}
+          onChange={action('change')}
         />
       </Wrapper>
     );
@@ -110,7 +106,7 @@ storiesOf('DocumentPreview', module)
           <DocumentPreview
             document={docArtEffects}
             fileFetchTimeout={fileFetchTimeout}
-            onPreviewStateChange={action('preview-state-change')}
+            onChange={action('change')}
           />
         </SearchContext.Provider>
       </Wrapper>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.26, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.27, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.26
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.27
     "@ibm-watson/discovery-styles": ^1.5.0-beta.24
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?
This PR is to add `onPreviewStateChange` event to the `DocumentPreview` component so that its parent component can be notified with the preview state changes.

#### How do you test/verify these changes?
I added an storybook action to the DocumentPreview storybooks. Switch to the Actions tab in the bottom pane and see if the state change event is logged.
<img width="1095" alt="image" src="https://user-images.githubusercontent.com/19485344/157669446-b3fc4d82-ad09-41e3-9a85-669b9365f4bd.png">

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
