### PR TITLE
render textLayer optionally

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -47,7 +47,7 @@ interface Props extends WithErrorBoundaryProps {
    */
   highlight?: QueryResultPassage | QueryTableResult;
   /**
-   * disable textLayer if true
+   * Disable the text layer overlay when rendering PDF (defaults to `false`)
    */
   disableTextLayer?: boolean;
   /**

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -47,6 +47,10 @@ interface Props extends WithErrorBoundaryProps {
    */
   highlight?: QueryResultPassage | QueryTableResult;
   /**
+   * disable textLayer if true
+   */
+  disableTextLayer?: boolean;
+  /**
    * i18n messages for the component
    */
   messages?: Messages;
@@ -162,7 +166,10 @@ const DocumentPreview: FC<Props> = ({
 };
 
 interface PreviewDocumentProps
-  extends Pick<Props, 'document' | 'file' | 'highlight' | 'fallbackComponent'> {
+  extends Pick<
+    Props,
+    'document' | 'file' | 'highlight' | 'fallbackComponent' | 'disableTextLayer'
+  > {
   currentPage: number;
   scale: number;
   setPdfPageCount?: (count: number) => void;
@@ -184,6 +191,7 @@ function PreviewDocument({
   hideToolbarControls,
   setHideToolbarControls,
   highlight,
+  disableTextLayer,
   setCurrentPage,
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
@@ -209,6 +217,7 @@ function PreviewDocument({
           setHideToolbarControls={setHideToolbarControls}
           highlight={highlight}
           setCurrentPage={setCurrentPage}
+          disableTextLayer={disableTextLayer}
         />
       );
     case 'HTML':

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -61,7 +61,7 @@ const PdfViewer: FC<Props> = ({
   scale,
   document,
   textLayerClassName,
-  disableTextLayer,
+  disableTextLayer = false,
   setPageCount,
   setLoading,
   setHideToolbarControls,

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -32,6 +32,11 @@ type Props = PdfDisplayProps & {
   textLayerClassName?: string;
 
   /**
+   * disable textLayer if true
+   */
+  disableTextLayer?: boolean;
+
+  /**
    * Callback invoked with page count, once `file` has been parsed
    */
   setPageCount?: (count: number) => void;
@@ -56,6 +61,7 @@ const PdfViewer: FC<Props> = ({
   scale,
   document,
   textLayerClassName,
+  disableTextLayer,
   setPageCount,
   setLoading,
   setHideToolbarControls,
@@ -112,16 +118,22 @@ const PdfViewer: FC<Props> = ({
         <canvas
           ref={canvasRef}
           className={`${base}__canvas`}
-          style={{ width: `${canvasInfo?.width ?? 0}px`, height: `${canvasInfo?.height ?? 0}px` }}
+          style={{
+            width: `${canvasInfo?.width ?? 0}px`,
+            height: `${canvasInfo?.height ?? 0}px`,
+            transform: `scale(${scale})`
+          }}
           width={canvasInfo?.canvasWidth}
           height={canvasInfo?.canvasHeight}
         />
-        <PdfViewerTextLayer
-          className={cx(`${base}__text`, textLayerClassName)}
-          loadedPage={loadedPage}
-          scale={scale}
-          setRenderedText={setRenderedText}
-        />
+        {!disableTextLayer && (
+          <PdfViewerTextLayer
+            className={cx(`${base}__text`, textLayerClassName)}
+            loadedPage={loadedPage}
+            scale={scale}
+            setRenderedText={setRenderedText}
+          />
+        )}
         {children}
       </div>
     </div>

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -32,7 +32,7 @@ type Props = PdfDisplayProps & {
   textLayerClassName?: string;
 
   /**
-   * disable textLayer if true
+   * Disable the text layer overlay (defaults to `false`)
    */
   disableTextLayer?: boolean;
 


### PR DESCRIPTION
#### What do these changes do/fix?

<!--
If there's a related issue, please add a link to the issue here.
-->
- Implements the following [issue](https://github.ibm.com/watson-discovery/disco-issue-tracker/issues/11135)
- allows disabling `textLayer` rendering
#### How do you test/verify these changes?
- use `Storybook` within the issue it implements to verify that `textLayer` is NOT rendered 
- use `Storybook` within the `discovery-components` to verify that `textLayer` is rendered by default

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
