### PR TITLE
fix: fix page switching issue with PdfViewerWithHighlight

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
@@ -171,7 +171,7 @@ function useHighlightState({
 /**
  * Hook to move PDF page depending on active highlight
  */
-function useMovePageToActiveHighlight(
+export function useMovePageToActiveHighlight(
   page: number,
   activeHighlightPages: number[],
   activeIds: string[] | undefined,

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
@@ -25,6 +25,7 @@ import {
 } from '../PdfHighlight/utils/common/highlightUtils';
 import flatMap from 'lodash/flatMap';
 import uniq from 'lodash/uniq';
+import isEqual from 'lodash/isEqual';
 
 type Props = PdfViewerProps &
   HighlightProps & {
@@ -76,7 +77,12 @@ const PdfViewerWithHighlight: FC<Props> = ({
     activeIds,
     documentInfo
   });
-  const currentPage = useMovePageToActiveHighlight(page, state.activePages, setCurrentPage);
+  const currentPage = useMovePageToActiveHighlight(
+    page,
+    state.activePages,
+    state.activeIds,
+    setCurrentPage
+  );
 
   const highlightReady = !!documentInfo && !!renderedText;
   return (
@@ -168,6 +174,7 @@ function useHighlightState({
 function useMovePageToActiveHighlight(
   page: number,
   activeHighlightPages: number[],
+  activeIds: string[] | undefined,
   setPage: ((page: number) => any) | undefined
 ) {
   const [currentPage, setCurrentPage] = useState(page);
@@ -175,27 +182,30 @@ function useMovePageToActiveHighlight(
   // update current page when the 'page' is changed (i.e. user changes the page)
   const previousPageRef = useRef(page);
   useEffect(() => {
-    if (previousPageRef.current !== page && currentPage !== page) {
+    if (
+      previousPageRef.current !== page && // `page` is changed by user
+      currentPage !== page // `currentPage` is not same to the new `page`
+    ) {
       setCurrentPage(page);
     }
     previousPageRef.current = page;
   }, [currentPage, page]);
 
   // update the current page and invoke setPage when the page is changed by activating a highlight
-  const previousHighlightPageRef = useRef<number | undefined>();
+  const prevHighlightRef = useRef<{ activeHighlightPages?: number[]; activeIds?: string[] }>({});
   useEffect(() => {
-    const highlightPage = activeHighlightPages[0];
-    if (highlightPage == null || activeHighlightPages.includes(currentPage)) {
-      // do nothing when no highlight or the active highlight is on the current page
-      return;
+    if (activeHighlightPages.length > 0) {
+      if (
+        !isEqual(prevHighlightRef.current, { activeHighlightPages, activeIds }) && // active highlight is changed
+        !activeHighlightPages.includes(currentPage) // `currentPage` doesn't show active highlight page
+      ) {
+        const highlightPage = activeHighlightPages[0];
+        setCurrentPage(highlightPage);
+        setPage?.(highlightPage);
+      }
     }
-
-    if (previousHighlightPageRef.current !== highlightPage) {
-      previousHighlightPageRef.current = highlightPage;
-      setCurrentPage(highlightPage);
-      setPage?.(highlightPage);
-    }
-  }, [activeHighlightPages, currentPage, setPage]);
+    prevHighlightRef.current = { activeHighlightPages, activeIds };
+  }, [activeIds, activeHighlightPages, currentPage, setPage]);
 
   return currentPage;
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
@@ -174,8 +174,8 @@ function useHighlightState({
 export function useMovePageToActiveHighlight(
   page: number,
   activeHighlightPages: number[],
-  activeIds: string[] | undefined,
-  setPage: ((page: number) => any) | undefined
+  activeIds?: string[],
+  setPage?: (page: number) => any
 ) {
   const [currentPage, setCurrentPage] = useState(page);
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/__tests__/useMovePageToActiveHighlight.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/__tests__/useMovePageToActiveHighlight.test.ts
@@ -1,0 +1,111 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useMovePageToActiveHighlight } from '../PdfViewerWithHighlight';
+
+type HookProps = {
+  page?: number;
+  highlightPages?: number[];
+  activeIds?: string[] | undefined;
+  setPage?: ((page: number) => any) | undefined;
+};
+
+const EMPTY_ARRAY: never[] = [];
+
+describe('useMovePageToActiveHighlight', () => {
+  let setPage: any;
+
+  beforeEach(() => {
+    setPage = jest.fn();
+  });
+
+  function render(initialProps: HookProps = {}) {
+    return renderHook(
+      (props: HookProps) =>
+        useMovePageToActiveHighlight(
+          props.page ?? 1,
+          props.highlightPages ?? EMPTY_ARRAY,
+          props.activeIds ?? EMPTY_ARRAY,
+          props.setPage ?? setPage
+        ),
+      { initialProps }
+    );
+  }
+
+  describe('without having active highlight initially', () => {
+    it('returns the initial page', () => {
+      const rendered = render({ page: 3 });
+      expect(rendered.result.current).toBe(3); // page to render
+      expect(setPage).toBeCalledTimes(0); // set page shouldn't be called
+    });
+
+    it('returns the updated page after page is changed', () => {
+      const rendered = render({ page: 3 });
+
+      // update page (i.e. user changes the current page)
+      rendered.rerender({ page: 5 });
+      expect(rendered.result.current).toBe(5);
+      expect(setPage).toBeCalledTimes(0); // set page shouldn't be called
+    });
+
+    it('returns the active highlight page after active highlight is set', () => {
+      const rendered = render({ page: 3 });
+
+      // active highlight is set
+      rendered.rerender({ page: 3, highlightPages: [8] });
+      expect(rendered.result.current).toBe(8);
+      expect(setPage).toBeCalledTimes(1); // setPage should is called to to notify page change
+      expect(setPage).toBeCalledWith(8);
+    });
+  });
+
+  describe('with having active highlight', () => {
+    it('returns the page having the active highlight', () => {
+      const rendered = render({ page: 3, highlightPages: [5] });
+      expect(rendered.result.current).toBe(5); // page to render
+      expect(setPage).toBeCalledTimes(1); // setPage should is called to to notify page change
+      expect(setPage).toBeCalledWith(5);
+    });
+
+    it('returns the page after page is changed', () => {
+      const highlightPages = [5];
+      const rendered = render({ page: 5, highlightPages });
+
+      // update page (i.e. user changes the current page)
+      rendered.rerender({ page: 8, highlightPages });
+      expect(rendered.result.current).toBe(8);
+      expect(setPage).toBeCalledTimes(0);
+    });
+
+    it('returns the active highlight page after active highlight page is updated', () => {
+      const rendered = render({ page: 5, highlightPages: [5] });
+
+      // update active highlight's page
+      rendered.rerender({ page: 5, highlightPages: [8] });
+      expect(rendered.result.current).toBe(8);
+      expect(setPage).toBeCalledTimes(1);
+      expect(setPage).toBeCalledWith(8);
+    });
+
+    it('invokes setPage when active highlight id is updated and page change is necessary', () => {
+      const highlightPages = [5];
+      const activeIds1 = ['1'];
+      const activeIds2 = ['2'];
+      const activeIds3 = ['3'];
+      const rendered = render({ page: 5, highlightPages, activeIds: activeIds1 });
+
+      // change active highlight
+      rendered.rerender({ page: 5, highlightPages, activeIds: activeIds2 });
+      expect(rendered.result.current).toBe(5);
+      expect(setPage).toBeCalledTimes(0);
+
+      // move page
+      rendered.rerender({ page: 6, highlightPages, activeIds: activeIds2 });
+      expect(rendered.result.current).toBe(6);
+
+      // change active highlight
+      rendered.rerender({ page: 6, highlightPages, activeIds: activeIds3 });
+      expect(rendered.result.current).toBe(5);
+      expect(setPage).toBeCalledTimes(1);
+      expect(setPage).toBeCalledWith(5); // the page should get back to page 5
+    });
+  });
+});

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/__tests__/useMovePageToActiveHighlight.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/__tests__/useMovePageToActiveHighlight.test.ts
@@ -54,6 +54,11 @@ describe('useMovePageToActiveHighlight', () => {
       expect(rendered.result.current).toBe(8);
       expect(setPage).toBeCalledTimes(1); // setPage should is called to to notify page change
       expect(setPage).toBeCalledWith(8);
+
+      setPage.mockReset();
+      rendered.rerender({ page: 8, highlightPages: [8] }); // page updated by the setPage
+      expect(rendered.result.current).toBe(8);
+      expect(setPage).toBeCalledTimes(0);
     });
   });
 
@@ -63,6 +68,11 @@ describe('useMovePageToActiveHighlight', () => {
       expect(rendered.result.current).toBe(5); // page to render
       expect(setPage).toBeCalledTimes(1); // setPage should is called to to notify page change
       expect(setPage).toBeCalledWith(5);
+
+      setPage.mockReset();
+      rendered.rerender({ page: 5, highlightPages: [5] }); // page updated by the setPage
+      expect(rendered.result.current).toBe(5);
+      expect(setPage).toBeCalledTimes(0);
     });
 
     it('returns the page after page is changed', () => {
@@ -83,6 +93,11 @@ describe('useMovePageToActiveHighlight', () => {
       expect(rendered.result.current).toBe(8);
       expect(setPage).toBeCalledTimes(1);
       expect(setPage).toBeCalledWith(8);
+
+      setPage.mockReset();
+      rendered.rerender({ page: 8, highlightPages: [8] }); // page updated by the setPage
+      expect(rendered.result.current).toBe(8);
+      expect(setPage).toBeCalledTimes(0);
     });
 
     it('invokes setPage when active highlight id is updated and page change is necessary', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.27, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.28, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.27
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.28
     "@ibm-watson/discovery-styles": ^1.5.0-beta.24
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?
This PR is to fix the following issues related to page switching in PdfViewer with highlights.

- When PDF viewer is initially shown with active highlight, the first page change (for example,  by user's clicking on Next page button) is ignored
   - Fixed by improving logic of page change. The condition of setting page was wrong.
- Suppose that PDF viewer is initially shown with active highlight, and user moves the current page. When user tries to activate another highlight on the same page to the initially activated highlight, the newly activated highlight is not revealed. Instead, PDF viewer keep showing the same page. 
    - The internal logic tracked only page number of an active highlight. So it couldn't detect changes of active highlight  when the highlights are on the same page. Now the logic tracks active highlight ID as well to properly detect the changes.

#### How do you test/verify these changes?
I added a new storybook. I used the storybook to run the problematic scenario.
<img width="1482" alt="image" src="https://user-images.githubusercontent.com/19485344/157847830-c3a4af75-79dc-4c07-9559-f5dcf2a03503.png">

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
