### PR TITLE
feat: limit response size

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,12 @@
   },
   "rules": {
     "prettier/prettier": "error",
-    "no-only-tests/no-only-tests": "error"
+    "no-only-tests/no-only-tests": "error",
+    "react-hooks/exhaustive-deps": [
+      "warn",
+      {
+        "additionalHooks": "(useDeepCompareMemo|useDeepCompareCallback|useDeepCompareEffect)"
+      }
+    ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     + [Windows Only](#windows-only)
 - [Using Discovery Components in a React application](#using-discovery-components-in-a-react-application)
   * [Interacting with Discovery data in custom components](#interacting-with-discovery-data-in-custom-components)
+  * [Network performance](#network-performance)
+    + [Query 'return' parameter](#query-return-parameter)
   * [Optimize CSS](#optimize-css)
 - [Development](#development)
   * [Project structure](#project-structure)
@@ -336,6 +338,16 @@ const MyCustomComponent = () => {
 
 export default MyCustomComponent;
 ```
+
+### Network performance
+
+#### Query 'return' parameter
+
+By default, when querying a project (e.g. using `performSearch`), all of the document data for any matching documents is returned. Depending on the type of documents in your collection and how many are returned, the size of the reponse data can be quite large.
+
+To cut down on the size of the response, the [Discovery Query API](https://test.cloud.ibm.com/apidocs/discovery-data#query-request) allows you to set a list of fields in the `return` request body parameter. The documents returned will only contain those fields.
+
+If you use the `SearchResults` component, it updates the default search parameters to only request the document fields it needs to render results.
 
 ### Optimize CSS
 

--- a/examples/discovery-search-app/src/App.js
+++ b/examples/discovery-search-app/src/App.js
@@ -151,24 +151,24 @@ function PreviewPage() {
     fetchDocumentsResponseStore: { data: fetchDocumentResponse, isLoading }
   } = useContext(SearchContext);
   const { fetchDocuments, setSelectedResult } = useContext(SearchApi);
-  const [hasFetchedDocument, setHasFetchedDocument] = useState(false);
 
   const {
     document_id,
     result_metadata: { collection_id }
   } = selectedDocument;
+  const fullDocument = fetchDocumentResponse?.results?.find(
+    result =>
+      result.document_id === document_id && result.result_metadata.collection_id === collection_id
+  );
 
   // Fetch full document
   useEffect(() => {
-    if (!hasFetchedDocument) {
+    if (!fullDocument && !isLoading && document_id && collection_id) {
       // Note: Document IDs are unique within each collection, but not within project. Therefore,
       // to avoid returning the wrong document, we must also pass the collection ID.
       fetchDocuments(`document_id:${document_id}`, [collection_id], searchResponse);
-      setHasFetchedDocument(true);
     }
-  }, [document_id, collection_id, searchResponse, fetchDocuments, hasFetchedDocument]);
-
-  const fullDocument = fetchDocumentResponse?.results?.[0];
+  }, [document_id, collection_id, searchResponse, fetchDocuments, fullDocument, isLoading]);
 
   const tabs = [
     {

--- a/examples/discovery-search-app/src/App.js
+++ b/examples/discovery-search-app/src/App.js
@@ -107,38 +107,36 @@ function SearchPage() {
   } = useContext(SearchContext);
 
   return (
-    <main>
-      <div className="root">
-        <div className={`${settings.prefix}--search-app__nav-toolbar`}>
-          <p>Discovery React Components Example Search App</p>
+    <main className="root">
+      <div className={`${settings.prefix}--search-app__nav-toolbar`}>
+        <p>Discovery React Components Example Search App</p>
+      </div>
+      <div className={`${settings.prefix}--search-app__top-container ${settings.prefix}--grid`}>
+        <div className={`${settings.prefix}--row`}>
+          <div className={`${settings.prefix}--col-md-8`}>
+            {/* Carbon v11: change size value to "md" */}
+            <SearchInput light={true} size="lg" completionsCount={7} spellingSuggestions={true} />
+          </div>
         </div>
-        <div className={`${settings.prefix}--search-app__top-container ${settings.prefix}--grid`}>
-          <div className={`${settings.prefix}--row`}>
-            <div className={`${settings.prefix}--col-md-8`}>
-              {/* Carbon v11: change size value to "md" */}
-              <SearchInput light={true} size="lg" completionsCount={7} spellingSuggestions={true} />
-            </div>
+        <div
+          className={`${settings.prefix}--row ${settings.prefix}--search-app__facets-and-results`}
+        >
+          <div
+            className={`${settings.prefix}--col-md-2 ${settings.prefix}--search-app__facets-and-results__facets`}
+          >
+            <SearchFacets />
           </div>
           <div
-            className={`${settings.prefix}--row ${settings.prefix}--search-app__facets-and-results`}
+            className={`${settings.prefix}--col-md-6 ${settings.prefix}--search-app__facets-and-results__results`}
           >
-            <div
-              className={`${settings.prefix}--col-md-2 ${settings.prefix}--search-app__facets-and-results__facets`}
-            >
-              <SearchFacets />
-            </div>
-            <div
-              className={`${settings.prefix}--col-md-6 ${settings.prefix}--search-app__facets-and-results__results`}
-            >
-              {!isError ? <SearchResults /> : <p>An error occurred during search.</p>}
-            </div>
+            {!isError ? <SearchResults /> : <p>An error occurred during search.</p>}
           </div>
         </div>
-        <div className={`${settings.prefix}-grid ${settings.prefix}--search-app__pagination`}>
-          <div className={`${settings.prefix}--row`}>
-            <div className={`${settings.prefix}--col-md-8`}>
-              <ResultsPagination />
-            </div>
+      </div>
+      <div className={`${settings.prefix}-grid ${settings.prefix}--search-app__pagination`}>
+        <div className={`${settings.prefix}--row`}>
+          <div className={`${settings.prefix}--col-md-8`}>
+            <ResultsPagination />
           </div>
         </div>
       </div>

--- a/examples/discovery-search-app/src/app.scss
+++ b/examples/discovery-search-app/src/app.scss
@@ -34,7 +34,6 @@ h1 {
 // Search Page styles
 .#{$prefix}--search-app__top-container {
   background-color: $search-app-background-color;
-  max-height: 1500px;
   max-width: 1200px;
   padding: $spacing-06 $spacing-06 0 $spacing-06;
 }
@@ -114,6 +113,10 @@ h1 {
 
 // Document Preview Page styles
 .#{$prefix}--search-app--preview-page {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+
   .#{$prefix}--search-app__nav-toolbar,
   .#{$prefix}--preview-toolbar {
     height: $nav-toolbar-height;
@@ -143,6 +146,5 @@ h1 {
 
   .#{$prefix}--search-app__content {
     min-height: 0;
-    overflow-y: auto;
   }
 }

--- a/examples/discovery-search-app/src/app.scss
+++ b/examples/discovery-search-app/src/app.scss
@@ -129,6 +129,10 @@ h1 {
     top: $nav-toolbar-height;
   }
 
+  .#{$prefix}--loading-overlay {
+    background-color: unset;
+  }
+
   .#{$prefix}--search-app__tabs {
     flex: 0 0 auto;
   }

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -353,7 +353,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   useDeepCompareEffect(() => {
     setSearchResponse(overrideSearchResults);
-  }, [overrideSearchResults]);
+  }, [overrideSearchResults, setSearchResponse]);
 
   useDeepCompareEffect(() => {
     setSearchParameters(currentSearchParameters => {
@@ -363,11 +363,11 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
         ...deprecateReturnFields(overrideQueryParameters)
       };
     });
-  }, [projectId, overrideQueryParameters]);
+  }, [projectId, overrideQueryParameters, setSearchParameters]);
 
   useDeepCompareEffect(() => {
     setGlobalAggregationsResponse(overrideAggregationResults);
-  }, [overrideAggregationResults]);
+  }, [overrideAggregationResults, setGlobalAggregationsResponse]);
 
   useDeepCompareEffect(() => {
     setCollectionsResults(overrideCollectionsResults);
@@ -379,7 +379,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   useDeepCompareEffect(() => {
     setAutocompletions(overrideAutocompletionResults);
-  }, [overrideAutocompletionResults]);
+  }, [overrideAutocompletionResults, setAutocompletions]);
 
   useDeepCompareEffect(() => {
     setComponentSettings(overrideComponentSettings);
@@ -440,7 +440,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
         setAutocompletions(undefined);
       }
     },
-    [autocompletionOptions, projectId]
+    [autocompletionOptions, fetchAutocompletions, projectId, setAutocompletions]
   );
 
   const handleFetchAggregations = useCallback(

--- a/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/DiscoverySearch.tsx
@@ -353,7 +353,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   useDeepCompareEffect(() => {
     setSearchResponse(overrideSearchResults);
-  }, [overrideSearchResults, setSearchResponse]);
+  }, [overrideSearchResults]);
 
   useDeepCompareEffect(() => {
     setSearchParameters(currentSearchParameters => {
@@ -363,11 +363,11 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
         ...deprecateReturnFields(overrideQueryParameters)
       };
     });
-  }, [projectId, overrideQueryParameters, setSearchParameters]);
+  }, [projectId, overrideQueryParameters]);
 
   useDeepCompareEffect(() => {
     setGlobalAggregationsResponse(overrideAggregationResults);
-  }, [overrideAggregationResults, setGlobalAggregationsResponse]);
+  }, [overrideAggregationResults]);
 
   useDeepCompareEffect(() => {
     setCollectionsResults(overrideCollectionsResults);
@@ -379,7 +379,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
 
   useDeepCompareEffect(() => {
     setAutocompletions(overrideAutocompletionResults);
-  }, [overrideAutocompletionResults, setAutocompletions]);
+  }, [overrideAutocompletionResults]);
 
   useDeepCompareEffect(() => {
     setComponentSettings(overrideComponentSettings);
@@ -440,7 +440,7 @@ const DiscoverySearch: FC<DiscoverySearchProps> = ({
         setAutocompletions(undefined);
       }
     },
-    [autocompletionOptions, fetchAutocompletions, projectId, setAutocompletions]
+    [autocompletionOptions, projectId]
   );
 
   const handleFetchAggregations = useCallback(

--- a/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
+++ b/packages/discovery-react-components/src/components/DiscoverySearch/__tests__/DiscoverySearch.test.tsx
@@ -302,7 +302,13 @@ describe('DiscoverySearch', () => {
       const tree = (
         <SearchApi.Consumer>
           {({ fetchDocuments }) => (
-            <button onClick={() => fetchDocuments('document_id::bar', null)}>Action</button>
+            <button
+              onClick={() =>
+                fetchDocuments('document_id::bar', ['12345-12345-12345-12345'], undefined)
+              }
+            >
+              Action
+            </button>
           )}
         </SearchApi.Consumer>
       );
@@ -318,6 +324,7 @@ describe('DiscoverySearch', () => {
       expect(spy).toHaveBeenCalledWith({
         projectId: 'foo',
         filter: 'document_id::bar',
+        collection_ids: ['12345-12345-12345-12345'],
         aggregation: '',
         passages: {
           enabled: false

--- a/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__tests__/DocumentPreview.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, BoundFunction, GetByText, FindAllBy } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import omit from 'lodash/omit';
 import { NoAuthAuthenticator } from 'ibm-watson/auth';
 import DiscoveryV2 from 'ibm-watson/discovery/v2';

--- a/packages/discovery-react-components/src/components/SearchFacets/components/DynamicFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/DynamicFacets.tsx
@@ -45,7 +45,7 @@ export const DynamicFacets: FC<DynamicFacetsProps> = ({
 }) => {
   const handleOnCollapsibleFacetsGroupChange = (selectedFacets: SelectedFacet[]): void => {
     let updatedFacets = cloneDeep(dynamicFacets);
-    selectedFacets.map(({ selectedFacetKey, checked }) => {
+    selectedFacets.forEach(({ selectedFacetKey, checked }) => {
       const facetKeyIndex = dynamicFacets.findIndex(facet => facet.text === selectedFacetKey);
       if (facetKeyIndex > -1) {
         updatedFacets[facetKeyIndex].selected = checked;

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/CollapsibleFacetsGroup.tsx
@@ -101,7 +101,7 @@ export const CollapsibleFacetsGroup: FC<CollapsibleFacetsGroupProps> = ({
   if (hasCategories) {
     facetsByCategory[`${facetsLabel}`] = { categories: {} };
     if (isSelectableQueryTermAggregationResult(facets)) {
-      facets.map(result => {
+      facets.forEach(result => {
         const resultType = result!.aggregations![0].results![0].key;
         if (resultType in facetsByCategory[`${facetsLabel}`].categories) {
           facetsByCategory[`${facetsLabel}`].categories[`${resultType}`].facets.push({

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -115,12 +115,12 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
         // If this is in the Show more modal, we need to check the facet value's temporary selection value
         let facetSelected = !!facet.selected;
         if (tempSelectedFacets) {
-          tempSelectedFacets.find(({ selectedFacetKey, checked }) => {
+          tempSelectedFacets.every(({ selectedFacetKey, checked }) => {
             if (selectedFacetKey === facetText) {
               facetSelected = !!checked;
-              return true;
+              return false; // break from loop
             }
-            return false;
+            return true;
           });
         }
 

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FacetsGroups/MultiSelectFacetsGroup.tsx
@@ -118,7 +118,9 @@ export const MultiSelectFacetsGroup: FC<MultiSelectFacetsGroupProps> = ({
           tempSelectedFacets.find(({ selectedFacetKey, checked }) => {
             if (selectedFacetKey === facetText) {
               facetSelected = !!checked;
+              return true;
             }
+            return false;
           });
         }
 

--- a/packages/discovery-react-components/src/components/SearchFacets/components/FieldFacets.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/FieldFacets.tsx
@@ -58,7 +58,7 @@ export const FieldFacets: FC<FieldFacetsProps> = ({
 
   const handleOnFieldFacetsChange = (selectedFacets: SelectedFacet[]): void => {
     let updatedFacets = cloneDeep(allFacets);
-    selectedFacets.map(({ selectedFacetName, selectedFacetKey, checked }) => {
+    selectedFacets.forEach(({ selectedFacetName, selectedFacetKey, checked }) => {
       const facetsForNameIndex = getFacetsForNameIndex(selectedFacetName);
       if (facetsForNameIndex > -1) {
         const facetsForName = updatedFacets[facetsForNameIndex];

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -277,7 +277,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
  * Hook to update search parameters' `return` param with the fields
  * that are necessary to render this component.
  */
-function useUpdateQueryReturnParam({
+export function useUpdateQueryReturnParam({
   displaySettings,
   resultLinkField
 }: {
@@ -289,11 +289,10 @@ function useUpdateQueryReturnParam({
   } = useContext(SearchContext);
   const { setSearchParameters } = useContext(SearchApi);
 
-  const userReturnParam = parameters._return;
-
   useDeepCompareEffect(() => {
     const { bodyField, resultTitleField } = displaySettings;
     setSearchParameters((currentSearchParameters: DiscoveryV2.QueryParams) => {
+      const userReturnParam = currentSearchParameters._return;
       return {
         ...currentSearchParameters,
         _return: uniq(
@@ -307,7 +306,7 @@ function useUpdateQueryReturnParam({
         )
       };
     });
-  }, [displaySettings, parameters, resultLinkField, setSearchParameters, userReturnParam]);
+  }, [displaySettings, parameters, resultLinkField, setSearchParameters]);
 }
 
 export default withErrorBoundary(

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -177,7 +177,7 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
     if (!hasFetchedDocuments && tablesWithoutResults && tablesWithoutResults.length) {
       const filterString =
         'document_id::' + tablesWithoutResults.map(table => table.source_document_id).join('|');
-      const collections = compact(tablesWithoutResults.map(table => table.collection_id));
+      const collections = uniq(compact(tablesWithoutResults.map(table => table.collection_id)));
       fetchDocuments(filterString, collections, searchResponse || undefined);
       setHasFetchedDocuments(true);
     }

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -97,6 +97,15 @@ const BASE_QUERY_RETURN_FIELDS = [
   'result_metadata'
 ];
 
+/**
+ * Display search results as a column of tiles
+ *
+ * NOTE: This component will update the default search parameters in the current
+ * DiscoverySearch context (specifically the `return` param). This will make the
+ * response data smaller by only requesting the document fields which are necessary
+ * to render this component. If you need other document fields, you can do so by
+ * calling `setSearchParameters`.
+ */
 const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
   resultLinkField,
   resultLinkTemplate,

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -177,7 +177,8 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
     if (!hasFetchedDocuments && tablesWithoutResults && tablesWithoutResults.length) {
       const filterString =
         'document_id::' + tablesWithoutResults.map(table => table.source_document_id).join('|');
-      fetchDocuments(filterString, searchResponse);
+      const collections = compact(tablesWithoutResults.map(table => table.collection_id));
+      fetchDocuments(filterString, collections, searchResponse || undefined);
       setHasFetchedDocuments(true);
     }
   }, [searchResponse, fetchDocuments, hasFetchedDocuments]);

--- a/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/SearchResults.tsx
@@ -274,10 +274,8 @@ const SearchResults: React.FunctionComponent<SearchResultsProps> = ({
 };
 
 /**
- * Hook to update search parameters' `return` param with the minimal necessary fields
+ * Hook to update search parameters' `return` param with the fields
  * that are necessary to render this component.
- *
- * NOTE: This hook must be specified before any other use of `setSearchParameters`.
  */
 function useUpdateQueryReturnParam({
   displaySettings,

--- a/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -4,12 +4,20 @@ import { render, fireEvent, RenderResult } from '@testing-library/react';
 import {
   SearchContextIFC,
   searchResponseStoreDefaults,
-  fetchDocumentsResponseStoreDefaults
+  fetchDocumentsResponseStoreDefaults,
+  SearchApiIFC
 } from 'components/DiscoverySearch/DiscoverySearch';
 import { wrapWithContext } from 'utils/testingUtils';
-import SearchResults, { SearchResultsProps } from '../SearchResults';
+import SearchResults, { SearchResultsProps, useUpdateQueryReturnParam } from '../SearchResults';
 import { getByText as domGetByText } from '@testing-library/dom';
-import { QueryResult, QueryTableResult, ComponentSettingsResponse } from 'ibm-watson/discovery/v2';
+import {
+  QueryResult,
+  QueryTableResult,
+  ComponentSettingsResponse,
+  QueryParams
+} from 'ibm-watson/discovery/v2';
+import { renderHook } from '@testing-library/react-hooks';
+import { DisplaySettingsParams } from '../utils/getDisplaySettings';
 
 interface Setup {
   searchResults: RenderResult;
@@ -885,6 +893,75 @@ describe('<SearchResults />', () => {
           expect(searchResults.getByText('document passage text')).toBeInTheDocument();
         });
       });
+    });
+  });
+});
+
+describe('useUpdateQueryReturnParam', () => {
+  test('should update search parameters', async () => {
+    let searchParameters: QueryParams = {
+      ...searchResponseStoreDefaults.parameters,
+      _return: ['_extraReturnParam_']
+    };
+    const api: Partial<SearchApiIFC> = {
+      // @ts-ignore
+      setSearchParameters: (callback: (callback: QueryParams) => QueryParams) => {
+        searchParameters = callback(searchParameters);
+      }
+    };
+    const context: Partial<SearchContextIFC> = {
+      searchResponseStore: searchResponseStoreDefaults
+    };
+    let displaySettings: DisplaySettingsParams = {
+      resultTitleField: 'titleField',
+      bodyField: 'bodyField'
+    };
+
+    const wrapper = ({ children }: { children: any }) => wrapWithContext(children, api, context);
+
+    const { rerender } = renderHook(
+      () => useUpdateQueryReturnParam({ displaySettings, resultLinkField: 'linkField' }),
+      {
+        wrapper
+      }
+    );
+
+    expect(searchParameters).toEqual({
+      ...searchResponseStoreDefaults.parameters,
+      _return: expect.arrayContaining([
+        '_extraReturnParam_',
+        'document_id',
+        'document_passages',
+        'extracted_metadata.filename',
+        'extracted_metadata.title',
+        'highlight',
+        'result_metadata',
+        'bodyField',
+        'titleField',
+        'linkField'
+      ])
+    });
+
+    displaySettings = {
+      resultTitleField: 'filename',
+      bodyField: 'html'
+    };
+    rerender();
+
+    expect(searchParameters).toEqual({
+      ...searchResponseStoreDefaults.parameters,
+      _return: expect.arrayContaining([
+        '_extraReturnParam_',
+        'document_id',
+        'document_passages',
+        'extracted_metadata.filename',
+        'extracted_metadata.title',
+        'highlight',
+        'result_metadata',
+        'html',
+        'filename',
+        'linkField'
+      ])
     });
   });
 });

--- a/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -196,7 +196,7 @@ describe('<SearchResults />', () => {
           ({ searchResults } = setup({ queryResults, suggestedQuery }, componentProps));
           expect(
             searchResults.getByText((_, element) => {
-              return element.textContent === 'suggested';
+              return element?.textContent === 'suggested';
             })
           ).toBeInTheDocument();
         });
@@ -312,9 +312,9 @@ describe('<SearchResults />', () => {
 
     test('onUpdatePassageLength is called with the expected character count', () => {
       ({ setSearchParametersMock } = setup({}, componentProps));
-      expect(setSearchParametersMock).toBeCalledTimes(1);
+      expect(setSearchParametersMock).toBeCalledTimes(2);
       expect(setSearchParametersMock).toBeCalledWith(expect.any(Function));
-      const returnFunc = setSearchParametersMock.mock.calls[0][0];
+      const returnFunc = setSearchParametersMock.mock.calls[1][0];
       const returnValue = returnFunc();
       expect(returnValue).toEqual(
         expect.objectContaining({
@@ -331,7 +331,7 @@ describe('<SearchResults />', () => {
 
     test('onUpdatePassageLength is not called', () => {
       ({ setSearchParametersMock } = setup({}, componentProps));
-      expect(setSearchParametersMock).toBeCalledTimes(0);
+      expect(setSearchParametersMock).toBeCalledTimes(1);
     });
   });
 
@@ -448,7 +448,11 @@ describe('<SearchResults />', () => {
         test('fetchDocuments should be fired with the correct params', () => {
           ({ fetchDocumentsMock } = setup({ queryResults, tableResults }, componentProps));
           expect(fetchDocumentsMock).toBeCalledTimes(1);
-          expect(fetchDocumentsMock).toBeCalledWith('document_id::123', expect.any(Object));
+          expect(fetchDocumentsMock).toBeCalledWith(
+            'document_id::123',
+            ['collection_id'],
+            expect.any(Object)
+          );
         });
 
         describe('and the naturalLanguageQuery changes', () => {
@@ -549,7 +553,11 @@ describe('<SearchResults />', () => {
       test('searchClient.query should be fired with the correct params', () => {
         ({ fetchDocumentsMock } = setup({ queryResults, tableResults }));
         expect(fetchDocumentsMock).toBeCalledTimes(1);
-        expect(fetchDocumentsMock).toBeCalledWith('document_id::123|456', expect.any(Object));
+        expect(fetchDocumentsMock).toBeCalledWith(
+          'document_id::123|456',
+          ['collection_id'],
+          expect.any(Object)
+        );
       });
     });
   });

--- a/packages/discovery-react-components/src/components/SearchResults/utils/getDisplaySettings.ts
+++ b/packages/discovery-react-components/src/components/SearchResults/utils/getDisplaySettings.ts
@@ -1,7 +1,7 @@
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import get from 'lodash/get';
 
-interface DisplaySettingsParams {
+export interface DisplaySettingsParams {
   resultTitleField?: string;
   bodyField?: string;
   usePassages?: boolean;

--- a/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
+++ b/packages/discovery-react-components/src/utils/__tests__/useDataApi.test.tsx
@@ -61,6 +61,7 @@ class ErrorSearchClient extends BaseSearchClient {
     const error = new Error();
     error.message =
       'You have exceeded the number of daily queries allowed for your plan. You can resume requests after the daily reset.';
+    // @ts-ignore - `body` isn't a field on `Error`
     error.body = {
       status_code: 400,
       errors: [
@@ -699,6 +700,7 @@ describe('useSearchResultsApi', () => {
 });
 
 describe('useFetchDocumentsApi', () => {
+  const collectionId = '12345-12345-12345-12345';
   interface TestFetchDocumentsStoreComponentProps {
     searchParameters?: DiscoveryV2.QueryParams;
     searchClient?: SearchClient;
@@ -721,7 +723,9 @@ describe('useFetchDocumentsApi', () => {
       <>
         <button
           data-testid="fetchDocuments"
-          onClick={e => fetchDocumentsApi.fetchDocuments(e.currentTarget.value || '', callback)}
+          onClick={e =>
+            fetchDocumentsApi.fetchDocuments(e.currentTarget.value || '', [collectionId], callback)
+          }
         />
         <div data-testid="fetchDocumentsStore">{JSON.stringify(fetchDocumentsStore)}</div>
       </>
@@ -795,6 +799,7 @@ describe('useFetchDocumentsApi', () => {
       fireEvent.click(fetchDocumentsButton, { target: { value: 'filter_string' } });
       expect(checkParametersMock).toHaveBeenCalledWith({
         projectId: 'foo',
+        collection_ids: ['12345-12345-12345-12345'],
         _return: [],
         aggregation: '',
         passages: {},

--- a/packages/discovery-react-components/src/utils/useDataApi.ts
+++ b/packages/discovery-react-components/src/utils/useDataApi.ts
@@ -200,7 +200,7 @@ export interface FieldsStoreActions {
 
 /**
  * Concrete usage of the useDataApi helper method for fetching project fields
- * @param searchParameters - initial search parameters to set
+ * @param fetchFieldsParams - initial search parameters to set
  * @param searchClient - search client used to perform requests
  * @return a 2-element array containing the fields store data and fields-specific store actions
  */
@@ -282,8 +282,8 @@ export const useSearchResultsApi = (
     searchClient,
     overrideSearchResults
   );
-  const setSearchParameters = useCallback(
-    (backwardsCompatibleSearchParameters: React.SetStateAction<DiscoveryV2.QueryParams>) => {
+  const setSearchParameters: SearchResponseStoreActions['setSearchParameters'] = useCallback(
+    backwardsCompatibleSearchParameters => {
       // if backwardsCompatibleSearchParameters is a function, we cannot modify the parameters, call it with previous state
       if (typeof backwardsCompatibleSearchParameters === 'function') {
         setSearchParametersBackwardsCompatible(prevState => {
@@ -303,8 +303,8 @@ export const useSearchResultsApi = (
 
   // callback can be passed in here to return back data to the invoker of the search
   // in the specific case here, we need to set our aggregation store after performing a search
-  const performSearch = useCallback(
-    (callback?: (result: any) => void): void => setFetchToken({ trigger: true, callback }),
+  const performSearch: SearchResponseStoreActions['performSearch'] = useCallback(
+    callback => setFetchToken({ trigger: true, callback }),
     [setFetchToken]
   );
 
@@ -376,29 +376,25 @@ export const useGlobalAggregationsApi = (
     (result: DiscoveryV2.QueryResponse) => result.aggregations || []
   );
 
-  const fetchGlobalAggregations = useCallback(
-    (
-      searchParameters: DiscoveryV2.QueryParams,
-      callback?: (result: DiscoveryV2.QueryAggregation[]) => void
-    ): void => {
-      setGlobalAggregationParameters(searchParameters);
-      setFetchToken({ trigger: true, callback });
-    },
-    [setFetchToken, setGlobalAggregationParameters]
-  );
+  const fetchGlobalAggregations: GlobalAggregationsStoreActions['fetchGlobalAggregations'] =
+    useCallback(
+      (searchParameters, callback) => {
+        setGlobalAggregationParameters(searchParameters);
+        setFetchToken({ trigger: true, callback });
+      },
+      [setFetchToken, setGlobalAggregationParameters]
+    );
 
   // allow us to chain the result without storing in our reducer state
   // used alongside the fetchTypeForTopEntitiesAggregation
-  const fetchGlobalAggregationsWithoutStoring = useCallback(
-    (
-      searchParameters: DiscoveryV2.QueryParams,
-      callback?: (result: DiscoveryV2.QueryAggregation[]) => void
-    ): void => {
-      setGlobalAggregationParameters(searchParameters);
-      setFetchToken({ trigger: true, callback, storeResult: false });
-    },
-    [setFetchToken, setGlobalAggregationParameters]
-  );
+  const fetchGlobalAggregationsWithoutStoring: GlobalAggregationsStoreActions['fetchGlobalAggregationsWithoutStoring'] =
+    useCallback(
+      (searchParameters, callback) => {
+        setGlobalAggregationParameters(searchParameters);
+        setFetchToken({ trigger: true, callback, storeResult: false });
+      },
+      [setFetchToken, setGlobalAggregationParameters]
+    );
 
   return [
     {
@@ -429,7 +425,11 @@ export interface FetchDocumentsActions {
   /**
    * method used to invoke the search request with a callback to return the response data
    */
-  fetchDocuments: (filter: string, callback: (result: DiscoveryV2.QueryResponse) => void) => void;
+  fetchDocuments: (
+    filter: string,
+    collections: string[],
+    callback: (result: DiscoveryV2.QueryResponse) => void
+  ) => void;
 }
 
 /**
@@ -452,10 +452,10 @@ export const useFetchDocumentsApi = (
     searchClient
   );
 
-  const fetchDocuments = useCallback(
-    (filter: string, callback: (result: DiscoveryV2.QueryResponse) => void): void => {
+  const fetchDocuments: FetchDocumentsActions['fetchDocuments'] = useCallback(
+    (filter, collections, callback) => {
       setSearchParameters((currentSearchParameters: DiscoveryV2.QueryParams) => {
-        return { ...currentSearchParameters, filter };
+        return { ...currentSearchParameters, filter, collection_ids: collections };
       });
       setFetchToken({ trigger: true, callback });
     },
@@ -514,8 +514,8 @@ export const useAutocompleteApi = (
     overrideAutocompletions
   );
 
-  const fetchAutocompletions = useCallback(
-    (autocompleteParameters: DiscoveryV2.GetAutocompletionParams): void => {
+  const fetchAutocompletions: AutocompleteActions['fetchAutocompletions'] = useCallback(
+    autocompleteParameters => {
       setAutocompleteParameters(autocompleteParameters);
       setFetchToken({ trigger: true });
     },

--- a/packages/discovery-react-components/src/utils/useDeepCompareMemoize.ts
+++ b/packages/discovery-react-components/src/utils/useDeepCompareMemoize.ts
@@ -27,6 +27,7 @@ export function useDeepCompareCallback<T extends (...args: any[]) => any>(
 ): T {
   return useCallback(callback, useDeepCompareMemoize(dependencies));
 }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function useDeepCompareEffect(callback: EffectCallback, dependencies: readonly any[]): void {
   useEffect(callback, useDeepCompareMemoize(dependencies));

--- a/packages/discovery-styles/package.json
+++ b/packages/discovery-styles/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "node-sass --importer=../../node_modules/node-sass-tilde-importer --source-map=true scss/index.scss css/index.css",
     "prepublish": "yarn run build",
-    "start": "yarn run build -- --watch",
+    "start": "yarn run build --watch",
     "analyze": "yarn run g:analyze css/index.css",
     "update-styles-from-pdfjs": "scripts/update-styles-from-pdfjs.sh"
   },

--- a/packages/discovery-styles/scss/components/ci-document/_ci-document.scss
+++ b/packages/discovery-styles/scss/components/ci-document/_ci-document.scss
@@ -3,6 +3,7 @@
   flex-flow: column;
   height: 100%;
   min-width: 800px;
+  background-color: $ui-background;
 
   .#{$prefix}--ci-doc__toolbar {
     width: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^1.5.0-beta.29, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^1.5.0-beta.30, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^1.5.0-beta.29
+    "@ibm-watson/discovery-react-components": ^1.5.0-beta.30
     "@ibm-watson/discovery-styles": ^1.5.0-beta.24
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

Update `SearchResults` component to update the search parameters and limit the size of the response, to only what is needed to render `SearchResults`.
Update `fetchDocuments()` to take collection ID argument. Fix how response is merged into search store response.
Fix some eslint warnings.

#### How do you test/verify these changes?

Run example app and run a blank search. Note the size of the `/query` response before and after. Ensure that loading a document shows all document data.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

Yes. See comments below.
