### PR TITLE
fix: adjust how canvas dimensions are computed

### DIFF
--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -30,7 +30,7 @@
     "dist"
   ],
   "dependencies": {
-    "@react-hook/resize-observer": "^1.2.6",
+    "@react-hook/size": "^2.1.2",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "dompurify": "^2.0.17",

--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -30,6 +30,7 @@
     "dist"
   ],
   "dependencies": {
+    "@react-hook/resize-observer": "^1.2.6",
     "classnames": "^2.2.6",
     "debounce": "^1.2.0",
     "dompurify": "^2.0.17",

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -1,10 +1,9 @@
-import React, { FC, useEffect, useRef, useCallback, useMemo, useState, RefObject } from 'react';
+import React, { FC, useEffect, useRef, useCallback, useMemo, useState } from 'react';
 import cx from 'classnames';
 import PdfjsLib, { PDFDocumentProxy, PDFPageProxy, PDFPromise, PDFRenderTask } from 'pdfjs-dist';
 import PdfjsWorkerAsText from 'pdfjs-dist/build/pdf.worker.min.js';
 import { settings } from 'carbon-components';
-import debounce from 'lodash/debounce';
-import useResizeObserver from '@react-hook/resize-observer';
+import useSize from '@react-hook/size';
 import useAsyncFunctionCall from 'utils/useAsyncFunctionCall';
 import { QueryResult } from 'ibm-watson/discovery/v2';
 import { DocumentFile } from '../../types';
@@ -12,8 +11,6 @@ import { getTextMappings } from '../../utils/documentData';
 import PdfViewerTextLayer, { PdfRenderedText } from './PdfViewerTextLayer';
 import { toPDFSource } from './utils';
 import { PdfDisplayProps } from './types';
-
-const RESIZE_DEBOUNCE = 50;
 
 setupPdfjs();
 
@@ -75,7 +72,6 @@ const PdfViewer: FC<Props> = ({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   const [canvasInfo, setCanvasInfo] = useState<CanvasInfo | null>(null);
-  const [previousRootWidth, setPreviousRootWidth] = useState<number>(0);
 
   const loadedFile = useAsyncFunctionCall(
     useCallback(async () => (file ? await _loadPdf(file) : null), [file])
@@ -87,21 +83,11 @@ const PdfViewer: FC<Props> = ({
     )
   );
 
-  useEffect(
-    () => setCanvasInfo(getCanvasInfo(loadedPage, scale, rootRef)),
-    [loadedPage, scale, rootRef]
-  );
-
-  useResizeObserver(
-    rootRef.current,
-    debounce(() => {
-      const currentRootWidth = rootRef?.current?.getBoundingClientRect().width;
-      if (!!currentRootWidth && currentRootWidth !== previousRootWidth) {
-        setCanvasInfo(getCanvasInfo(loadedPage, scale, rootRef));
-        setPreviousRootWidth(currentRootWidth);
-      }
-    }, RESIZE_DEBOUNCE)
-  );
+  const [width] = useSize(rootRef);
+  useEffect(() => {
+    // width has changed; update canvas info
+    setCanvasInfo(getCanvasInfo(loadedPage, scale, width));
+  }, [loadedPage, scale, width]);
 
   // render page
   useAsyncFunctionCall(
@@ -132,7 +118,9 @@ const PdfViewer: FC<Props> = ({
     }
   }, [setHideToolbarControls]);
 
-  const proportion = canvasInfo?.proportion || 1;
+  // Ratio of the available width for the viewer to the native width of the PDF
+  // This value will be used to scale the text layer and highlights
+  const fitToWidthRatio = canvasInfo?.fitToWidthRatio || 1;
 
   const base = `${settings.prefix}--document-preview-pdf-viewer`;
   return (
@@ -152,11 +140,11 @@ const PdfViewer: FC<Props> = ({
           <PdfViewerTextLayer
             className={cx(`${base}__text`, textLayerClassName)}
             loadedPage={loadedPage}
-            scale={scale * proportion}
+            scale={scale * fitToWidthRatio}
             setRenderedText={setRenderedText}
           />
         )}
-        {typeof children === 'function' ? children({ proportion }) : children}
+        {typeof children === 'function' ? children({ fitToWidthRatio }) : children}
       </div>
     </div>
   );
@@ -238,28 +226,47 @@ type CanvasInfo = {
   height: number;
   canvasWidth: number;
   canvasHeight: number;
-  proportion: number;
+  fitToWidthRatio: number;
   viewport: PdfjsLib.PDFPageViewport;
 };
 
 function getCanvasInfo(
   loadedPage: PdfjsLib.PDFPageProxy | null | undefined,
   scale: number,
-  rootRef: RefObject<HTMLDivElement>
+  rootWidth: number
 ): CanvasInfo | null {
-  const rootDimensions = rootRef?.current?.getBoundingClientRect();
-  if (loadedPage && rootDimensions) {
-    const canvasScale = window.devicePixelRatio ?? 1;
-    const width = rootDimensions.width * scale;
-    const pageWidth = loadedPage.view[2];
-    const proportion = rootDimensions.width / pageWidth;
+  if (loadedPage) {
+    // Set the displayed width of the canvas to fill the available width (from parent component)
+    // when scale = 1, and to scale up or down accordingly with the scale value
+    const width = rootWidth * scale;
 
+    // The native width of the PDF page can be found by subtracting the x2 and x1 values
+    // of the page view, which indicate the left and right edge of the page
+    // @see https://mozilla.github.io/pdf.js/api/draft/module-pdfjsLib-PDFPageProxy.html#view
+    const pageWidth = loadedPage.view[2] - loadedPage.view[0];
+
+    // Proportion of the display width to the native width of the PDF,
+    // which will be used to scale the text layer and highlights
+    const fitToWidthRatio = rootWidth / pageWidth;
+
+    // Use the device's pixel ratio to adjust the canvas scale
+    const devicePixelRatio = window.devicePixelRatio ?? 1;
+
+    // Get the viewport of the page, scaled based on the current scale, fit-to-width ratio, and pixel ratio
     const viewport = loadedPage.getViewport({
-      scale: (scale * canvasScale * width) / pageWidth
+      scale: scale * fitToWidthRatio * devicePixelRatio
     });
+
+    // Pull the width and height of the viewport to be used when rendering the canvas element
     const { width: canvasWidth, height: canvasHeight } = viewport;
-    const height = (width * canvasHeight) / canvasWidth;
-    return { width, height, canvasWidth, canvasHeight, proportion, viewport };
+
+    // Height-to-width ratio of the PDF in the canvas
+    const pageAspectRatio = canvasHeight / canvasWidth;
+
+    // Set the displayed height of the canvas element based on the width and page aspect ratio
+    const height = width * pageAspectRatio;
+
+    return { width, height, canvasWidth, canvasHeight, fitToWidthRatio, viewport };
   }
   return null;
 }

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
@@ -87,14 +87,14 @@ const PdfViewerWithHighlight: FC<Props> = ({
   const highlightReady = !!documentInfo && !!renderedText;
   return (
     <PdfViewer {...rest} page={currentPage} setRenderedText={setRenderedText}>
-      {({ proportion }: { proportion: number }) => {
+      {({ fitToWidthRatio }: { fitToWidthRatio: number }) => {
         return (
           (state.fields || state.bboxes) && (
             <PdfHighlight
               parsedDocument={highlightReady ? documentInfo ?? null : null}
               pdfRenderedText={highlightReady ? renderedText : null}
               page={currentPage}
-              scale={scale * proportion}
+              scale={scale * fitToWidthRatio}
               highlights={state.fields}
               boxHighlights={state.bboxes}
               activeIds={state.activeIds}

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.tsx
@@ -87,18 +87,22 @@ const PdfViewerWithHighlight: FC<Props> = ({
   const highlightReady = !!documentInfo && !!renderedText;
   return (
     <PdfViewer {...rest} page={currentPage} setRenderedText={setRenderedText}>
-      {(state.fields || state.bboxes) && (
-        <PdfHighlight
-          parsedDocument={highlightReady ? documentInfo ?? null : null}
-          pdfRenderedText={highlightReady ? renderedText : null}
-          page={currentPage}
-          scale={scale}
-          highlights={state.fields}
-          boxHighlights={state.bboxes}
-          activeIds={state.activeIds}
-          {...highlightProps}
-        />
-      )}
+      {({ proportion }: { proportion: number }) => {
+        return (
+          (state.fields || state.bboxes) && (
+            <PdfHighlight
+              parsedDocument={highlightReady ? documentInfo ?? null : null}
+              pdfRenderedText={highlightReady ? renderedText : null}
+              page={currentPage}
+              scale={scale * proportion}
+              highlights={state.fields}
+              boxHighlights={state.bboxes}
+              activeIds={state.activeIds}
+              {...highlightProps}
+            />
+          )
+        );
+      }}
     </PdfViewer>
   );
 };

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
@@ -4,11 +4,27 @@
 
 .#{$prefix}--document-preview-pdf-viewer {
   display: flex;
-  justify-content: center;
+
+  // Take up entire width, but do not expand beyond it
+  width: 100%;
+  max-width: 100%;
 }
 
 .#{$prefix}--document-preview-pdf-viewer__wrapper {
   position: relative;
+
+  // This combination should force all browsers to
+  // allow full scrolling of PDFs when zoomed in
+  justify-content: safe center;
+  min-width: min-content;
+
+  // Center when smaller than the window width
+  margin-left: auto;
+  margin-right: auto;
+
+  // Prevent bottom whitespace from displaying
+  line-height: 0;
+
   @include pdfjsTextLayer;
 }
 

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview.scss
@@ -20,7 +20,7 @@
 
 .#{$prefix}--document-preview__document {
   position: relative;
-  overflow: scroll;
+  overflow: auto;
 }
 
 .#{$prefix}--document-preview__document > * {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,10 +2163,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.3, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
+    "@react-hook/resize-observer": ^1.2.6
     "@rollup/plugin-alias": ^3.1.5
     "@rollup/plugin-commonjs": ^20.0.0
     "@rollup/plugin-json": ^4.1.0
@@ -2531,6 +2532,13 @@ __metadata:
     "@types/yargs": ^15.0.0
     chalk: ^4.0.0
   checksum: a0bd3d2f22f26ddb23f41fddf6e6a30bf4fab2ce79ec1cb6ce6fdfaf90a72e00f4c71da91ec61e13db3b10c41de22cf49d07c57ff2b59171d64b29f909c1d8d6
+  languageName: node
+  linkType: hard
+
+"@juggle/resize-observer@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "@juggle/resize-observer@npm:3.3.1"
+  checksum: ddabc4044276a2cb57d469c4917206c7e39f2463aa8e3430e33e4eda554412afe29c22afa40e6708b49dad5d56768dc83acd68a704b1dcd49a0906bb96b991b2
   languageName: node
   linkType: hard
 
@@ -3691,6 +3699,37 @@ __metadata:
     react: 15.x || 16.x || 16.4.0-alpha.0911da3
     react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
   checksum: f64372497e0464a9fdfd79283fec3f4fd01ee093f1599d8a8035e0a41fbce22113bfa46dcea63aa8b7b4e0796e916f134aa8e3fccd3974be397e7c19468de3c4
+  languageName: node
+  linkType: hard
+
+"@react-hook/latest@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@react-hook/latest@npm:1.0.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 2408c9cd35c5cfa7697b6da3bc5eebef254a932ade70955074c474f23be7dd3e2f81bbba12edcc9208bd0f89c6ed366d6b11d4f6d7b1052877a0bac8f74afad4
+  languageName: node
+  linkType: hard
+
+"@react-hook/passive-layout-effect@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@react-hook/passive-layout-effect@npm:1.2.1"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 217cb8aa90fb8e677672319a9a466d7752890cf4357c76df000b207696e9cc717cf2ee88080671cc9dae238a82f92093ab4f61ab2f6032d2a8db958fc7d99b5d
+  languageName: node
+  linkType: hard
+
+"@react-hook/resize-observer@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@react-hook/resize-observer@npm:1.2.6"
+  dependencies:
+    "@juggle/resize-observer": ^3.3.1
+    "@react-hook/latest": ^1.0.2
+    "@react-hook/passive-layout-effect": ^1.2.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: d2ff6c50e847514acad774f2a4010fb1e6782a231ae00c9507c1a98028b3a26399e35f094170918f11b1eeafc581d60da7641bc178d496abf00c56eee8a6b36b
   languageName: node
   linkType: hard
 
@@ -10664,7 +10703,7 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^3.0.2
+    "@ibm-watson/discovery-react-components": ^3.0.3
     "@ibm-watson/discovery-styles": ^3.0.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,7 +2167,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
-    "@react-hook/resize-observer": ^1.2.6
+    "@react-hook/size": ^2.1.2
     "@rollup/plugin-alias": ^3.1.5
     "@rollup/plugin-commonjs": ^20.0.0
     "@rollup/plugin-json": ^4.1.0
@@ -3720,7 +3720,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-hook/resize-observer@npm:^1.2.6":
+"@react-hook/resize-observer@npm:^1.2.1":
   version: 1.2.6
   resolution: "@react-hook/resize-observer@npm:1.2.6"
   dependencies:
@@ -3730,6 +3730,18 @@ __metadata:
   peerDependencies:
     react: ">=16.8"
   checksum: d2ff6c50e847514acad774f2a4010fb1e6782a231ae00c9507c1a98028b3a26399e35f094170918f11b1eeafc581d60da7641bc178d496abf00c56eee8a6b36b
+  languageName: node
+  linkType: hard
+
+"@react-hook/size@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@react-hook/size@npm:2.1.2"
+  dependencies:
+    "@react-hook/passive-layout-effect": ^1.2.0
+    "@react-hook/resize-observer": ^1.2.1
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 89876e93957f420ba63518b60992b46ca82b0d12da0cf50ad487461e0b4230ec0e036ecf100840e2b2e93c9101895ad33e8bd6bc02a25641c28c904a09ab2563
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### What do these changes do/fix?

- Set initial canvas size based on the available width
- Adjust the size of the text layer and highlights proportionally
- Add ResizeObserver to adjust canvas accordingly when page is resized

Contributes to https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/12758

#### How do you test/verify these changes?

- Run UI locally linked with components repo running with this branch.
- Check that document highlighting, underlining, and boxing all align with PDF documents, regardless of zooming in and out
- Check that Storybook looks correct and that zooming works correctly for all stories

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

