### PR TITLE
fix: fix pdf text box mapping

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/MappingSourceTextProvider.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/MappingSourceTextProvider.ts
@@ -76,4 +76,11 @@ export class MappingSourceTextProvider {
   isBlank(text: string): boolean {
     return this.normalizer.isBlank(text);
   }
+
+  /**
+   * Cleanup the consumed text position history
+   */
+  resetHistory() {
+    this.provider.resetHistory();
+  }
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/TextProvider.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/TextProvider.ts
@@ -133,4 +133,11 @@ export class TextProvider {
     });
     this.history = validSpans.slice(0, MAX_HISTORY);
   }
+
+  /**
+   * Cleanup the consumed text position history
+   */
+  resetHistory() {
+    this.history = [];
+  }
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/__tests__/getTextBoxMapping.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/__tests__/getTextBoxMapping.test.ts
@@ -61,4 +61,35 @@ describe('getTextBoxMapping', () => {
     expect(normalized2?.cell).toBe(target.cellAt(1)); // mapped to 2nd cell in target
     expect(normalized2?.span).toEqual([0, 3]); // mapped to the span [0, 3] in the 2nd cell
   });
+
+  it('should map text after long match properly', () => {
+    const source = new SimpleTextLayout([
+      // text_mappings box
+      {
+        text: '1 abc def ghi jkl 2 abc def ghi jkl 3 abc def ghi jkl 4 abc def ghi jkl',
+        bbox: bbox(0, 0, 2, 4)
+      }
+    ]);
+    const target = new SimpleTextLayout([
+      // 1st line
+      { bbox: bbox(0, 0), text: '1 abc def ghi' },
+      { bbox: bbox(1, 0), text: 'jkl' },
+      // 2nd line
+      { bbox: bbox(0, 1), text: '2 abc def ghi' },
+      { bbox: bbox(1, 1), text: 'jkl' },
+      // 3nd line
+      { bbox: bbox(0, 2), text: '3 abc def ghi' },
+      { bbox: bbox(1, 2), text: 'jkl' },
+      // 4th line
+      { bbox: bbox(0, 3), text: '4 abc def ghi' },
+      { bbox: bbox(1, 3), text: 'jkl' }
+    ]);
+    const mapping = getTextBoxMappings(source, target);
+
+    // verify the mapping result of the 1st 'jkl' in the source
+    const result1 = mapping.apply(source.cellAt(0).getPartial([14, 17]));
+    expect(result1).toHaveLength(1);
+    const normalized1 = result1[0].cell?.getNormalized();
+    expect(normalized1?.cell).toBe(target.cellAt(1)); // mapped to first cell in target
+  });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/getTextBoxMapping.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textBoxMapping/getTextBoxMapping.ts
@@ -51,6 +51,7 @@ export function getTextBoxMappings<
         matchInSource.markAsMapped();
       }
     });
+    source.resetHistory();
   }
   return builder.toTextBoxMapping();
 }
@@ -176,6 +177,13 @@ class Source<SourceCell extends TextLayoutCell, TargetCell extends TextLayoutCel
         matchedSourceProvider.consume(matchedSourceSpan);
       }
     };
+  }
+
+  /**
+   * Cleanup history in sources to process text from the start
+   */
+  resetHistory() {
+    this.sourceProviders.forEach(provider => provider.resetHistory());
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.29, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.30, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.29
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.30
     "@ibm-watson/discovery-styles": ^1.5.0-beta.24
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?
This PR improve PDF highlighting.

1. 9b826479090c8e5c6c97f0612c4520d32f3d56a7 In some PDF, highlight location was wrong like following. In the image, the highlighted `10h00`  should be right below the `18h00`, but it isn't. This is because I improved highlighting by giving priority to longer matches in #313.
<img width="1003" alt="screenshot 2022-03-28 22 28 49" src="https://user-images.githubusercontent.com/19485344/160409019-e3ffb36f-88aa-49a4-b460-6468a89958f5.png">

The text box mapping logic manages text positions where text fragments are mapped recently. The positions are used to generate longer chunk of matches. But with the improvement, the mapping process is repeated. So, the logic tried to generate longer chunk based on the position information form the previous iteration. It made the wrong highlight location.

So, I fixed the logic to reset the position information after each iteration.
<img width="1003" alt="screenshot 2022-03-28 22 30 46" src="https://user-images.githubusercontent.com/19485344/160412198-87a9b256-3d73-4005-a391-4214399d9178.png">

2. a0a33241d805193eab8093b7418cf24ccceb8bce Sort TextContentItems from PDF by the order of bboxes in HTML.

#### How do you test/verify these changes?
- Test case added for 1
- Use Storybook to check if the change doesn't break the PDF highlighting

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
