### PR TITLE
fix: change the facet query method to exact match

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -82,7 +82,7 @@ export class SearchFilterTransform {
       const results = get(facet, 'results', []);
       const keys = this.quoteSelectedFacets(results, 'key');
       if (keys.length) {
-        filterStrings.push(keys.map(key => `${escapeFieldName(field)}:${key}`).join('|'));
+        filterStrings.push(keys.map(key => `${escapeFieldName(field)}::${key}`).join('|'));
       }
     });
     return filterStrings.join(',');
@@ -96,7 +96,7 @@ export class SearchFilterTransform {
       .filter(result => result.selected)
       .map(result => {
         const text = get(result, key, '');
-        return `"${text.replace(/"/, '\\"')}"`;
+        return `${text.replace(/"/, '\\"')}`;
       });
   }
 }


### PR DESCRIPTION
#### What do these changes do/fix?

* Initially: searching returns no results when only facets are selected
![Web capture_18-7-2022_11411_localhost](https://user-images.githubusercontent.com/13806592/179576532-df5b90db-72f5-453a-898a-18c5ae21b5c3.jpeg)
    * Using contain match query 
![Screen Shot 2022-07-18 at 11 04 29 AM](https://user-images.githubusercontent.com/13806592/179576790-51bfe105-4e31-4e1d-84a8-eb2ee78c64bf.png)
* Fix: showing results when facets are selected
  ![Web capture_18-7-2022_11534_localhost](https://user-images.githubusercontent.com/13806592/179576931-e1d0e052-fa88-4574-82c8-392d8f65c6e4.jpeg)
    * Using exact match query
    ![Screen Shot 2022-07-18 at 11 05 45 AM](https://user-images.githubusercontent.com/13806592/179577028-3d3f1b16-953e-4b6d-9281-d27be3ddeb59.png)

Contributes to https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/12682

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
