### PR TITLE
fix: revert to renaming ref prop with forwardRef and HOC

### DIFF
--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -53,7 +53,7 @@ export interface ResultsPaginationProps {
   /**
    * Reference to imperative API
    */
-  resetRef?: ForwardedRef<ResultsPaginationAPI>;
+  apiRef?: ForwardedRef<ResultsPaginationAPI>;
   /**
    * Additional props to be passed into Carbon's Pagination component
    */
@@ -81,7 +81,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
   showPageSizeSelector = true,
   messages = defaultMessages,
   onChange,
-  resetRef,
+  apiRef,
   ...inputProps
 }) => {
   const mergedMessages = { ...defaultMessages, ...messages };
@@ -134,7 +134,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
 
   // Externalize the reset function to a ref that the parent can send in,
   // so that it can also reset the pagination as desired
-  useImperativeHandle(resetRef, () => ({ reset }));
+  useImperativeHandle(apiRef, () => ({ reset }));
 
   useEffect(() => {
     if (!!pageSize || !!resultsPerPage) {
@@ -235,5 +235,5 @@ const ResultsPaginationWithBoundary = withErrorBoundary<ResultsPaginationProps>(
   onErrorCallback
 );
 export default forwardRef<any, ResultsPaginationProps>((props, ref) => {
-  return <ResultsPaginationWithBoundary {...props} resetRef={ref} />;
+  return <ResultsPaginationWithBoundary {...props} apiRef={ref} />;
 });

--- a/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
+++ b/packages/discovery-react-components/src/components/ResultsPagination/ResultsPagination.tsx
@@ -53,7 +53,7 @@ export interface ResultsPaginationProps {
   /**
    * Reference to imperative API
    */
-  ref?: ForwardedRef<ResultsPaginationAPI>;
+  resetRef?: ForwardedRef<ResultsPaginationAPI>;
   /**
    * Additional props to be passed into Carbon's Pagination component
    */
@@ -81,7 +81,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
   showPageSizeSelector = true,
   messages = defaultMessages,
   onChange,
-  ref,
+  resetRef,
   ...inputProps
 }) => {
   const mergedMessages = { ...defaultMessages, ...messages };
@@ -134,7 +134,7 @@ const ResultsPagination: FC<ResultsPaginationProps> = ({
 
   // Externalize the reset function to a ref that the parent can send in,
   // so that it can also reset the pagination as desired
-  useImperativeHandle(ref, () => ({ reset }));
+  useImperativeHandle(resetRef, () => ({ reset }));
 
   useEffect(() => {
     if (!!pageSize || !!resultsPerPage) {
@@ -235,5 +235,5 @@ const ResultsPaginationWithBoundary = withErrorBoundary<ResultsPaginationProps>(
   onErrorCallback
 );
 export default forwardRef<any, ResultsPaginationProps>((props, ref) => {
-  return <ResultsPaginationWithBoundary {...props} ref={ref} />;
+  return <ResultsPaginationWithBoundary {...props} resetRef={ref} />;
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^2.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2218,7 +2218,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^2.0.1, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^3.0.0, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10664,8 +10664,8 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^2.1.0
-    "@ibm-watson/discovery-styles": ^2.0.1
+    "@ibm-watson/discovery-react-components": ^3.0.0
+    "@ibm-watson/discovery-styles": ^3.0.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
     body-parser: ^1.19.0


### PR DESCRIPTION
#### What do these changes do/fix?

- rename the `ref` prop back to `resetRef` to allow it to be passed in properly
(Fix bug from https://github.com/watson-developer-cloud/discovery-components/pull/340#discussion_r922628853)

Contributes to [Watson-Discovery/disco-issue-tracker#4145](https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/4145)

#### How do you test/verify these changes?

Link to local tooling, make sure the resetRef prop is actually  getting populated (doesn't remain `undefined`).

#### Have you documented your changes (if necessary)?
Shouldn't need additional documentation.

#### Are there any breaking changes included in this pull request?
No.
