### PR TITLE
fix: revert previous facet changes and make new changes

### DIFF
--- a/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
@@ -83,6 +83,6 @@ describe('Dynamic Facets', () => {
     // makes a query with both filters', () => {
     cy.wait('@postQueryDynamicAndNonDynamic')
       .its('requestBody.filter')
-      .should('eq', 'location:"Hancock, MN","regression"');
+      .should('eq', 'location::"Hancock, MN","regression"');
   });
 });

--- a/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/dynamic_facets/spec.ts
@@ -37,7 +37,7 @@ describe('Dynamic Facets', () => {
     cy.get('label').contains('regression').click();
 
     // makes a query for the right facets
-    cy.wait('@postQueryFacetsSingle').its('requestBody.filter').should('eq', '(regression)');
+    cy.wait('@postQueryFacetsSingle').its('requestBody.filter').should('eq', '"regression"');
 
     // shows the bubble next to dynamic facets saying 1
     cy.get('.bx--tag--filter').contains('1').should('exist');
@@ -51,7 +51,7 @@ describe('Dynamic Facets', () => {
     // makes a query for both filters
     cy.wait('@postQueryMultiRefinement')
       .its('requestBody.filter')
-      .should('eq', '(regression),(classification)');
+      .should('eq', '"regression","classification"');
 
     // shows the bubble next to dynamic facets saying 2
     cy.get('.bx--tag--filter').contains('2').should('exist');
@@ -72,7 +72,7 @@ describe('Dynamic Facets', () => {
     cy.get('label').contains('regression').click();
 
     // makes a query without any selected facets
-    cy.wait('@postQueryFacets').its('requestBody.filter').should('eq', '(regression)');
+    cy.wait('@postQueryFacets').its('requestBody.filter').should('eq', '"regression"');
 
     // and a different filter is clicked from a different facet
     cy.route('POST', '**/query?version=2019-01-01', '@facetsQueryDynamicAndNonDynamicJSON').as(
@@ -83,6 +83,6 @@ describe('Dynamic Facets', () => {
     // makes a query with both filters', () => {
     cy.wait('@postQueryDynamicAndNonDynamic')
       .its('requestBody.filter')
-      .should('eq', 'location:(Hancock\\, MN),(regression)');
+      .should('eq', 'location:"Hancock, MN","regression"');
   });
 });

--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -48,7 +48,7 @@ describe('Multi-Select Facets', () => {
       it('queries and selects the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:(Ames\\, IA)');
+          .should('eq', 'location:"Ames, IA"');
         cy.get('.bx--tag--filter').contains('1').should('exist');
       });
 
@@ -64,7 +64,7 @@ describe('Multi-Select Facets', () => {
         it('queries and selects the right facets', () => {
           cy.get('@multiFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:(Pittsburgh\\, PA)|location:(Ames\\, IA)');
+            .should('eq', 'location:"Pittsburgh, PA"|location:"Ames, IA"');
           cy.get('.bx--tag--filter').contains('2').should('exist');
         });
       });
@@ -115,7 +115,7 @@ describe('Multi-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:(Ames\\, IA),price:(Low)');
+            .should('eq', 'location:"Ames, IA",price:"Low"');
         });
 
         describe('and the selected filters bubble from only one of the facets is clicked', () => {
@@ -130,7 +130,7 @@ describe('Multi-Select Facets', () => {
           it('has the filters from only that facet clear', () => {
             cy.get('@amesFilterQueryObject')
               .its('requestBody.filter')
-              .should('eq', 'location:(Ames\\, IA)');
+              .should('eq', 'location:"Ames, IA"');
           });
         });
       });

--- a/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/multi_select_facets/spec.ts
@@ -48,7 +48,7 @@ describe('Multi-Select Facets', () => {
       it('queries and selects the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:"Ames, IA"');
+          .should('eq', 'location::"Ames, IA"');
         cy.get('.bx--tag--filter').contains('1').should('exist');
       });
 
@@ -64,7 +64,7 @@ describe('Multi-Select Facets', () => {
         it('queries and selects the right facets', () => {
           cy.get('@multiFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Pittsburgh, PA"|location:"Ames, IA"');
+            .should('eq', 'location::"Pittsburgh, PA"|location::"Ames, IA"');
           cy.get('.bx--tag--filter').contains('2').should('exist');
         });
       });
@@ -115,7 +115,7 @@ describe('Multi-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Ames, IA",price:"Low"');
+            .should('eq', 'location::"Ames, IA",price::"Low"');
         });
 
         describe('and the selected filters bubble from only one of the facets is clicked', () => {
@@ -130,7 +130,7 @@ describe('Multi-Select Facets', () => {
           it('has the filters from only that facet clear', () => {
             cy.get('@amesFilterQueryObject')
               .its('requestBody.filter')
-              .should('eq', 'location:"Ames, IA"');
+              .should('eq', 'location::"Ames, IA"');
           });
         });
       });

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -47,7 +47,7 @@ describe('Single-Select Facets', () => {
       it('makes a query for the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:(Ames\\, IA)');
+          .should('eq', 'location:"Ames, IA"');
       });
 
       describe('and a different filter is selected from the same facet', () => {
@@ -62,7 +62,7 @@ describe('Single-Select Facets', () => {
         it('makes a query for only the new facet', () => {
           cy.get('@hancockFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:(Hancock\\, MN)');
+            .should('eq', 'location:"Hancock, MN"');
         });
       });
 
@@ -103,7 +103,7 @@ describe('Single-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:(Ames\\, IA),price:(Low)');
+            .should('eq', 'location:"Ames, IA",price:"Low"');
         });
       });
     });

--- a/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
+++ b/examples/discovery-search-app/cypress/integration/single_select_facets/spec.ts
@@ -47,7 +47,7 @@ describe('Single-Select Facets', () => {
       it('makes a query for the right facets', () => {
         cy.get('@amesFilterQueryObject')
           .its('requestBody.filter')
-          .should('eq', 'location:"Ames, IA"');
+          .should('eq', 'location::"Ames, IA"');
       });
 
       describe('and a different filter is selected from the same facet', () => {
@@ -62,7 +62,7 @@ describe('Single-Select Facets', () => {
         it('makes a query for only the new facet', () => {
           cy.get('@hancockFilterQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Hancock, MN"');
+            .should('eq', 'location::"Hancock, MN"');
         });
       });
 
@@ -103,7 +103,7 @@ describe('Single-Select Facets', () => {
         it('makes a query with both filters', () => {
           cy.get('@combinedFacetQueryObject')
             .its('requestBody.filter')
-            .should('eq', 'location:"Ames, IA",price:"Low"');
+            .should('eq', 'location::"Ames, IA",price::"Low"');
         });
       });
     });

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__fixtures__/shortenedContract.json
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__fixtures__/shortenedContract.json
@@ -673,16 +673,7 @@
               "end": 14171
             },
             "text": "a) any Material provided by Buyer or its Affiliates, or for and/or on behalf of any member of the Customer Group and/or by the Consortium Members to the Supplier in connection with the performance or receipt of the Services, other than New Materials and Supplier Background Materials; and",
-            "attributes": [
-              {
-                "type": "DefinedTerm",
-                "text": "Buyer Background Material",
-                "location": {
-                  "begin": 13269,
-                  "end": 13294
-                }
-              }
-            ],
+            "attributes": [],
             "categories": [],
             "types": [
               {
@@ -703,16 +694,7 @@
               "end": 14887
             },
             "text": "b) any Material (including Modifications to Material) which is acquired or created by, for or on behalf of (other than from or by the Supplier Group) Buyer and/or any member of the Customer Group (including by the Consortium Members) in anticipation of, in connection with and/or in the course of the performance or receipt of the Services;",
-            "attributes": [
-              {
-                "type": "DefinedTerm",
-                "text": "Buyer Background Material",
-                "location": {
-                  "begin": 13269,
-                  "end": 13294
-                }
-              }
-            ],
+            "attributes": [],
             "categories": [],
             "types": [
               {
@@ -765,16 +747,7 @@
               "end": 15876
             },
             "text": "a) held by any member of Buyer which is supplied, transferred or disclosed to the Supplier, or which is accessible by the Supplier pursuant to the Agreement (including, in all cases, Customer data); and",
-            "attributes": [
-              {
-                "type": "DefinedTerm",
-                "text": "Buyer Data",
-                "location": {
-                  "begin": 15089,
-                  "end": 15099
-                }
-              }
-            ],
+            "attributes": [],
             "categories": [],
             "types": [
               {
@@ -796,16 +769,7 @@
               "end": 16646
             },
             "text": "b) (other than data referred to in (a) above) which is created, obtained, collected, stored, used or processed by or on behalf of the Supplier solely for Buyer (and not for the Supplier's own internal or administrative purposes) as part of the Services pursuant to the relevant SOW; but, for the avoidance of doubt, excludes any Supplier Background Materials and Type A Materials, Type B Materials and Type C Materials;",
-            "attributes": [
-              {
-                "type": "DefinedTerm",
-                "text": "Buyer Data",
-                "location": {
-                  "begin": 15089,
-                  "end": 15099
-                }
-              }
-            ],
+            "attributes": [],
             "categories": [],
             "types": [
               {

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocument/__tests__/CIDocument.spec.tsx
@@ -1,9 +1,8 @@
 import React from 'react';
 import {
+  screen,
   render,
   fireEvent,
-  wait,
-  waitForElement,
   getByText as globalGetByText,
   getByLabelText as globalGetByLabelText,
   BoundFunction,
@@ -30,7 +29,8 @@ describe('<CIDocument />', () => {
       ({ getByTestId, getByText, findByText, findByTestId, queryByTestId } = render(
         <CIDocument document={invoice} overrideDocWidth={400} overrideDocHeight={600} />
       ));
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await screen.findByText('invoice.pdf');
     });
 
     it('loads correct document', async () => {
@@ -92,7 +92,8 @@ describe('<CIDocument />', () => {
       ({ getAllByRole, getByTestId, getByText, findByText, findByTitle, queryByTitle } = render(
         <CIDocument document={purchaseOrder} overrideDocWidth={400} overrideDocHeight={600} />
       ));
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await screen.findByText('purchase_orders.pdf');
     });
 
     it('loads correct document', async () => {
@@ -106,10 +107,8 @@ describe('<CIDocument />', () => {
     });
 
     it('filters and navigates forward through the list of elements', async () => {
-      const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('CIDocument_filterPanel');
-        return globalGetByLabelText(filters, 'Currency(2)');
-      });
+      const filters = await screen.findByTestId('CIDocument_filterPanel');
+      const filterCheckbox = globalGetByLabelText(filters, 'Currency(2)');
       fireEvent.click(filterCheckbox);
 
       const nextButton = await findByTitle('Next', { selector: 'button' });
@@ -125,10 +124,8 @@ describe('<CIDocument />', () => {
     });
 
     it('filters and navigates backward through the list of elements', async () => {
-      const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('CIDocument_filterPanel');
-        return globalGetByLabelText(filters, 'Currency(2)');
-      });
+      const filters = await screen.findByTestId('CIDocument_filterPanel');
+      const filterCheckbox = globalGetByLabelText(filters, 'Currency(2)');
       fireEvent.click(filterCheckbox);
 
       const previousButton = await findByTitle('Previous', { selector: 'button' });
@@ -144,14 +141,12 @@ describe('<CIDocument />', () => {
     });
 
     it('selects a filter and then resets filters', async () => {
-      const filterCheckbox = await waitForElement(() => {
-        const filters = getByTestId('CIDocument_filterPanel');
-        return globalGetByLabelText(filters, 'Suppliers(1)');
-      });
+      const filters = await screen.findByTestId('CIDocument_filterPanel');
+      const filterCheckbox = globalGetByLabelText(filters, 'Suppliers(1)');
       fireEvent.click(filterCheckbox);
 
-      const filters = getByTestId('CIDocument_filterPanel');
-      const resetButton = globalGetByText(filters, 'Reset filters');
+      const filters2 = getByTestId('CIDocument_filterPanel');
+      const resetButton = globalGetByText(filters2, 'Reset filters');
       fireEvent.click(resetButton);
 
       // Navigation should be disabled now
@@ -171,7 +166,8 @@ describe('<CIDocument />', () => {
       ({ getByTestId, getByText, findByText, findByTestId, queryByTestId } = render(
         <CIDocument document={shortContract} overrideDocWidth={400} overrideDocHeight={1200} />
       ));
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await screen.findByText('Art Effects Koya Creative Base TSA 2008.pdf');
     });
 
     it('loads correct document', async () => {
@@ -240,7 +236,7 @@ describe('<CIDocument />', () => {
       // unselect filter
       fireEvent.click(categoryCheckbox);
       // other filter should reflect changes
-      globalGetByLabelText(filters, 'DefinedTerm(26)');
+      globalGetByLabelText(filters, 'DefinedTerm(22)');
     });
   });
 });

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/__fixtures__/contract.json
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/__fixtures__/contract.json
@@ -722,13 +722,7 @@
         {
           "location": { "begin": 13717, "end": 14171 },
           "text": "a) any Material provided by Buyer or its Affiliates, or for and/or on behalf of any member of the Customer Group and/or by the Consortium Members to the Supplier in connection with the performance or receipt of the Services, other than New Materials and Supplier Background Materials; and",
-          "attributes": [
-            {
-              "type": "DefinedTerm",
-              "text": "Buyer Background Material",
-              "location": { "begin": 13269, "end": 13294 }
-            }
-          ],
+          "attributes": [],
           "categories": [],
           "types": [
             {
@@ -740,23 +734,11 @@
             }
           ],
           "__type": "elements"
-        },
-        {
-          "type": "DefinedTerm",
-          "text": "Buyer Background Material",
-          "location": { "begin": 13269, "end": 13294 },
-          "__type": "attributes"
         },
         {
           "location": { "begin": 14383, "end": 14887 },
           "text": "b) any Material (including Modifications to Material) which is acquired or created by, for or on behalf of (other than from or by the Supplier Group) Buyer and/or any member of the Customer Group (including by the Consortium Members) in anticipation of, in connection with and/or in the course of the performance or receipt of the Services;",
-          "attributes": [
-            {
-              "type": "DefinedTerm",
-              "text": "Buyer Background Material",
-              "location": { "begin": 13269, "end": 13294 }
-            }
-          ],
+          "attributes": [],
           "categories": [],
           "types": [
             {
@@ -768,12 +750,6 @@
             }
           ],
           "__type": "elements"
-        },
-        {
-          "type": "DefinedTerm",
-          "text": "Buyer Background Material",
-          "location": { "begin": 13269, "end": 13294 },
-          "__type": "attributes"
         }
       ]
     },
@@ -849,13 +825,7 @@
         {
           "location": { "begin": 16064, "end": 16646 },
           "text": "b) (other than data referred to in (a) above) which is created, obtained, collected, stored, used or processed by or on behalf of the Supplier solely for Buyer (and not for the Supplier's own internal or administrative purposes) as part of the Services pursuant to the relevant SOW; but, for the avoidance of doubt, excludes any Supplier Background Materials and Type A Materials, Type B Materials and Type C Materials;",
-          "attributes": [
-            {
-              "type": "DefinedTerm",
-              "text": "Buyer Data",
-              "location": { "begin": 15089, "end": 15099 }
-            }
-          ],
+          "attributes": [],
           "categories": [],
           "types": [
             {
@@ -868,12 +838,6 @@
             }
           ],
           "__type": "elements"
-        },
-        {
-          "type": "DefinedTerm",
-          "text": "Buyer Data",
-          "location": { "begin": 15089, "end": 15099 },
-          "__type": "attributes"
         }
       ]
     },

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/__tests__/CIDocumentContent.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/__tests__/CIDocumentContent.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, waitForElement } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 import CIDocumentContent from '../CIDocumentContent';
 
 describe('<CIDocumentContent />', () => {
@@ -17,19 +17,15 @@ describe('<CIDocumentContent />', () => {
       }
     ];
 
-    let getByTestId: NonNullable<Function>;
-    act(() => {
-      ({ getByTestId } = render(
-        <CIDocumentContent
-          styles={styles}
-          sections={sections}
-          itemMap={{ byItem: {}, bySection: {} }}
-        />
-      ));
-    });
+    render(
+      <CIDocumentContent
+        styles={styles}
+        sections={sections}
+        itemMap={{ byItem: {}, bySection: {} }}
+      />
+    );
 
-    const styleNode = await waitForElement(() => getByTestId('style'));
-
+    let styleNode = await screen.findByTestId('style');
     expect(styleNode.innerHTML.includes('super-large-foobar')).toBe(true);
     expect(styleNode.innerHTML.includes('offensive')).toBe(true);
   });

--- a/packages/discovery-react-components/src/components/CIDocument/components/Section/__tests__/Section.spec.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/Section/__tests__/Section.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, waitForElement } from '@testing-library/react';
+import { screen, act, render } from '@testing-library/react';
 import 'utils/test/createRange.mock';
 import Section from '../Section';
 import sectionData from '../__fixtures__/sectionData';
@@ -14,12 +14,11 @@ describe('<Section />', () => {
       }
     };
 
-    let getByText: NonNullable<Function>;
     act(() => {
-      ({ getByText } = render(<Section section={data} />));
+      render(<Section section={data} />);
     });
 
-    await waitForElement(() => getByText('Here I am!'));
+    await screen.findByText('Here I am!');
   });
 
   it('renders enrichment fields', async () => {

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, wait } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import PdfViewer from '../PdfViewer';
 import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Effects.pdf';
 
@@ -7,9 +7,10 @@ describe('PdfViewer', () => {
   it('renders PDF document', async () => {
     render(<PdfViewer file={atob(doc)} page={1} scale={1} setLoading={(): void => {}} />);
 
+    // wait for component to finish rendering (prevent "act" warning)
+    await waitFor(() => expect(document.querySelectorAll('canvas')).toBeDefined());
+
     const canvasList = document.querySelectorAll('canvas');
     expect(canvasList.length).toBe(1);
-
-    await wait(); // wait for component to finish rendering (prevent "act" warning)
   });
 });

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/__tests__/SimpleDocument.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/SimpleDocument/__tests__/SimpleDocument.test.tsx
@@ -37,18 +37,18 @@ describe('SimpleDocument', () => {
   it('renders with array wrapped text', () => {
     let getByText: BoundFunction<GetByText> = noop;
 
-    const spy = jest.spyOn(console, 'log');
-    expect(spy).not.toHaveBeenCalled();
+    const mock = jest.fn();
+    expect(mock).not.toHaveBeenCalled();
     act(() => {
       ({ getByText } = render(
         <SimpleDocument
           document={docArrayJson}
           setLoading={(): void => {}}
-          setHideToolbarControls={(): void => console.log('setHideToolbarControls called')}
+          setHideToolbarControls={(): void => mock('setHideToolbarControls called')}
         />
       ));
     });
-    expect(spy).toHaveBeenCalled();
+    expect(mock).toHaveBeenCalled();
     getByText(
       'services) for its business operations and to meet obligations in connection with transactions under the Prime-Contract. This',
       { exact: false }

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, RenderResult, fireEvent, wait, within } from '@testing-library/react';
+import { render, RenderResult, fireEvent, waitFor, within } from '@testing-library/react';
 import { wrapWithContext } from 'utils/testingUtils';
 import SearchFacets from 'components/SearchFacets/SearchFacets';
 import {
@@ -75,7 +75,10 @@ describe('CollapsibleFacetsGroupComponent', () => {
   describe('when aggregations should not be collapsed for any fields', () => {
     test('show more link is not shown', async () => {
       const { searchFacetsComponent } = setup({ collapsedFacetsCount: 20 });
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await waitFor(() => {
+        searchFacetsComponent.findByText('category');
+      });
       const showMoreButtons = searchFacetsComponent.queryAllByText('Show more');
       expect(showMoreButtons).toHaveLength(0);
     });
@@ -274,7 +277,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'products:"assistant"'
+              filter: 'products::"assistant"'
             }),
             false
           );

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollapsibleFacetsGroup.test.tsx
@@ -274,7 +274,7 @@ describe('CollapsibleFacetsGroupComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'products:(assistant)'
+              filter: 'products:"assistant"'
             }),
             false
           );

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollectionFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/CollectionFacets.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, RenderResult, wait } from '@testing-library/react';
+import { screen, render, fireEvent, RenderResult } from '@testing-library/react';
 import { wrapWithContext } from 'utils/testingUtils';
 import { SearchContextIFC, SearchApiIFC } from 'components/DiscoverySearch/DiscoverySearch';
 import SearchFacets from 'components/SearchFacets/SearchFacets';
@@ -81,7 +81,8 @@ describe('CollectionFacetsComponent', () => {
   describe('collectionIds query param not set', () => {
     test('does not show pre-selected count', async () => {
       const { collectionFacetsComponent } = setup();
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await screen.findByText('Collections');
       const selectedCount = collectionFacetsComponent.queryByTitle('Clear all selected items');
       expect(selectedCount).toBeNull();
     });

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, RenderResult, wait } from '@testing-library/react';
+import { screen, render, fireEvent, RenderResult } from '@testing-library/react';
 import { wrapWithContext } from 'utils/testingUtils';
 import {
   SearchContextIFC,
@@ -111,7 +111,7 @@ describe('DynamicFacetsComponent', () => {
     describe('when no selections are made', () => {
       beforeEach(async () => {
         setupData = setup();
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        await screen.findAllByText('Show more'); // wait for component to finish rendering (prevent "act" warning)
       });
 
       test('the clear button does not appear', () => {
@@ -123,7 +123,7 @@ describe('DynamicFacetsComponent', () => {
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
         setupData = setup({ filter: '"trust the process"' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        await screen.findAllByText('Show more'); // wait for component to finish rendering (prevent "act" warning)
       });
 
       test('the clear button appears once', () => {
@@ -153,7 +153,7 @@ describe('DynamicFacetsComponent', () => {
     describe('when 2 selections are made', () => {
       beforeEach(async () => {
         setupData = setup({ filter: '"trust the process","just not the electrician"' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        await screen.findAllByText('Show more'); // wait for component to finish rendering (prevent "act" warning)
       });
 
       test('the clear button appears once', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/DynamicFacets.test.tsx
@@ -99,7 +99,7 @@ describe('DynamicFacetsComponent', () => {
     });
 
     test('checkboxes are checked when set in filter query', async () => {
-      const { searchFacetsComponent } = setup({ filter: 'sam hinkie' });
+      const { searchFacetsComponent } = setup({ filter: '"sam hinkie"' });
       const saviorCheckbox = await searchFacetsComponent.findByLabelText('sam hinkie');
       expect(saviorCheckbox['checked']).toEqual(true);
     });
@@ -122,7 +122,7 @@ describe('DynamicFacetsComponent', () => {
 
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'trust the process' });
+        setupData = setup({ filter: '"trust the process"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -152,7 +152,7 @@ describe('DynamicFacetsComponent', () => {
 
     describe('when 2 selections are made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'trust the process,just not the electrician' });
+        setupData = setup({ filter: '"trust the process","just not the electrician"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -190,7 +190,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '(trust the process)'
+          filter: '"trust the process"'
         }),
         false
       );
@@ -208,7 +208,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '(maybe \\| not)'
+          filter: '"maybe | not"'
         }),
         false
       );
@@ -223,7 +223,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '(bogus\\, strings)'
+          filter: '"bogus, strings"'
         }),
         false
       );
@@ -238,7 +238,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '(this\\: is)'
+          filter: '"this: is"'
         }),
         false
       );
@@ -247,7 +247,7 @@ describe('DynamicFacetsComponent', () => {
 
     test('it adds correct filters when second checkbox is checked', async () => {
       const { searchFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'sam hinkie'
+        filter: '"sam hinkie"'
       });
       const embiidCheckbox = await searchFacetsComponent.findByLabelText('trust the process');
       performSearchMock.mockReset();
@@ -255,7 +255,7 @@ describe('DynamicFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: '(sam hinkie),(trust the process)'
+          filter: '"sam hinkie","trust the process"'
         }),
         false
       );
@@ -266,7 +266,7 @@ describe('DynamicFacetsComponent', () => {
   describe('checkboxes remove filters', () => {
     test('it removes correct filter when checkbox within single facet is unchecked', async () => {
       const { searchFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'sam hinkie'
+        filter: '"sam hinkie"'
       });
       const saviorCheckbox = await searchFacetsComponent.findByLabelText('sam hinkie');
       performSearchMock.mockReset();

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { render, fireEvent, RenderResult, wait, within } from '@testing-library/react';
+import { render, fireEvent, RenderResult, waitFor, within } from '@testing-library/react';
 import DiscoveryV2 from 'ibm-watson/discovery/v2';
 import { wrapWithContext } from 'utils/testingUtils';
 import {
@@ -145,7 +145,10 @@ describe('FieldFacetsComponent', () => {
             }
           ]
         });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupResult.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('should match labels by name', () => {
@@ -191,7 +194,7 @@ describe('FieldFacetsComponent', () => {
     });
 
     test('checkboxes are checked when set in filter query', async () => {
-      const { fieldFacetsComponent } = setup({ filter: 'subject:Animals' });
+      const { fieldFacetsComponent } = setup({ filter: 'subject::Animals' });
       const animalsCheckbox = await fieldFacetsComponent.findByLabelText('Animals (138993)');
       expect(animalsCheckbox['checked']).toEqual(true);
     });
@@ -206,7 +209,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"Animals"'
+          filter: 'subject::"Animals"'
         }),
         false
       );
@@ -224,7 +227,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"This | that"'
+          filter: 'subject::"This | that"'
         }),
         false
       );
@@ -241,7 +244,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"hey, you"'
+          filter: 'subject::"hey, you"'
         }),
         false
       );
@@ -258,7 +261,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"something: else"'
+          filter: 'subject::"something: else"'
         }),
         false
       );
@@ -267,7 +270,7 @@ describe('FieldFacetsComponent', () => {
 
     test('it adds correct filters when second checkbox within single facet is checked', async () => {
       const { fieldFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'subject:Animals'
+        filter: 'subject::Animals'
       });
       const peopleCheckbox = await fieldFacetsComponent.findByLabelText('People (133760)');
       performSearchMock.mockReset();
@@ -275,7 +278,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"Animals"|subject:"People"'
+          filter: 'subject::"Animals"|subject::"People"'
         }),
         false
       );
@@ -284,7 +287,7 @@ describe('FieldFacetsComponent', () => {
 
     test('it adds correct filter when checkboxes from multiple facets are checked', async () => {
       const { fieldFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'subject:"Animals"'
+        filter: 'subject::"Animals"'
       });
       const newsStaffCheckbox = await fieldFacetsComponent.findByLabelText('News Staff (57158)');
       performSearchMock.mockReset();
@@ -292,7 +295,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"News Staff",subject:"Animals"'
+          filter: 'author::"News Staff",subject::"Animals"'
         }),
         false
       );
@@ -348,8 +351,11 @@ describe('FieldFacetsComponent', () => {
       const termAgg2 = { ...termAgg, name: 'second' };
 
       beforeEach(async () => {
-        setupResult = setup({ aggregationResults: [termAgg, termAgg2], filter: 'foo:two' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        setupResult = setup({ aggregationResults: [termAgg, termAgg2], filter: 'foo::two' });
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupResult.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('should only deselect one of the two', () => {
@@ -406,9 +412,12 @@ describe('FieldFacetsComponent', () => {
           ]
         }
       ];
-      const filter = 'foo:"hi"';
+      const filter = 'foo::"hi"';
       setupResult = setup({ componentSettingsAggregations, aggregationResults, filter });
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await waitFor(() => {
+        expect(setupResult.fieldFacetsComponent).toBeDefined();
+      });
     });
 
     test('should only select one of the two', () => {
@@ -422,7 +431,7 @@ describe('FieldFacetsComponent', () => {
 
   describe('checkboxes remove filters', () => {
     test('it removes correct filter when checkbox within single facet is unchecked', async () => {
-      const { fieldFacetsComponent, performSearchMock } = setup({ filter: 'subject:Animals' });
+      const { fieldFacetsComponent, performSearchMock } = setup({ filter: 'subject::Animals' });
       const animalsCheckbox = await fieldFacetsComponent.findByLabelText('Animals (138993)');
       performSearchMock.mockReset();
       fireEvent.click(animalsCheckbox);
@@ -443,7 +452,10 @@ describe('FieldFacetsComponent', () => {
     describe('when no selections are made', () => {
       beforeEach(async () => {
         setupData = setup();
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupData.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('the clear button does not appear', () => {
@@ -454,8 +466,11 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff"' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        setupData = setup({ filter: 'author::"ABMN Staff"' });
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupData.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('the clear button appears once', () => {
@@ -485,8 +500,11 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in the same category', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff"|author:"News Staff"' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        setupData = setup({ filter: 'author::"ABMN Staff"|author::"News Staff"' });
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupData.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('the clear button appears once', () => {
@@ -516,8 +534,11 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in different categories', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:"ABMN Staff",subject:"Animals"' });
-        await wait(); // wait for component to finish rendering (prevent "act" warning)
+        setupData = setup({ filter: 'author::"ABMN Staff",subject::"Animals"' });
+        // wait for component to finish rendering (prevent "act" warning)
+        await waitFor(() => {
+          expect(setupData.fieldFacetsComponent).toBeDefined();
+        });
       });
 
       test('the clear button appears twice', () => {
@@ -536,7 +557,7 @@ describe('FieldFacetsComponent', () => {
           const { performSearchMock } = setupData;
           expect(performSearchMock).toHaveBeenCalledWith(
             expect.objectContaining({
-              filter: 'subject:"Animals"',
+              filter: 'subject::"Animals"',
               offset: 0
             }),
             false
@@ -549,7 +570,7 @@ describe('FieldFacetsComponent', () => {
   describe('when multiple_selections_allowed is false', () => {
     test('radiobuttons are selected when set in filter query', async () => {
       const { fieldFacetsComponent } = setup({
-        filter: 'subject:Animals',
+        filter: 'subject::Animals',
         componentSettingsAggregations: updateSelectionSettings(['subject_id'])
       });
       const animalRadioButton = await fieldFacetsComponent.findAllByLabelText('Animals (138993)');
@@ -569,7 +590,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:"People"',
+          filter: 'subject::"People"',
           offset: 0
         }),
         false
@@ -615,7 +636,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"ABMN Staff"|author:"News Staff",subject:"People"',
+          filter: 'author::"ABMN Staff"|author::"News Staff",subject::"People"',
           offset: 0
         }),
         false
@@ -642,7 +663,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:"News Staff",subject:"People"',
+          filter: 'author::"News Staff",subject::"People"',
           offset: 0
         }),
         false
@@ -678,7 +699,10 @@ describe('FieldFacetsComponent', () => {
           }
         ]
       });
-      await wait(); // wait for component to finish rendering (prevent "act" warning)
+      // wait for component to finish rendering (prevent "act" warning)
+      await waitFor(() => {
+        expect(setupResult.fieldFacetsComponent).toBeDefined();
+      });
     });
 
     describe('legend header elements', () => {
@@ -883,7 +907,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text::"pittsburgh"',
               offset: 0
             }),
             false
@@ -892,7 +916,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"us"|enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text::"us"|enriched_text.entities.text::"pittsburgh"',
               offset: 0
             }),
             false
@@ -929,7 +953,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"pittsburgh"',
+              filter: 'enriched_text.entities.text::"pittsburgh"',
               offset: 0
             }),
             false
@@ -938,7 +962,8 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text:"pittsburgh"',
+              filter:
+                'enriched_text.entities.text::"ibm"|enriched_text.entities.text::"pittsburgh"',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/components/__tests__/FieldFacets.test.tsx
@@ -206,7 +206,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(Animals)'
+          filter: 'subject:"Animals"'
         }),
         false
       );
@@ -224,7 +224,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(This \\| that)'
+          filter: 'subject:"This | that"'
         }),
         false
       );
@@ -241,7 +241,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(hey\\, you)'
+          filter: 'subject:"hey, you"'
         }),
         false
       );
@@ -258,7 +258,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(something\\: else)'
+          filter: 'subject:"something: else"'
         }),
         false
       );
@@ -275,7 +275,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(Animals)|subject:(People)'
+          filter: 'subject:"Animals"|subject:"People"'
         }),
         false
       );
@@ -284,7 +284,7 @@ describe('FieldFacetsComponent', () => {
 
     test('it adds correct filter when checkboxes from multiple facets are checked', async () => {
       const { fieldFacetsComponent, performSearchMock, onChangeMock } = setup({
-        filter: 'subject:Animals'
+        filter: 'subject:"Animals"'
       });
       const newsStaffCheckbox = await fieldFacetsComponent.findByLabelText('News Staff (57158)');
       performSearchMock.mockReset();
@@ -292,7 +292,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:(News Staff),subject:(Animals)'
+          filter: 'author:"News Staff",subject:"Animals"'
         }),
         false
       );
@@ -406,7 +406,7 @@ describe('FieldFacetsComponent', () => {
           ]
         }
       ];
-      const filter = 'foo:hi';
+      const filter = 'foo:"hi"';
       setupResult = setup({ componentSettingsAggregations, aggregationResults, filter });
       await wait(); // wait for component to finish rendering (prevent "act" warning)
     });
@@ -454,7 +454,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 1 selection is made', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:ABMN Staff' });
+        setupData = setup({ filter: 'author:"ABMN Staff"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -485,7 +485,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in the same category', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:ABMN Staff|author:News Staff' });
+        setupData = setup({ filter: 'author:"ABMN Staff"|author:"News Staff"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -516,7 +516,7 @@ describe('FieldFacetsComponent', () => {
 
     describe('when 2 selections are made in different categories', () => {
       beforeEach(async () => {
-        setupData = setup({ filter: 'author:ABMN Staff,subject:Animals' });
+        setupData = setup({ filter: 'author:"ABMN Staff",subject:"Animals"' });
         await wait(); // wait for component to finish rendering (prevent "act" warning)
       });
 
@@ -536,7 +536,7 @@ describe('FieldFacetsComponent', () => {
           const { performSearchMock } = setupData;
           expect(performSearchMock).toHaveBeenCalledWith(
             expect.objectContaining({
-              filter: 'subject:(Animals)',
+              filter: 'subject:"Animals"',
               offset: 0
             }),
             false
@@ -569,7 +569,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'subject:(People)',
+          filter: 'subject:"People"',
           offset: 0
         }),
         false
@@ -615,7 +615,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:(ABMN Staff)|author:(News Staff),subject:(People)',
+          filter: 'author:"ABMN Staff"|author:"News Staff",subject:"People"',
           offset: 0
         }),
         false
@@ -642,7 +642,7 @@ describe('FieldFacetsComponent', () => {
       expect(performSearchMock).toBeCalledTimes(1);
       expect(performSearchMock).toBeCalledWith(
         expect.objectContaining({
-          filter: 'author:(News Staff),subject:(People)',
+          filter: 'author:"News Staff",subject:"People"',
           offset: 0
         }),
         false
@@ -883,7 +883,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:(pittsburgh)',
+              filter: 'enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false
@@ -892,7 +892,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:(us)|enriched_text.entities.text:(pittsburgh)',
+              filter: 'enriched_text.entities.text:"us"|enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false
@@ -929,7 +929,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(1);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:(pittsburgh)',
+              filter: 'enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false
@@ -938,7 +938,7 @@ describe('FieldFacetsComponent', () => {
           expect(performSearchMock).toBeCalledTimes(2);
           expect(performSearchMock).toBeCalledWith(
             expect.objectContaining({
-              filter: 'enriched_text.entities.text:(ibm)|enriched_text.entities.text:(pittsburgh)',
+              filter: 'enriched_text.entities.text:"ibm"|enriched_text.entities.text:"pittsburgh"',
               offset: 0
             }),
             false

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -77,10 +77,10 @@ const weirdAggs = [
   }
 ];
 const weirdFilters =
-  'extracted_stuff.weirdAggs:"this | that"|extracted_stuff.weirdAggs:"1:30"|extracted_stuff.weirdAggs:"1,200"|extracted_stuff.weirdAggs:"double \\" quote",' +
-  'extracted_stuff.oddAggs:"something, new"|extracted_stuff.oddAggs:"blah|junk",' +
-  'extracted_stuff.normalAggs:"something normal"|extracted_stuff.normalAggs:"nospaces",' +
-  't\\(ext\\):"something normal"|t\\(ext\\):"nospaces"';
+  'extracted_stuff.weirdAggs::"this | that"|extracted_stuff.weirdAggs::"1:30"|extracted_stuff.weirdAggs::"1,200"|extracted_stuff.weirdAggs::"double \\" quote",' +
+  'extracted_stuff.oddAggs::"something, new"|extracted_stuff.oddAggs::"blah|junk",' +
+  'extracted_stuff.normalAggs::"something normal"|extracted_stuff.normalAggs::"nospaces",' +
+  't\\(ext\\)::"something normal"|t\\(ext\\)::"nospaces"';
 
 describe('QueryTermAggregation array to filter string', () => {
   test('it properly handles aggregations with reserved characters', () => {
@@ -91,7 +91,7 @@ describe('QueryTermAggregation array to filter string', () => {
 describe('Filter string to QueryTermAggregation array', () => {
   test('it properly handles unquoted terms', () => {
     expect(
-      SearchFilterTransform.fromString('field:term|field:two words,field2:blah\\"stuff')
+      SearchFilterTransform.fromString('field::term|field::two words,field2::blah\\"stuff')
         .filterFields
     ).toEqual([
       {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/__tests__/searchFilterTransform.test.ts
@@ -77,10 +77,10 @@ const weirdAggs = [
   }
 ];
 const weirdFilters =
-  'extracted_stuff.weirdAggs:(this \\| that)|extracted_stuff.weirdAggs:(1\\:30)|extracted_stuff.weirdAggs:(1\\,200)|extracted_stuff.weirdAggs:(double \\" quote),' +
-  'extracted_stuff.oddAggs:(something\\, new)|extracted_stuff.oddAggs:(blah\\|junk),' +
-  'extracted_stuff.normalAggs:(something normal)|extracted_stuff.normalAggs:(nospaces),' +
-  't\\(ext\\):(something normal)|t\\(ext\\):(nospaces)';
+  'extracted_stuff.weirdAggs:"this | that"|extracted_stuff.weirdAggs:"1:30"|extracted_stuff.weirdAggs:"1,200"|extracted_stuff.weirdAggs:"double \\" quote",' +
+  'extracted_stuff.oddAggs:"something, new"|extracted_stuff.oddAggs:"blah|junk",' +
+  'extracted_stuff.normalAggs:"something normal"|extracted_stuff.normalAggs:"nospaces",' +
+  't\\(ext\\):"something normal"|t\\(ext\\):"nospaces"';
 
 describe('QueryTermAggregation array to filter string', () => {
   test('it properly handles aggregations with reserved characters', () => {

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -10,7 +10,7 @@ import {
 
 export class SearchFilterTransform {
   static SPLIT_UNQUOTED_COMMAS = /,(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
-  static SPLIT_UNQUOTED_COLONS = /:(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
+  static SPLIT_UNQUOTED_COLONS = /::(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
   static SPLIT_UNQUOTED_PIPES = /\|(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
 
   static fromString(filterString: string): SearchFilterFacets {
@@ -96,7 +96,7 @@ export class SearchFilterTransform {
       .filter(result => result.selected)
       .map(result => {
         const text = get(result, key, '');
-        return `${text.replace(/"/, '\\"')}`;
+        return `"${text.replace(/"/, '\\"')}"`;
       });
   }
 }

--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -8,24 +8,10 @@ import {
   SelectableDynamicFacets
 } from './searchFacetInterfaces';
 
-/*
- * Utility class for creating and parsing query strings for search filters
- */
-
 export class SearchFilterTransform {
-  // Match any unescaped commas, colons, pipes
-  static SPLIT_UNESCAPED_COMMAS = /(?<!\\),/;
-  static SPLIT_UNESCAPED_COLONS = /(?<!\\):/;
-  static SPLIT_UNESCAPED_PIPES = /(?<!\\)\|/;
-  // Match if the string is surrounded by parens
-  // The substring inside of the parens will be in $1
-  static STRING_IN_PARENS = /^\((.+)\)$/;
-  // Match any special characters
-  // @see https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-operators
-  static CHARS_TO_ESCAPE = /[|",:()[\]<>^*~.!]/g;
-  // Match any escaped special characters
-  // The unescaped version of the character will be in $1
-  static ESCAPED_CHAR = /\\([|",:()[\]<>^*~.!])/g;
+  static SPLIT_UNQUOTED_COMMAS = /,(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
+  static SPLIT_UNQUOTED_COLONS = /:(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
+  static SPLIT_UNQUOTED_PIPES = /\|(?=(?:(?:[^"\\"]*["\\"]){2})*[^"\\"]*$)/;
 
   static fromString(filterString: string): SearchFilterFacets {
     if (filterString === '') {
@@ -35,24 +21,24 @@ export class SearchFilterTransform {
       };
     }
 
-    const colonRegex = RegExp(SearchFilterTransform.SPLIT_UNESCAPED_COLONS);
+    const colonRegex = RegExp(SearchFilterTransform.SPLIT_UNQUOTED_COLONS);
     const filterFacets = partition(
-      filterString.split(SearchFilterTransform.SPLIT_UNESCAPED_COMMAS),
+      filterString.split(SearchFilterTransform.SPLIT_UNQUOTED_COMMAS),
       filter => colonRegex.test(filter)
     );
     const fields = filterFacets[0].map(facetField => {
-      const facets = facetField.split(SearchFilterTransform.SPLIT_UNESCAPED_PIPES);
-      const field = facets[0].split(SearchFilterTransform.SPLIT_UNESCAPED_COLONS)[0];
+      const facets = facetField.split(SearchFilterTransform.SPLIT_UNQUOTED_PIPES);
+      const field = facets[0].split(SearchFilterTransform.SPLIT_UNQUOTED_COLONS)[0];
       const results = facets
         .map(facet => {
-          const facetPair = facet.split(SearchFilterTransform.SPLIT_UNESCAPED_COLONS);
+          const facetPair = facet.split(SearchFilterTransform.SPLIT_UNQUOTED_COLONS);
           return facetPair[1];
         })
         .sort()
         .map(result => {
-          const unescapedResult = this.unescapeString(result);
+          const unquotedResult = this.unquoteString(result);
           return {
-            key: unescapedResult,
+            key: unquotedResult,
             matching_results: 1,
             selected: true
           };
@@ -66,9 +52,9 @@ export class SearchFilterTransform {
     });
 
     const suggestions = filterFacets[1].map(suggestion => {
-      const unescapedSuggestion = this.unescapeString(suggestion);
+      const unquotedSuggestion = this.unquoteString(suggestion);
       return {
-        text: unescapedSuggestion,
+        text: unquotedSuggestion,
         selected: true
       };
     });
@@ -79,50 +65,38 @@ export class SearchFilterTransform {
     };
   }
 
-  // Returns a query string by combining field and dynamic query strings
   static toString(facets: SearchFilterFacets): string {
     const fieldFilters = this.fieldsToString(facets.filterFields);
-    const dynamicFilters = this.escapeSelectedFacets(facets.filterDynamic, 'text').join(',');
+    const dynamicFilters = this.quoteSelectedFacets(facets.filterDynamic, 'text').join(',');
     return [fieldFilters, dynamicFilters].filter(Boolean).join(',');
   }
 
-  private static unescapeString(escapedString: string): string {
-    // Remove the parentheses added by escapeSelectedFacets
-    // Unescape the special characters within the string
-    const unescapedString = escapedString
-      .replace(RegExp(SearchFilterTransform.STRING_IN_PARENS), '$1')
-      .replace(RegExp(SearchFilterTransform.ESCAPED_CHAR), '$1');
-    return unescapedString;
+  private static unquoteString(quotedString: string): string {
+    return quotedString.replace(/^"(.+)"$/, '$1').replace(/\\"/, '"');
   }
 
-  // Returns a full filter query string from the set of filterFields
-  // Use the includes query operator (:) for all fields
-  // @see https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-operators#includes
   static fieldsToString(facets: InternalQueryTermAggregation[]): string {
     const filterStrings: string[] = [];
     facets.forEach(facet => {
       const field = get(facet, 'field', '');
       const results = get(facet, 'results', []);
-      const keys = this.escapeSelectedFacets(results, 'key');
+      const keys = this.quoteSelectedFacets(results, 'key');
       if (keys.length) {
-        filterStrings.push(keys.map(key => `${escapeFieldName(field)}:${key}`).join('|'));
+        filterStrings.push(keys.map(key => `${escapeFieldName(field)}::${key}`).join('|'));
       }
     });
     return filterStrings.join(',');
   }
 
-  private static escapeSelectedFacets(
+  private static quoteSelectedFacets(
     facets: (SelectableQueryTermAggregationResult | SelectableDynamicFacets)[],
     key: string
   ): string[] {
-    const escapeRegex = RegExp(SearchFilterTransform.CHARS_TO_ESCAPE);
     return facets
       .filter(result => result.selected)
       .map(result => {
         const text = get(result, key, '');
-        // Add parentheses to prevent query ambiguity without changing the query's meaning
-        // Escape special characters within the string so they aren't parsed as part of the query
-        return `(${text.replace(escapeRegex, '\\$&')})`;
+        return `${text.replace(/"/, '\\"')}`;
       });
   }
 }

--- a/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/__tests__/SearchResults.test.tsx
@@ -548,7 +548,7 @@ describe('<SearchResults />', () => {
             table: {}
           },
           {
-            table_id: 'table id',
+            table_id: 'table id 2',
             source_document_id: '456',
             collection_id: 'collection_id',
             table_html: '<div>table html</div>',

--- a/packages/discovery-react-components/src/utils/document/documentUtils.ts
+++ b/packages/discovery-react-components/src/utils/document/documentUtils.ts
@@ -33,13 +33,13 @@ export function findOffsetInDOM(
   if (beginNode === null) {
     beginNode = parentNode;
     console.warn(
-      `Failed to find a node containing the start of the highlight: ${begin}. Using root node instead.`
+      `Unable to find a node containing the start of the highlight: ${begin}. Using root node instead.`
     );
   }
   if (endNode === null) {
     endNode = parentNode;
     console.warn(
-      `Failed to find a node containing the end of the highlight: ${end}. Using root node instead.`
+      `Unable to find a node containing the end of the highlight: ${end}. Using root node instead.`
     );
   }
 
@@ -102,7 +102,7 @@ export function getTextNodeAndOffset(node: Node, strOffset: number): NodeOffset 
 
   if (textNode === null && prevNode === null) {
     // If no text nodes were found, throw an error.
-    throw new Error(`Failed to find text node. Node: ${node.textContent}, offset: ${strOffset}`);
+    throw new Error(`Unable to find text node. Node: ${node.textContent}, offset: ${strOffset}`);
   } else if (textNode === null && prevNode !== null) {
     // If the offset was not found in the last text node,
     // return the last node with an offset pointing to the end of that node.

--- a/packages/discovery-react-components/src/utils/document/processDoc.ts
+++ b/packages/discovery-react-components/src/utils/document/processDoc.ts
@@ -461,7 +461,7 @@ function sortFieldsBySection(field: any, sections: any[], fieldType: string): vo
   if (sectionIdx === -1) {
     // notify of error, but keep going
     // eslint-disable-next-line no-console
-    console.error('Failed to find doc section which contains given field');
+    console.error('Unable to find doc section which contains given field');
     return;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^3.0.0
+    "@ibm-watson/discovery-react-components": ^3.0.2
     "@ibm-watson/discovery-styles": ^3.0.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -10664,7 +10664,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^3.0.1
+    "@ibm-watson/discovery-react-components": ^3.0.0
     "@ibm-watson/discovery-styles": ^3.0.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?
- revert previous commit (changes were requested by Chris Cook [here](https://ibm-analytics.slack.com/archives/G0117CFBJTU/p1658509360115819?thread_ts=1658332780.760249&cid=G0117CFBJTU))
- re-add double quotes to query
- adjust query decoding to use '::'
- clean up test warnings and logs

Contributes to https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/12682

#### How do you test/verify these changes?
Try the following on each of these two [staging](https://us-south.discovery.test.watson.cloud.ibm.com/v2/instances/crn%3Av1%3Astaging%3Apublic%3Adiscovery%3Aus-south%3Aa%2F24f453567f259b67c34ae38a6e6026fb%3A97732895-f1ad-4a2b-9951-548ee712f480%3A%3A/projects/918a1017-e178-4bc8-9b0e-a5950763ac16/workspace) / [local](http://localhost:4000/instances/crn%3Av1%3Astaging%3Apublic%3Adiscovery%3Aus-south%3Aa%2F24f453567f259b67c34ae38a6e6026fb%3A97732895-f1ad-4a2b-9951-548ee712f480%3A%3A/projects/918a1017-e178-4bc8-9b0e-a5950763ac16/workspace) (with this branch and linked to tooling)
1. Run an empty search.
2. Apply a `National Institute of Standards and Technology` facet filter.
3. Note that staging returns nothing, but local returns 56 results.

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
