### PR TITLE
fix: prevent unnecessary horizontal scrollbar

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -3,7 +3,7 @@ import cx from 'classnames';
 import PdfjsLib, { PDFDocumentProxy, PDFPageProxy, PDFPromise, PDFRenderTask } from 'pdfjs-dist';
 import PdfjsWorkerAsText from 'pdfjs-dist/build/pdf.worker.min.js';
 import { settings } from 'carbon-components';
-import useSize from '@react-hook/size';
+import useSize from 'utils/useSize';
 import useAsyncFunctionCall from 'utils/useAsyncFunctionCall';
 import { QueryResult } from 'ibm-watson/discovery/v2';
 import { DocumentFile } from '../../types';
@@ -83,7 +83,9 @@ const PdfViewer: FC<Props> = ({
     )
   );
 
-  const [width] = useSize(rootRef);
+  // Returns the width of the root ref in order to trigger resizing the canvas when this value changes
+  const { width } = useSize(rootRef);
+
   useEffect(() => {
     // width has changed; update canvas info
     setCanvasInfo(getCanvasInfo(loadedPage, scale, width));

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -70,7 +70,7 @@ const PdfViewer: FC<Props> = ({
   children
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const [rootNode, setRootNode] = useState<HTMLElement | null>(null);
   const [canvasInfo, setCanvasInfo] = useState<CanvasInfo | null>(null);
 
   const loadedFile = useAsyncFunctionCall(
@@ -83,8 +83,13 @@ const PdfViewer: FC<Props> = ({
     )
   );
 
-  // Returns the width of the root ref in order to trigger resizing the canvas when this value changes
-  const { width } = useSize(rootRef);
+  // Avoid issues with useRef not notifying effects about changes
+  // @see https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+  const rootRef = useCallback(node => {
+    setRootNode(node);
+  }, []);
+
+  const { width } = useSize(rootNode);
 
   useEffect(() => {
     // width has changed; update canvas info

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -3,6 +3,7 @@ import cx from 'classnames';
 import PdfjsLib, { PDFDocumentProxy, PDFPageProxy, PDFPromise, PDFRenderTask } from 'pdfjs-dist';
 import PdfjsWorkerAsText from 'pdfjs-dist/build/pdf.worker.min.js';
 import { settings } from 'carbon-components';
+import useSafeRef from 'utils/useSafeRef';
 import useSize from 'utils/useSize';
 import useAsyncFunctionCall from 'utils/useAsyncFunctionCall';
 import { QueryResult } from 'ibm-watson/discovery/v2';
@@ -70,7 +71,7 @@ const PdfViewer: FC<Props> = ({
   children
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [rootNode, setRootNode] = useState<HTMLElement | null>(null);
+  const { node: rootNode, setRef: setRootRef } = useSafeRef();
   const [canvasInfo, setCanvasInfo] = useState<CanvasInfo | null>(null);
 
   const loadedFile = useAsyncFunctionCall(
@@ -82,12 +83,6 @@ const PdfViewer: FC<Props> = ({
       [loadedFile, page]
     )
   );
-
-  // Avoid issues with useRef not notifying effects about changes
-  // @see https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
-  const rootRef = useCallback(node => {
-    setRootNode(node);
-  }, []);
 
   const { width } = useSize(rootNode);
 
@@ -131,7 +126,7 @@ const PdfViewer: FC<Props> = ({
 
   const base = `${settings.prefix}--document-preview-pdf-viewer`;
   return (
-    <div ref={rootRef} className={cx(base, className)}>
+    <div ref={setRootRef} className={cx(base, className)}>
       <div className={`${base}__wrapper`}>
         <canvas
           ref={canvasRef}

--- a/packages/discovery-react-components/src/index.tsx
+++ b/packages/discovery-react-components/src/index.tsx
@@ -18,4 +18,6 @@ export { default as StructuredQuery } from './components/StructuredQuery/Structu
 
 // utility methods
 export { getDocumentTitle } from './utils/getDocumentTitle';
+export { default as useSafeRef } from './utils/useSafeRef';
+export { default as useSize } from './utils/useSize';
 export { escapeFieldName } from './components/SearchFacets/utils/escapeFieldName';

--- a/packages/discovery-react-components/src/utils/useSafeRef.ts
+++ b/packages/discovery-react-components/src/utils/useSafeRef.ts
@@ -1,0 +1,22 @@
+import { useState, useCallback } from 'react';
+
+// A hook to create a ref whose node can be used in effects
+// This is necessary to avoid issues with useRef not notifying effects about changes
+// @see https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+
+type SafeRefProps = {
+  setRef: (node: HTMLElement | null) => void;
+  node: HTMLElement | null;
+};
+
+const useSafeRef = (): SafeRefProps => {
+  const [node, setNode] = useState(null);
+
+  const setRef = useCallback(node => {
+    setNode(node);
+  }, []);
+
+  return { setRef, node };
+};
+
+export default useSafeRef;

--- a/packages/discovery-react-components/src/utils/useSize.ts
+++ b/packages/discovery-react-components/src/utils/useSize.ts
@@ -1,0 +1,37 @@
+import { useState, useLayoutEffect, RefObject } from 'react';
+import useResizeObserver from '@react-hook/resize-observer';
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+/**
+ * This hook is similar to the useSize hook shipped with @react-hook,
+ * but uses getBoundingClientRect for more precise measurements
+ *
+ * @param target A React ref of the element to be measured
+ */
+const useSize = <T extends HTMLElement>(target: RefObject<T>): Size => {
+  const [size, setSize] = useState<Size>(getCurrentSize(target));
+
+  useLayoutEffect(() => {
+    setSize(getCurrentSize(target));
+  }, [target]);
+
+  useResizeObserver(target, () => {
+    setSize(getCurrentSize(target));
+  });
+
+  return size;
+};
+
+function getCurrentSize(target: RefObject<HTMLElement>) {
+  const size = target?.current?.getBoundingClientRect();
+  return {
+    width: size?.width || 0,
+    height: size?.height || 0
+  };
+}
+
+export default useSize;

--- a/packages/discovery-react-components/src/utils/useSize.ts
+++ b/packages/discovery-react-components/src/utils/useSize.ts
@@ -1,4 +1,4 @@
-import { useState, useLayoutEffect, RefObject } from 'react';
+import { useState, useLayoutEffect } from 'react';
 import useResizeObserver from '@react-hook/resize-observer';
 
 type Size = {
@@ -12,7 +12,7 @@ type Size = {
  *
  * @param target A React ref of the element to be measured
  */
-const useSize = <T extends HTMLElement>(target: RefObject<T>): Size => {
+const useSize = (target: HTMLElement | null): Size => {
   const [size, setSize] = useState<Size>(getCurrentSize(target));
 
   useLayoutEffect(() => {
@@ -26,8 +26,8 @@ const useSize = <T extends HTMLElement>(target: RefObject<T>): Size => {
   return size;
 };
 
-function getCurrentSize(target: RefObject<HTMLElement>) {
-  const size = target?.current?.getBoundingClientRect();
+function getCurrentSize(target: HTMLElement | null) {
+  const size = target?.getBoundingClientRect();
   return {
     width: size?.width || 0,
     height: size?.height || 0

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
@@ -8,6 +8,8 @@
   // Take up entire width, but do not expand beyond it
   width: 100%;
   max-width: 100%;
+
+  overflow: auto;
 }
 
 .#{$prefix}--document-preview-pdf-viewer__wrapper {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2163,7 +2163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.3, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.0.4, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2219,7 +2219,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^3.0.0, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^3.0.4, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -10715,8 +10715,8 @@ __metadata:
   dependencies:
     "@carbon/icons": ^10.5.0
     "@cypress/webpack-preprocessor": ^5.11.0
-    "@ibm-watson/discovery-react-components": ^3.0.3
-    "@ibm-watson/discovery-styles": ^3.0.0
+    "@ibm-watson/discovery-react-components": ^3.0.4
+    "@ibm-watson/discovery-styles": ^3.0.4
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
     body-parser: ^1.19.0


### PR DESCRIPTION
#### What do these changes do/fix?

- use the width of the bounding rectangle of the root ref, since useSize rounds up on half pixels

#### How do you test/verify these changes?
- Run Storybook, and check that PdfViewer stories are handling zooming and resizing properly and don't have unnecessary scrollbars
- Link to tooling and run tooling Storybook, and check that StructureView stories are handling zooming and resizing properly and don't have unnecessary scrollbars

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

