### PR TITLE
feat: strip out inputs, forms, buttons, and scripts from HTML doc view

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -40,6 +40,9 @@ const SANITIZE_CONFIG = {
     // bbox
     'page'
   ],
+  FORBID_TAGS: ['input', 'form', 'a', 'button', 'script'],
+  FORBID_CONTENTS: ['script'],
+  KEEP_CONTENT: true,
   WHOLE_DOCUMENT: true
 };
 


### PR DESCRIPTION
#### What do these changes do/fix?
Related to https://github.ibm.com/watson-discovery/disco-issue-tracker/issues/12092
<!--
If there's a related issue, please add a link to the issue here.
-->
Adds settings to the config getting passed into DOMPurify, so that the HTML docs we display to users don't have elements such as inputs, forms, and scripts that could execute code or navigate them away from the current page. Leaves the content in place as text on the document for everything except the scripts.

**BEFORE (note login forms)**
![image](https://user-images.githubusercontent.com/11284492/192057442-0fd26958-6f56-4630-bed7-5b17848b40bd.png)

**AFTER**
<img width="891" alt="Screen Shot 2022-09-23 at 5 11 50 PM" src="https://user-images.githubusercontent.com/11284492/192057388-bdb7c6e9-44c0-4222-9f62-1dfc6a4bdc7a.png">
(Not same file, but very similar, so you can see the effect of the new restrictions)

#### How do you test/verify these changes?
1. Link to tooling
2. (you'll probably have to manually set the uuid dependency in `discovery-react-components/package.json` to "^8.0.0" in order to avoid a version mismatch error)
3. Run tooling & upload some HTML docs to a collection which contain elements like login forms, links, scripts, etc.
4. Once docs have processed, view them in the HTML view, and see that the forbidden elements are just text now.
#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
I don't think this should break anyone's code, but it would limit functionality if, for some reason, a user expected to use any of the forbidden tags when viewing document results. 🤷🏻‍♂️ 
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
