### PR TITLE
fix: Mitigate some pagination issues in search results

### DIFF
--- a/examples/discovery-search-app/cypress/fixtures/query/tableResults.json
+++ b/examples/discovery-search-app/cypress/fixtures/query/tableResults.json
@@ -124,18 +124,24 @@
     },
     {
       "table_id": "TABLE_1",
-      "source_document_id": "DOCUMENT_2",
+      "source_document_id": "DOCUMENT_1",
       "collection_id": "COLLECTION_ID_0",
       "table_html": "<table style='width:100%'><tr><th>Col A</th><th>Col B</th></tr><tr><td>Learning</td><td>You should be able to see this table</td></table>"
     },
     {
       "table_id": "TABLE_2",
-      "source_document_id": "DOCUMENT_2",
+      "source_document_id": "DOCUMENT_1",
       "collection_id": "COLLECTION_ID_0",
       "table_html": "<table style='width:100%'><tr><th>Col A</th><th>Col B</th></tr><tr><td>Learning</td><td>You should NOT be able to see this table</td></table>"
     },
     {
       "table_id": "TABLE_3",
+      "source_document_id": "DOCUMENT_2",
+      "collection_id": "COLLECTION_ID_0",
+      "table_html": "<table style='width:100%'><tr><th>Col A</th><th>Col B</th></tr><tr><td>Learning</td><td>You should ONLY see this table when tables-only results are shown.</td></table>"
+    },
+    {
+      "table_id": "TABLE_4",
       "source_document_id": "DOCUMENT_3",
       "collection_id": "COLLECTION_ID_0",
       "table_html": "<table style='width:100%'><tr><th>Col A</th><th>Col B</th></tr><tr><td>Learning</td><td>This table has an accompanying passage</td></table>"

--- a/examples/discovery-search-app/cypress/fixtures/query/tableResults.json
+++ b/examples/discovery-search-app/cypress/fixtures/query/tableResults.json
@@ -106,6 +106,33 @@
           "field": "text"
         }
       ]
+    },
+    {
+      "document_id": "DOCUMENT_4",
+      "result_metadata": {
+        "collection_id": "COLLECTION_ID_0",
+        "document_retrieval_source": "search",
+        "confidence": 0.05678
+      },
+      "text": ["This document is just basic text."],
+      "enriched_text": [],
+      "metadata": {
+        "parent_document_id": "PARENT_DOCUMENT_ID_0"
+      },
+      "extracted_metadata": {
+        "sha1": "C430CF959216D050CA8C077B6372F78B804E0E7D",
+        "numPages": "1",
+        "filename": "basic.pdf",
+        "file_type": "structure"
+      },
+      "document_passages": [
+        {
+          "passage_text": "This document is just basic text.",
+          "start_offset": 0,
+          "end_offset": 35,
+          "field": "text"
+        }
+      ]
     }
   ],
   "table_results": [

--- a/examples/discovery-search-app/cypress/integration/tables/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/tables/spec.ts
@@ -46,8 +46,8 @@ describe('Table Results', () => {
       cy.get('label').contains('Show table results only').click();
 
       // only the results with tables are displayed and the toggle is marked on
-      cy.get('.bx--search-result').should('have.length', 4);
-      cy.get('.bx--search-result').filter(':contains(table)').should('have.length', 4);
+      cy.get('.bx--search-result').should('have.length', 5);
+      cy.get('.bx--search-result').filter(':contains(table)').should('have.length', 5);
       cy.get('.bx--search-result')
         .contains(
           'This result multiple passages, but you should only be able to see the first one.'
@@ -57,12 +57,15 @@ describe('Table Results', () => {
       cy.get('.bx--search-result')
         .contains('This result has passages and a table.')
         .should('not.exist');
+      cy.get('table')
+        .contains('You should ONLY see this table when tables-only results are shown.')
+        .should('exist');
       cy.get('.bx--toggle-input__label').contains('On').should('exist');
 
       // "show table results only" is toggled back off
       cy.get('label').contains('Show table results only').click();
 
-      // all of the results are displayed
+      // all of the passage results are displayed
       cy.get('.bx--search-result').should('have.length', 4);
       cy.get('.bx--search-result').filter(':contains(table)').should('have.length', 3);
       cy.get('.bx--search-result')

--- a/examples/discovery-search-app/cypress/integration/tables/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/tables/spec.ts
@@ -12,18 +12,20 @@ describe('Table Results', () => {
   describe('When entering a query whose results contain tables', () => {
     it('should show expected results and toggle tables on/off', () => {
       cy.get('.bx--search-input').type('learning{enter}');
+      cy.get('.bx--search-result').should('have.length', 3);
 
       // SearchResults displays ONLY the first table of the results that have tables
       cy.get('table').contains('You should be able to see this table').should('exist');
+      cy.get('table').contains('This table has an accompanying passage').should('exist');
       cy.get('.bx--search-result')
         .contains('You should NOT be able to see this table')
         .should('not.exist');
-      cy.get('.bx--search-result').contains('Supervised Learning').should('exist');
+      cy.get('.bx--search-result').contains('Supervised Learning').should('not.exist');
 
       // each result with a table has a link to view table in document
       cy.findAllByTestId('search-result-element-preview-button')
         .filter(':contains("View table in document")')
-        .should('have.length', 3);
+        .should('have.length', 2);
 
       // when clicking on "View table in document" for a result
       cy.findAllByTestId('search-result-element-preview-button')
@@ -33,14 +35,18 @@ describe('Table Results', () => {
       // navigates to Document Preview for that document
       cy.get('p').contains('Document').should('exist');
       cy.get('.bx--document-preview').should('exist');
-      cy.get('.bx--document-preview').contains('Supervised Learning').should('exist');
+      cy.get('.bx--document-preview')
+        .contains(
+          'This result multiple passages, but you should only be able to see the first one.'
+        )
+        .should('exist');
 
       // clicking on the close preview button
       cy.findByLabelText('Back to search').click();
 
       // closes the document preview
       cy.get('.bx--document-preview').should('not.exist');
-      cy.get('.bx--search-result').should('have.length', 4);
+      cy.get('.bx--search-result').should('have.length', 3);
 
       // "show table results only" is toggled on
       cy.get('label').contains('Show table results only').click();
@@ -66,8 +72,8 @@ describe('Table Results', () => {
       cy.get('label').contains('Show table results only').click();
 
       // all of the passage results are displayed
-      cy.get('.bx--search-result').should('have.length', 4);
-      cy.get('.bx--search-result').filter(':contains(table)').should('have.length', 3);
+      cy.get('.bx--search-result').should('have.length', 3);
+      cy.get('.bx--search-result').filter(':contains(table)').should('have.length', 2);
       cy.get('.bx--search-result')
         .contains(
           'This result multiple passages, but you should only be able to see the first one.'

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -22,7 +22,7 @@ import { formatMessage } from 'utils/formatMessage';
 /**
  * A pagination component to allow users to navigate through multiple pages of results
  *
- * Returns a reset function via the `resetRef` prop that resets the component to page 1.
+ * Externalizes a reset function through an imperative API (via the `ref` prop) that resets the component to page 1.
  */
 
 export interface ResultsPaginationProps {
@@ -51,9 +51,9 @@ export interface ResultsPaginationProps {
    */
   onChange?: (e: ResultsPaginationEvent) => void;
   /**
-   * ref passed in by parent that can be used to reset the pagination component back to page 1
+   * Reference to imperative API
    */
-  resetRef?: ForwardedRef<any>;
+  ref?: ForwardedRef<ResultsPaginationAPI>;
   /**
    * Additional props to be passed into Carbon's Pagination component
    */
@@ -64,6 +64,10 @@ export interface ResultsPaginationProps {
 interface ResultsPaginationEvent {
   page: number;
   pageSize: number;
+}
+
+export interface ResultsPaginationAPI {
+  reset: (options: ResetOptions) => void;
 }
 
 interface ResetOptions {
@@ -77,7 +81,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
   showPageSizeSelector = true,
   messages = defaultMessages,
   onChange,
-  resetRef,
+  ref,
   ...inputProps
 }) => {
   const mergedMessages = { ...defaultMessages, ...messages };
@@ -130,7 +134,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
 
   // Externalize the reset function to a ref that the parent can send in,
   // so that it can also reset the pagination as desired
-  useImperativeHandle(resetRef, () => ({ reset }));
+  useImperativeHandle(ref, () => ({ reset }));
 
   useEffect(() => {
     if (!!pageSize || !!resultsPerPage) {
@@ -231,5 +235,5 @@ const ResultsPaginationWithBoundary = withErrorBoundary<ResultsPaginationProps>(
   onErrorCallback
 );
 export default forwardRef<any, ResultsPaginationProps>((props, ref) => {
-  return <ResultsPaginationWithBoundary {...props} resetRef={ref} />;
+  return <ResultsPaginationWithBoundary {...props} ref={ref} />;
 });

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -19,6 +19,12 @@ import onErrorCallback from 'utils/onErrorCallback';
 import { defaultMessages, Messages } from './messages';
 import { formatMessage } from 'utils/formatMessage';
 
+/**
+ * A pagination component to allow users to navigate through multiple pages of results
+ *
+ * Returns a reset function via the `resetRef` prop that resets the component to page 1.
+ */
+
 export interface ResultsPaginationProps {
   /**
    * The current page
@@ -45,7 +51,7 @@ export interface ResultsPaginationProps {
    */
   onChange?: (e: ResultsPaginationEvent) => void;
   /**
-   * ref passed in by parent that can be used to reset Carbon's pagination component
+   * ref passed in by parent that can be used to reset the pagination component back to page 1
    */
   resetRef?: ForwardedRef<any>;
   /**
@@ -112,6 +118,8 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
   const reset = useCallback(
     ({ triggerOnChange }: ResetOptions) => {
       setCurrentPage(1);
+      // This is structured as a counter so that the `key` prop of the Carbon pagination component
+      // updates (triggering a full re-render) in a simple and performant manner
       setResetCounter(resetCounter + 1);
       if (triggerOnChange) {
         handleOnChange({ page: 1, pageSize: resultsPerPage });

--- a/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
@@ -116,20 +116,6 @@ describe('ResultsPaginationComponent', () => {
         pageSize: 20
       });
     });
-
-    test('will add pageSize as a pageSize selection if it is not already included', async () => {
-      const { getByText } = await setup(
-        { pageSize: 25, pageSizes: [10, 20, 30, 40, 50] },
-        {
-          searchResponseStore: {
-            ...searchResponseStoreDefaults,
-            parameters: { projectId: '', count: 25 }
-          }
-        }
-      );
-
-      expect(getByText('25')).toBeInTheDocument();
-    });
   });
 
   describe('when there are component settings available', () => {

--- a/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/__tests__/ResultsPagination.test.tsx
@@ -118,48 +118,6 @@ describe('ResultsPaginationComponent', () => {
     });
   });
 
-  describe('when there are component settings available', () => {
-    describe('and there are no display parameters passed on ResultsPagination', () => {
-      test('will update the count search param', async () => {
-        const { setSearchParametersMock, rerender, fullTree } = await setup(
-          {},
-          { componentSettings: { results_per_page: 30 } }
-        );
-
-        rerender(fullTree);
-        expect(setSearchParametersMock).toBeCalledTimes(1);
-        expect(setSearchParametersMock).toBeCalledWith(expect.any(Function));
-        const returnFunc = setSearchParametersMock.mock.calls[0][0];
-        const returnValue = returnFunc();
-        expect(returnValue).toEqual(
-          expect.objectContaining({
-            count: 30
-          })
-        );
-      });
-    });
-
-    describe('and there are some display parameters passed on ResultsPagination', () => {
-      test('will update the count search param', async () => {
-        const { setSearchParametersMock, rerender, fullTree } = await setup(
-          { pageSize: 18 },
-          { componentSettings: { results_per_page: 30 } }
-        );
-
-        rerender(fullTree);
-        expect(setSearchParametersMock).toBeCalledTimes(1);
-        expect(setSearchParametersMock).toBeCalledWith(expect.any(Function));
-        const returnFunc = setSearchParametersMock.mock.calls[0][0];
-        const returnValue = returnFunc();
-        expect(returnValue).toEqual(
-          expect.objectContaining({
-            count: 18
-          })
-        );
-      });
-    });
-  });
-
   describe('i18n messages', () => {
     describe('when default messages are used and not overridden', () => {
       describe('itemRangeText', () => {

--- a/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -734,9 +734,9 @@ describe('<SearchResults />', () => {
           componentProps.showTablesOnly = false;
         });
 
-        test('tableHtml and not empty state text should be displayed', () => {
+        test('no result should be displayed', () => {
           ({ searchResults } = setup({ queryResults, tableResults }, componentProps));
-          expect(searchResults.getByText('I am table.')).toBeInTheDocument();
+          expect(searchResults.queryByText('I am table.')).toBe(null);
           expect(searchResults.queryByText('Excerpt unavailable.')).toBe(null);
           expect(searchResults.queryByText('View document')).toBe(null);
         });

--- a/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -122,7 +122,7 @@ describe('<SearchResults />', () => {
       describe('when no messages are provided', () => {
         describe('has the correct default placeholder text', () => {
           test('for search results with passages, tables, and empty results', () => {
-            ({ searchResults } = setup({ queryResults, tableResults }));
+            ({ searchResults } = setup({ queryResults, tableResults }, componentProps));
             const collectionLabel = searchResults.getByText('Collection:', { exact: false });
             const viewExcerptInDocumentButtonText = searchResults.getByText(
               'View passage in document'
@@ -139,7 +139,7 @@ describe('<SearchResults />', () => {
 
           test('for no search results found state', () => {
             queryResults = [];
-            ({ searchResults } = setup({ queryResults }));
+            ({ searchResults } = setup({ queryResults }, componentProps));
             expect(searchResults.getByText('There were no results found')).toBeDefined();
           });
         });
@@ -181,7 +181,7 @@ describe('<SearchResults />', () => {
       });
 
       test('renders the results', () => {
-        ({ searchResults } = setup({ queryResults }));
+        ({ searchResults } = setup({ queryResults }, componentProps));
         expect(searchResults.getByText('some document_id')).toBeInTheDocument();
       });
     });
@@ -191,7 +191,7 @@ describe('<SearchResults />', () => {
         queryResults = [];
       });
       test('renders the no results found message', () => {
-        ({ searchResults } = setup({ queryResults }));
+        ({ searchResults } = setup({ queryResults }, componentProps));
         expect(searchResults.getByText('There were no results found')).toBeInTheDocument();
       });
 
@@ -268,7 +268,7 @@ describe('<SearchResults />', () => {
       });
 
       test('renders the skeleton text', () => {
-        ({ searchResults } = setup({ searchResponseStoreOverrides }));
+        ({ searchResults } = setup({ searchResponseStoreOverrides }, componentProps));
         expect(searchResults.getAllByTestId('skeleton_text')).toHaveLength(3);
       });
 
@@ -281,7 +281,7 @@ describe('<SearchResults />', () => {
         });
 
         test('renders fewer skeleton text', () => {
-          ({ searchResults } = setup({ searchResponseStoreOverrides }));
+          ({ searchResults } = setup({ searchResponseStoreOverrides }, componentProps));
           expect(searchResults.getAllByTestId('skeleton_text')).toHaveLength(2);
         });
       });
@@ -295,7 +295,7 @@ describe('<SearchResults />', () => {
         });
 
         test('renders at most 3 skeleton text', () => {
-          ({ searchResults } = setup({ searchResponseStoreOverrides }));
+          ({ searchResults } = setup({ searchResponseStoreOverrides }, componentProps));
           expect(searchResults.getAllByTestId('skeleton_text')).toHaveLength(3);
         });
       });
@@ -307,7 +307,7 @@ describe('<SearchResults />', () => {
       });
 
       test('renders only the header', () => {
-        ({ searchResults } = setup({ searchResponseStoreOverrides }));
+        ({ searchResults } = setup({ searchResponseStoreOverrides }, componentProps));
         expect(searchResults.getAllByTestId('search_results_header')).toHaveLength(1);
       });
     });
@@ -559,7 +559,7 @@ describe('<SearchResults />', () => {
       });
 
       test('searchClient.query should be fired with the correct params', () => {
-        ({ fetchDocumentsMock } = setup({ queryResults, tableResults }));
+        ({ fetchDocumentsMock } = setup({ queryResults, tableResults }, componentProps));
         expect(fetchDocumentsMock).toBeCalledTimes(1);
         expect(fetchDocumentsMock).toBeCalledWith(
           'document_id::123|456',

--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -120,6 +120,11 @@ export const Result: React.FunctionComponent<ResultProps> = ({
   const hasText = displayedText && !showTablesOnlyResults;
   const emptyResultContent = !(hasText || tableHtml);
 
+  // Don't display tables-only results when displaying passages
+  if (!showTablesOnlyResults && tableHtml && !displayedText) {
+    return null;
+  }
+
   let title = getDocumentTitle(result, resultTitleField);
 
   if (Array.isArray(title)) {
@@ -213,11 +218,9 @@ export const Result: React.FunctionComponent<ResultProps> = ({
           {isLoading || !result ? (
             <SkeletonText width={'30%'} data-testid="result-title-skeleton" />
           ) : (
-            result && (
-              <div className={searchResultFooterTitleClass} title={title}>
-                {title}
-              </div>
-            )
+            <div className={searchResultFooterTitleClass} title={title}>
+              {title}
+            </div>
           )}
           {collectionName && (
             <div className={searchResultFooterCollectionNameClass} title={collectionName}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^2.0.4, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^2.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^2.0.4
+    "@ibm-watson/discovery-react-components": ^2.1.0
     "@ibm-watson/discovery-styles": ^2.0.1
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

- Only include each document once in filter string
- Allow pagination to be reset externally

##### BREAKING CHANGES:
- No longer display table-only results with passage results
- No longer add page size to pagination options (if it wasn't already included)
- Use count values exclusively (ignore results_per_page)


Contributes to [Watson-Discovery/disco-issue-tracker#4145](https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/4145)

#### How do you test/verify these changes?
Run example app or against tooling

#### Have you documented your changes (if necessary)?
TO BE ADDED

#### Are there any breaking changes included in this pull request?
Yes, see above.
