### PR TITLE
fix: when nodes aren't found, warn in console rather than erroring

### DIFF
--- a/packages/discovery-react-components/src/utils/document/documentUtils.ts
+++ b/packages/discovery-react-components/src/utils/document/documentUtils.ts
@@ -31,10 +31,16 @@ export function findOffsetInDOM(
   let endNode = findContainingNodeWithin(parentNode, end);
 
   if (beginNode === null) {
-    throw new Error(`Failed to find a node containing the start of the highlight: ${begin}`);
+    beginNode = parentNode;
+    console.warn(
+      `Failed to find a node containing the start of the highlight: ${begin}. Using root node instead.`
+    );
   }
   if (endNode === null) {
-    throw new Error(`Failed to find a node containing the end of the highlight: ${end}`);
+    endNode = parentNode;
+    console.warn(
+      `Failed to find a node containing the end of the highlight: ${end}. Using root node instead.`
+    );
   }
 
   const { textNode: beginTextNode, textOffset: beginOffset } = getTextNodeAndOffset(


### PR DESCRIPTION
#### What do these changes do/fix?

- If offsets are not outside of parent node, set node to parent node
- Add console.warn with message about failing to find node.

#### How do you test/verify these changes?
Run tooling app locally linked with components repo. Run the following steps:

1. Create a Doc Retrieval project with Web Crawl collection against https://yarnpkg.com/ (take defaults for collection)
2. Do an empty search, which will find results for the page titles
3. Click View passage in document for one of these "title" results. Note that the document highlights correctly. Notice the warning in the console.

#### Have you documented your changes (if necessary)?
N/A

#### Are there any breaking changes included in this pull request?
N/A
