### PR TITLE
fix: add 'icp4d-api' path for auth url

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ yarn workspace discovery-search-app run start
      DISCOVERY_DISABLE_SSL=true
      ```
      where:
-     - `DISCOVERY_AUTH_URL` is the URL to your base CP4D installation (ex. `https://zen-25-cpd-zen-25.apps.my-cluster-name.com`)
+     - `DISCOVERY_AUTH_URL` is the URL to your base CP4D installation (ex. `https://zen-25-cpd-zen-25.apps.my-cluster-name.com`) plus the path `/icp4d-api` (ex. `https://zen-25-cpd-zen-25.apps.my-cluster-name.com/icp4d-api`)
      - `DISCOVERY_URL` is the API URL to your Discovery installation (ex. `https://zen-25-cpd-zen-25.apps.my-cluster-name.com/discovery/wd/instances/1578610482214/api`)
      - `DISCOVERY_USERNAME` the username used to login to `DISCOVERY_AUTH_URL`
      - `DISCOVERY_PASSWORD` the password used to login to `DISCOVERY_AUTH_URL`

--- a/runExampleApp.sh
+++ b/runExampleApp.sh
@@ -4,8 +4,8 @@ set -e
 
 PREREQUISITES=("yarn" "node")
 SCRIPT_DIR=$(
-    cd "$(dirname "$0")"
-    pwd
+  cd "$(dirname "$0")"
+  pwd
 )
 USE_FORMAT=$(
   type tput >/dev/null 2>&1
@@ -54,11 +54,11 @@ function checkForDependencies() {
     fi
 
     if [ $exists -ne 0 ]; then
-      (( missing+=1 ))
+      ((missing += 1))
     fi
   done
 
-  if [[ $missing > 0 ]]; then
+  if [[ $missing -gt 0 ]]; then
     echo
     echo "Not all prerequistes are installed." >&2
     exit 1
@@ -94,20 +94,20 @@ function updateEnvFile() {
     colorMessage "  https://zen-25-cpd-zen-25.apps.my-cluster-name.com" 3
     echo
     while [[ "$url" == "" ]]; do
-        read -p "  url: " url
+      read -p "  url: " url
     done
     echo "  Provide the credentials used to log into the CP4D dashboard."
     while [[ "$username" == "" ]]; do
-        read -p "  username: " username
+      read -p "  username: " username
     done
 
     while [[ "$password" == "" ]]; do
-        read -s -p "  password: " password
+      read -s -p "  password: " password
     done
 
-    cat > "$CREDENTIALS_FILE" <<EOL
+    cat >"$CREDENTIALS_FILE" <<EOL
 DISCOVERY_AUTH_TYPE=${authType}
-DISCOVERY_AUTH_URL=${url}
+DISCOVERY_AUTH_URL="${url}/icp4d-api"
 DISCOVERY_AUTH_DISABLE_SSL=true
 DISCOVERY_USERNAME=${username}
 DISCOVERY_PASSWORD=${password}
@@ -119,12 +119,12 @@ EOL
     colorMessage "  https://api.us-south.discovery.cloud.ibm.com/instances/1234" 3
     echo
     while [[ "$url" == "" ]]; do
-        read -p "  url: " url
+      read -p "  url: " url
     done
     while [[ "$apikey" == "" ]]; do
-        read -s -p "  apikey: " apikey
+      read -s -p "  apikey: " apikey
     done
-      cat > "$CREDENTIALS_FILE" <<EOL
+    cat >"$CREDENTIALS_FILE" <<EOL
 DISCOVERY_AUTH_TYPE=${authType}
 DISCOVERY_URL=${url}
 DISCOVERY_APIKEY=${apikey}
@@ -141,12 +141,12 @@ EOL
     read -p "  project_id: " projectId
   done
 
-  cat > "$ENV_LOCAL_FILE" <<EOL
+  cat >"$ENV_LOCAL_FILE" <<EOL
 REACT_APP_PROJECT_ID=${projectId}
 EOL
 
   if [ $OSTYPE == 'msys' ]; then
-    echo "SASS_PATH=\"../../node_modules;src\"" >> "$ENV_LOCAL_FILE"
+    echo "SASS_PATH=\"../../node_modules;src\"" >>"$ENV_LOCAL_FILE"
   fi
   echo
 }
@@ -204,5 +204,5 @@ colorMessage "done" 2
 
 read -p "$(paddedMessage 'Start the example app now (y/n)? ')" startServer
 if [[ "${startServer}" =~ ^(Y|y)$ ]]; then
-    yarn workspace discovery-search-app run start
+  yarn workspace discovery-search-app run start
 fi

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^2.0.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^2.0.3, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^2.0.2
+    "@ibm-watson/discovery-react-components": ^2.0.3
     "@ibm-watson/discovery-styles": ^2.0.1
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

CP4D now requires the base path `/icp4d-api` for the auth url

#### How do you test/verify these changes?

1. Run `./runExampleApp.sh` against a CP4D deployment
2. Follow the "Manual setup" instructions against a CP4D deployment

#### Have you documented your changes (if necessary)?

Yes: updated README

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
