### PR TITLE
fix: update tests from phrase query removal

### DIFF
--- a/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
@@ -37,7 +37,7 @@ describe('Dynamic Facets', () => {
     cy.get('label').contains('regression').click();
 
     // makes a query for the right facets
-    cy.wait('@postQueryFacetsSingle').its('requestBody.filter').should('eq', '"regression"');
+    cy.wait('@postQueryFacetsSingle').its('requestBody.filter').should('eq', '(regression)');
 
     // shows the bubble next to dynamic facets saying 1
     cy.get('.bx--tag--filter').contains('1').should('exist');
@@ -51,7 +51,7 @@ describe('Dynamic Facets', () => {
     // makes a query for both filters
     cy.wait('@postQueryMultiRefinement')
       .its('requestBody.filter')
-      .should('eq', '"regression","classification"');
+      .should('eq', '(regression),(classification)');
 
     // shows the bubble next to dynamic facets saying 2
     cy.get('.bx--tag--filter').contains('2').should('exist');
@@ -72,7 +72,7 @@ describe('Dynamic Facets', () => {
     cy.get('label').contains('regression').click();
 
     // makes a query without any selected facets
-    cy.wait('@postQueryFacets').its('requestBody.filter').should('eq', '"regression"');
+    cy.wait('@postQueryFacets').its('requestBody.filter').should('eq', '(regression)');
 
     // and a different filter is clicked from a different facet
     cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryDynamicAndNonDynamicJSON').as(
@@ -83,6 +83,6 @@ describe('Dynamic Facets', () => {
     // makes a query with both filters', () => {
     cy.wait('@postQueryDynamicAndNonDynamic')
       .its('requestBody.filter')
-      .should('eq', 'location:"Hancock, MN","regression"');
+      .should('eq', 'location:(Hancock\\, MN),(regression)');
   });
 });

--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -48,7 +48,7 @@ describe('Multi-Select Facets', () => {
       it('queries and selects the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:"Ames, IA"');
+          .should('eq', 'location:(Ames\\, IA)');
         cy.get('.bx--tag--filter').contains('1').should('exist');
       });
 
@@ -64,7 +64,7 @@ describe('Multi-Select Facets', () => {
         it('queries and selects the right facets', () => {
           cy.get('@multiFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Pittsburgh, PA"|location:"Ames, IA"');
+            .should('eq', 'location:(Pittsburgh\\, PA)|location:(Ames\\, IA)');
           cy.get('.bx--tag--filter').contains('2').should('exist');
         });
       });
@@ -115,7 +115,7 @@ describe('Multi-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Ames, IA",price:"Low"');
+            .should('eq', 'location:(Ames\\, IA),price:(Low)');
         });
 
         describe('and the selected filters bubble from only one of the facets is clicked', () => {
@@ -130,7 +130,7 @@ describe('Multi-Select Facets', () => {
           it('has the filters from only that facet clear', () => {
             cy.get('@amesFilterQueryObject')
               .its('requestBody.filter')
-              .should('eq', 'location:"Ames, IA"');
+              .should('eq', 'location:(Ames\\, IA)');
           });
         });
       });

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -47,7 +47,7 @@ describe('Single-Select Facets', () => {
       it('makes a query for the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:"Ames, IA"');
+          .should('eq', 'location:(Ames\\, IA)');
       });
 
       describe('and a different filter is selected from the same facet', () => {
@@ -62,7 +62,7 @@ describe('Single-Select Facets', () => {
         it('makes a query for only the new facet', () => {
           cy.get('@hancockFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Hancock, MN"');
+            .should('eq', 'location:(Hancock\\, MN)');
         });
       });
 
@@ -103,7 +103,7 @@ describe('Single-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Ames, IA",price:"Low"');
+            .should('eq', 'location:(Ames\\, IA),price:(Low)');
         });
       });
     });

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -274,7 +274,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'products:"assistant"'
+              filter: 'products:(assistant)'
             }),
             false
           );

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
@@ -99,7 +99,7 @@ describe('DynamicFacetsComponent', () => {
     });
 
     test('checkboxes are checked when set in filter query', async () => {
-      const { searchFacetsComponent } = setup({ filter: '"sam hinkie"' });
+      const { searchFacetsComponent } = setup({ filter: 'sam hinkie' });
       const saviorCheckbox = await searchFacetsComponent.findByLabelText('sam hinkie');
       expect(saviorCheckbox['checked']).toEqual(true);
     });
@@ -122,7 +122,7 @@ describe('DynamicFacetsComponent', () => {
 
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: '"trust the process"' });
+        setupData = setup({ filter: 'trust the process' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -152,7 +152,7 @@ describe('DynamicFacetsComponent', () => {
 
     describe('when 2 selections are made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: '"trust the process","just not the electrician"' });
+        setupData = setup({ filter: 'trust the process,just not the electrician' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -190,7 +190,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '"trust the process"'
+          filter: '(trust the process)'
         }),
         false
       );
@@ -208,7 +208,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '"maybe | not"'
+          filter: '(maybe \\| not)'
         }),
         false
       );
@@ -223,7 +223,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '"bogus, strings"'
+          filter: '(bogus\\, strings)'
         }),
         false
       );
@@ -238,7 +238,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '"this: is"'
+          filter: '(this\\: is)'
         }),
         false
       );
@@ -247,7 +247,7 @@ describe('DynamicFacetsComponent', () => {
 
     test('it adds correct filters when second checkbox is checked', async () => {
       const { searchFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: '"sam hinkie"'
+        filter: 'sam hinkie'
       });
       const embiidCheckbox = await searchFacetsComponent.findByLabelText('trust the process');
       performSearchMock.mockReset();
@@ -255,7 +255,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '"sam hinkie","trust the process"'
+          filter: '(sam hinkie),(trust the process)'
         }),
         false
       );
@@ -266,7 +266,7 @@ describe('DynamicFacetsComponent', () => {
   describe('checkboxes remove filters', () => {
     test('it removes correct filter when checkbox within single facet is unchecked', async () => {
       const { searchFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: '"sam hinkie"'
+        filter: 'sam hinkie'
       });
       const saviorCheckbox = await searchFacetsComponent.findByLabelText('sam hinkie');
       performSearchMock.mockReset();

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -206,7 +206,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"Animals"'
+          filter: 'subject:(Animals)'
         }),
         false
       );
@@ -224,7 +224,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"This | that"'
+          filter: 'subject:(This \\| that)'
         }),
         false
       );
@@ -241,7 +241,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"hey, you"'
+          filter: 'subject:(hey\\, you)'
         }),
         false
       );
@@ -258,7 +258,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"something: else"'
+          filter: 'subject:(something\\: else)'
         }),
         false
       );
@@ -275,7 +275,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"Animals"|subject:"People"'
+          filter: 'subject:(Animals)|subject:(People)'
         }),
         false
       );
@@ -284,7 +284,7 @@ describe('FieldFacetsComponent', () => {
 
     test('it adds correct filter when checkboxes from multiple facets are checked', async () => {
       const { fieldFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'subject:"Animals"'
+        filter: 'subject:Animals'
       });
       const newsStaffCheckbox = await fieldFacetsComponent.findByLabelText('News Staff (57158)');
       performSearchMock.mockReset();
@@ -292,7 +292,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"News Staff",subject:"Animals"'
+          filter: 'author:(News Staff),subject:(Animals)'
         }),
         false
       );
@@ -406,7 +406,7 @@ describe('FieldFacetsComponent', () => {
           ]
         }
       ];
-      const filter = 'foo:"hi"';
+      const filter = 'foo:hi';
       setupResult = setup({ componentSettingsAggregations, aggregationResults, filter });
       await wait(); // wait for component to finish rendering (prevent "act" warning)
     });
@@ -454,7 +454,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff"' });
+        setupData = setup({ filter: 'author:ABMN Staff' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -485,7 +485,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in the same category', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff"|author:"News Staff"' });
+        setupData = setup({ filter: 'author:ABMN Staff|author:News Staff' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -516,7 +516,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in different categories', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff",subject:"Animals"' });
+        setupData = setup({ filter: 'author:ABMN Staff,subject:Animals' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -536,7 +536,7 @@ describe('FieldFacetsComponent', () => {
           const { performSearchMock } = setupData;
           expect(performSearchMock).toHaveBeenCalledWith(
             expect.objectContaining({
-              filter: 'subject:"Animals"',
+              filter: 'subject:(Animals)',
               offset: 0
             }),
             false
@@ -569,7 +569,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"People"',
+          filter: 'subject:(People)',
           offset: 0
         }),
         false
@@ -615,7 +615,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"ABMN Staff"|author:"News Staff",subject:"People"',
+          filter: 'author:(ABMN Staff)|author:(News Staff),subject:(People)',
           offset: 0
         }),
         false
@@ -642,7 +642,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"News Staff",subject:"People"',
+          filter: 'author:(News Staff),subject:(People)',
           offset: 0
         }),
         false
@@ -883,7 +883,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text:(pittsburgh)',
               offset: 0
             }),
             false
@@ -892,7 +892,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"us"|enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text:(us)|enriched_text.entities.text:(pittsburgh)',
               offset: 0
             }),
             false
@@ -929,7 +929,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text:(pittsburgh)',
               offset: 0
             }),
             false
@@ -938,7 +938,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text:(ibm)|enriched_text.entities.text:(pittsburgh)',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -77,10 +77,10 @@ const weirdAggs = [
   }
 ];
 const weirdFilters =
-  'extracted_stuff.weirdAggs:"this | that"|extracted_stuff.weirdAggs:"1:30"|extracted_stuff.weirdAggs:"1,200"|extracted_stuff.weirdAggs:"double \\" quote",' +
-  'extracted_stuff.oddAggs:"something, new"|extracted_stuff.oddAggs:"blah|junk",' +
-  'extracted_stuff.normalAggs:"something normal"|extracted_stuff.normalAggs:"nospaces",' +
-  't\\(ext\\):"something normal"|t\\(ext\\):"nospaces"';
+  'extracted_stuff.weirdAggs:(this \\| that)|extracted_stuff.weirdAggs:(1\\:30)|extracted_stuff.weirdAggs:(1\\,200)|extracted_stuff.weirdAggs:(double \\" quote),' +
+  'extracted_stuff.oddAggs:(something\\, new)|extracted_stuff.oddAggs:(blah\\|junk),' +
+  'extracted_stuff.normalAggs:(something normal)|extracted_stuff.normalAggs:(nospaces),' +
+  't\\(ext\\):(something normal)|t\\(ext\\):(nospaces)';
 
 describe('QueryTermAggregation array to filter string', () => {
   test('it properly handles aggregations with reserved characters', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -8,14 +8,23 @@ import {
   SelectableDynamicFacets
 } from './searchFacetInterfaces';
 
+/*
+ * Utility class for creating and parsing query strings for search filters
+ */
+
 export class SearchFilterTransform {
   // Match any unescaped commas, colons, pipes
   static SPLIT_UNESCAPED_COMMAS = /(?<!\\),/;
   static SPLIT_UNESCAPED_COLONS = /(?<!\\):/;
   static SPLIT_UNESCAPED_PIPES = /(?<!\\)\|/;
+  // Match if the string is surrounded by parens
+  // The substring inside of the parens will be in $1
+  static STRING_IN_PARENS = /^\((.+)\)$/;
   // Match any special characters
+  // @see https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-operators
   static CHARS_TO_ESCAPE = /[|",:()[\]<>^*~.!]/g;
   // Match any escaped special characters
+  // The unescaped version of the character will be in $1
   static ESCAPED_CHAR = /\\([|",:()[\]<>^*~.!])/g;
 
   static fromString(filterString: string): SearchFilterFacets {
@@ -70,6 +79,7 @@ export class SearchFilterTransform {
     };
   }
 
+  // Returns a query string by combining field and dynamic query strings
   static toString(facets: SearchFilterFacets): string {
     const fieldFilters = this.fieldsToString(facets.filterFields);
     const dynamicFilters = this.escapeSelectedFacets(facets.filterDynamic, 'text').join(',');
@@ -80,11 +90,14 @@ export class SearchFilterTransform {
     // Remove the parentheses added by escapeSelectedFacets
     // Unescape the special characters within the string
     const unescapedString = escapedString
-      .replace(/^\((.+)\)$/, '$1')
+      .replace(RegExp(SearchFilterTransform.STRING_IN_PARENS), '$1')
       .replace(RegExp(SearchFilterTransform.ESCAPED_CHAR), '$1');
     return unescapedString;
   }
 
+  // Returns a full filter query string from the set of filterFields
+  // Use the includes query operator (:) for all fields
+  // @see https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-operators#includes
   static fieldsToString(facets: InternalQueryTermAggregation[]): string {
     const filterStrings: string[] = [];
     facets.forEach(facet => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^3.0.0
+    "@ibm-watson/discovery-react-components": ^3.0.1
     "@ibm-watson/discovery-styles": ^3.0.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

- revert exact match change
- group search phrases with parens to prevent query ambiguity
- escape more special characters
- fix unit and cypress tests
- fix build by updating version numbers in yarn.lock

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
Try the following on each of these two [staging](https://us-south.discovery.test.watson.cloud.ibm.com/v2/instances/crn%3Av1%3Astaging%3Apublic%3Adiscovery%3Aus-south%3Aa%2F24f453567f259b67c34ae38a6e6026fb%3A97732895-f1ad-4a2b-9951-548ee712f480%3A%3A/projects/918a1017-e178-4bc8-9b0e-a5950763ac16/workspace) / [local](http://localhost:4000/instances/crn%3Av1%3Astaging%3Apublic%3Adiscovery%3Aus-south%3Aa%2F24f453567f259b67c34ae38a6e6026fb%3A97732895-f1ad-4a2b-9951-548ee712f480%3A%3A/projects/918a1017-e178-4bc8-9b0e-a5950763ac16/workspace) (with this branch and linked to tooling)
1. Run an empty search.
2. Apply a `National Institute of Standards and Technology` facet filter.
3. Note that staging returns nothing, but local returns 56 results.