### PR TITLE
fix: render correct doc to show passage highlights

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -43,7 +43,7 @@ interface Props extends WithErrorBoundaryProps {
   loadingClassName?: string;
   /**
    * Passage or table to highlight in document. Reference to item with
-   * `document.document_passages` or `document.table_results`.
+   * `document.document_passages` or `searchResults.table_results`.
    */
   highlight?: QueryResultPassage | QueryTableResult;
   /**
@@ -188,8 +188,8 @@ function PreviewDocument({
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
   const previewType = useMemo(
-    () => (document ? detectPreviewType(document, file) : null),
-    [document, file]
+    () => (document ? detectPreviewType(document, highlight, file) : null),
+    [document, file, highlight]
   );
 
   if (!document) {

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -188,7 +188,7 @@ function PreviewDocument({
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
   const previewType = useMemo(
-    () => (document ? detectPreviewType(document, highlight, file) : null),
+    () => (document ? detectPreviewType(document, file, highlight) : null),
     [document, file, highlight]
   );
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/__tests__/documentData.test.ts
@@ -137,10 +137,10 @@ describe('documentData', () => {
         const previewType = detectPreviewType(
           {
             ...commonData,
-            extracted_metadata: { file_type: 'pdf' },
-            document_passages: [{ passage_text: 'passage' }]
+            extracted_metadata: { file_type: 'pdf' }
           },
-          'file'
+          'file',
+          { passage_text: 'passage' }
         );
         expect(previewType).toEqual('TEXT');
       });
@@ -178,12 +178,15 @@ describe('documentData', () => {
       });
 
       it('return TEXT when document does not have text_mappings but have passage_text', () => {
-        const previewType = detectPreviewType({
-          ...commonData,
-          extracted_metadata: { file_type: 'html' },
-          document_passages: [{ passage_text: 'passage' }],
-          html: '<html></html>'
-        });
+        const previewType = detectPreviewType(
+          {
+            ...commonData,
+            extracted_metadata: { file_type: 'html' },
+            html: '<html></html>'
+          },
+          undefined,
+          { passage_text: 'passage' }
+        );
         expect(previewType).toEqual('TEXT');
       });
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/utils/documentData.ts
@@ -44,8 +44,8 @@ export function isJsonFile(doc: QueryResult | null | undefined): boolean {
  */
 export function detectPreviewType(
   document: DiscoveryDocument,
-  highlight?: QueryResultPassage | QueryTableResult,
-  file?: DocumentFile
+  file?: DocumentFile,
+  highlight?: QueryResultPassage | QueryTableResult
 ): PreviewType {
   const fileType = document.extracted_metadata?.file_type;
   // passages contain location offsets against text-based strings (not HTML)


### PR DESCRIPTION
#### What do these changes do/fix?

Render TEXT when given an HTML file with passage to highlight (which only works on text, when there is no `text_mappings` to map to HTML-based offsets).

#### How do you test/verify these changes?

Run example app against a collection of web-crawled HTML files, where SDU model is default text-only.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->

---

#### To do:
- [ ] Update tests
- [ ] Add test to make sure we don't regress this in the future.