### PR TITLE
fix: finish updating pdfjs

### DIFF
--- a/examples/discovery-search-app/package.json
+++ b/examples/discovery-search-app/package.json
@@ -7,10 +7,10 @@
   "author": "IBM Corp.",
   "homepage": ".",
   "scripts": {
+    "setup": "mkdir -p ./public/assets/ && cp ../../node_modules/pdfjs-dist/build/pdf.worker.min.js ./public/assets/pdf.worker.min.js",
     "build:app": "yarn run build",
-    "build": "cross-env SKIP_PREFLIGHT_CHECK=true CI=false react-scripts build",
-    "eject": "cross-env SKIP_PREFLIGHT_CHECK=true react-scripts eject",
-    "start": "cross-env SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "build": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true CI=false react-scripts build",
+    "start": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true react-scripts start",
     "lint": "yarn run g:eslint --quiet '{src,cypress}/**/*.{js,jsx,ts,tsx}' './*.{js,jsx,ts,tsx}'",
     "test:e2e": "cross-env REACT_APP_CYPRESS_MODE=true BROWSER=none CYPRESS_baseUrl=http://localhost:3000 start-server-and-test start http://localhost:3000 'cypress run'",
     "test:unit": "cross-env SKIP_PREFLIGHT_CHECK=true CI=1 react-scripts test --env=jsdom",

--- a/packages/discovery-react-components/.storybook/main.ts
+++ b/packages/discovery-react-components/.storybook/main.ts
@@ -14,7 +14,7 @@ module.exports = {
   core: {
     builder: 'webpack5',
   },
-  staticDirs: ['../../../node_modules/pdfjs-dist'],
+  staticDirs: ['../../../node_modules/pdfjs-dist/build/'],
   webpackFinal: (config) => {
     // ignore some Node.js packages
     config.resolve.fallback.crypto = false;

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -55,6 +55,10 @@ interface Props extends WithErrorBoundaryProps {
    */
   messages?: Messages;
   /**
+   * URL of hosted PDF worker
+   */
+  pdfWorkerUrl?: string;
+  /**
    * React component rendered as a fallback when no preview is available
    */
   fallbackComponent?: ComponentProps<typeof SimpleDocument>['fallbackComponent'];
@@ -74,6 +78,7 @@ const DocumentPreview: FC<Props> = ({
   highlight,
   messages = defaultMessages,
   didCatch,
+  pdfWorkerUrl,
   fallbackComponent,
   onChange
 }) => {
@@ -147,6 +152,7 @@ const DocumentPreview: FC<Props> = ({
               loading={loading}
               hideToolbarControls={hideToolbarControls}
               setCurrentPage={setCurrentPage}
+              pdfWorkerUrl={pdfWorkerUrl}
               fallbackComponent={fallbackComponent}
             />
           </div>
@@ -178,6 +184,7 @@ interface PreviewDocumentProps
   loading: boolean;
   hideToolbarControls: boolean;
   setCurrentPage?: (page: number) => void;
+  pdfWorkerUrl?: string;
 }
 
 function PreviewDocument({
@@ -193,6 +200,7 @@ function PreviewDocument({
   highlight,
   disableTextLayer,
   setCurrentPage,
+  pdfWorkerUrl,
   fallbackComponent
 }: PreviewDocumentProps): ReactElement | null {
   const previewType = useMemo(
@@ -218,6 +226,7 @@ function PreviewDocument({
           highlight={highlight}
           setCurrentPage={setCurrentPage}
           disableTextLayer={disableTextLayer}
+          pdfWorkerUrl={pdfWorkerUrl}
         />
       );
     case 'HTML':

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -57,7 +57,7 @@ interface Props extends WithErrorBoundaryProps {
   /**
    * URL of hosted PDF worker
    */
-  pdfWorkerUrl?: string;
+  pdfWorkerUrl: string;
   /**
    * React component rendered as a fallback when no preview is available
    */
@@ -184,7 +184,7 @@ interface PreviewDocumentProps
   loading: boolean;
   hideToolbarControls: boolean;
   setCurrentPage?: (page: number) => void;
-  pdfWorkerUrl?: string;
+  pdfWorkerUrl: string;
 }
 
 function PreviewDocument({

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
@@ -6,6 +6,9 @@ import PdfViewer from './PdfViewer';
 import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Effects.pdf';
 import './PdfViewer.stories.scss';
 
+// pulled from pdfjs-dist (see main.js > staticDirs)
+const PDF_WORKER_URL = 'pdf.worker.min.js';
+
 const sourceKnob = {
   label: 'Source',
   options: {
@@ -61,8 +64,7 @@ storiesOf('DocumentPreview/components/PdfViewer', module)
           scale={scale}
           setLoading={setLoadingAction}
           setRenderedText={setRenderedTextAction}
-          // pulled from pdfjs-dist (see main.js > staticDirs)
-          pdfWorkerUrl={'pdf.worker.min.js'}
+          pdfWorkerUrl={PDF_WORKER_URL}
         />
       </div>
     );

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.stories.tsx
@@ -61,6 +61,8 @@ storiesOf('DocumentPreview/components/PdfViewer', module)
           scale={scale}
           setLoading={setLoadingAction}
           setRenderedText={setRenderedTextAction}
+          // pulled from pdfjs-dist (see main.js > staticDirs)
+          pdfWorkerUrl={'pdf.worker.min.js'}
         />
       </div>
     );

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -226,7 +226,8 @@ function _renderPage(
 let currentPdfWorkerUrl: string | null = null;
 function setupPdfjs(pdfWorkerUrl: string): void {
   // Only load the worker the first time the worker url is sent in
-  if (pdfWorkerUrl !== currentPdfWorkerUrl) {
+  // and don't load the worker in unit tests (see setupTests.ts)
+  if (typeof Worker !== 'undefined' && pdfWorkerUrl !== currentPdfWorkerUrl) {
     const pdfjsWorker = new Worker(pdfWorkerUrl);
     PdfjsLib.GlobalWorkerOptions.workerPort = pdfjsWorker;
     currentPdfWorkerUrl = pdfWorkerUrl;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -57,7 +57,7 @@ export type PdfViewerProps = PdfDisplayProps & {
   /**
    * URL of hosted PDF worker
    */
-  pdfWorkerUrl?: string;
+  pdfWorkerUrl: string;
 };
 
 const PdfViewer: FC<PdfViewerProps> = ({

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
@@ -7,6 +7,7 @@ import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Eff
 
 describe('PdfViewer', () => {
   it('renders PDF document', async () => {
+    // @ts-ignore pdfWorkerUrl is required, but needs to be undefined for tests
     render(<PdfViewer file={atob(doc)} page={1} scale={1} setLoading={(): void => {}} />);
 
     // wait for component to finish rendering (prevent "act" warning)

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
@@ -7,8 +7,15 @@ import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Eff
 
 describe('PdfViewer', () => {
   it('renders PDF document', async () => {
-    // @ts-ignore pdfWorkerUrl is required, but needs to be undefined for tests
-    render(<PdfViewer file={atob(doc)} page={1} scale={1} setLoading={(): void => {}} />);
+    render(
+      <PdfViewer
+        file={atob(doc)}
+        page={1}
+        scale={1}
+        setLoading={(): void => {}}
+        pdfWorkerUrl={''}
+      />
+    );
 
     // wait for component to finish rendering (prevent "act" warning)
     await waitFor(() => expect(screen.getByText('ART EFFECTS LIMITED')).toBeVisible());

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
@@ -27,6 +27,9 @@ import document from 'components/DocumentPreview/__fixtures__/Art Effects Koya C
 import { document as docJa } from 'components/DocumentPreview/__fixtures__/DiscoComponent-ja.pdf';
 import documentJa from 'components/DocumentPreview/__fixtures__/DiscoComponents-ja_document.json';
 
+// pulled from pdfjs-dist (see main.js > staticDirs)
+const PDF_WORKER_URL = 'pdf.worker.min.js';
+
 const pageKnob = {
   label: 'Page',
   options: {
@@ -180,8 +183,7 @@ const WithTextSelection: typeof PdfViewerWithHighlight = props => {
         highlights={highlights}
         activeIds={activeIds}
         highlightClassName="highlight"
-        // pulled from pdfjs-dist (see main.js > staticDirs)
-        pdfWorkerUrl={'pdf.worker.min.js'}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
       <div className="rightPane">
         <h6>
@@ -281,8 +283,7 @@ const WithToolbar: FC<
         scale={zoom}
         activeIds={activeIds}
         highlightClassName="highlight"
-        // pulled from pdfjs-dist (see main.js > staticDirs)
-        pdfWorkerUrl={'pdf.worker.min.js'}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
     </div>
   );
@@ -332,8 +333,7 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         highlights={highlightKnob.data[highlights]}
         activeIds={activeIds}
         setCurrentPage={handleSetCurrentPage}
-        // pulled from pdfjs-dist (see main.js > staticDirs)
-        pdfWorkerUrl={'pdf.worker.min.js'}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
     );
   })
@@ -353,6 +353,7 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         document={document}
         highlights={EMPTY}
         setCurrentPage={setCurrentPage}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
     );
   })
@@ -372,6 +373,7 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         document={documentJa}
         highlights={EMPTY}
         setCurrentPage={setCurrentPage}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
     );
   })
@@ -413,6 +415,7 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         document={document}
         highlights={EMPTY}
         setCurrentPage={setCurrentPage}
+        pdfWorkerUrl={PDF_WORKER_URL}
       />
     );
   })

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewerWithHighlight/PdfViewerWithHighlight.stories.tsx
@@ -180,6 +180,8 @@ const WithTextSelection: typeof PdfViewerWithHighlight = props => {
         highlights={highlights}
         activeIds={activeIds}
         highlightClassName="highlight"
+        // pulled from pdfjs-dist (see main.js > staticDirs)
+        pdfWorkerUrl={'pdf.worker.min.js'}
       />
       <div className="rightPane">
         <h6>
@@ -279,6 +281,8 @@ const WithToolbar: FC<
         scale={zoom}
         activeIds={activeIds}
         highlightClassName="highlight"
+        // pulled from pdfjs-dist (see main.js > staticDirs)
+        pdfWorkerUrl={'pdf.worker.min.js'}
       />
     </div>
   );
@@ -328,6 +332,8 @@ storiesOf('DocumentPreview/components/PdfViewerWithHighlight', module)
         highlights={highlightKnob.data[highlights]}
         activeIds={activeIds}
         setCurrentPage={handleSetCurrentPage}
+        // pulled from pdfjs-dist (see main.js > staticDirs)
+        pdfWorkerUrl={'pdf.worker.min.js'}
       />
     );
   })

--- a/packages/discovery-react-components/src/setupTests.ts
+++ b/packages/discovery-react-components/src/setupTests.ts
@@ -1,3 +1,6 @@
 import '@testing-library/jest-dom/extend-expect';
+import * as PdfjsLib from 'pdfjs-dist';
 
+// Set pdf.js worker for all tests
+PdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.min.js';
 Element.prototype.scrollIntoView = jest.fn();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.0.7, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -11093,7 +11093,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^3.0.7
+    "@ibm-watson/discovery-react-components": ^3.1.0
     "@ibm-watson/discovery-styles": ^3.0.7
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
@@ -25765,7 +25765,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^3.8.2, typescript@npm:^3.9.5, typescript@npm:^3.9.7":
+"typescript@npm:^3.8.2":
+  version: 3.9.10
+  resolution: "typescript@npm:3.9.10"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 46c842e2cd4797b88b66ef06c9c41dd21da48b95787072ccf39d5f2aa3124361bc4c966aa1c7f709fae0509614d76751455b5231b12dbb72eb97a31369e1ff92
+  languageName: node
+  linkType: hard
+
+"typescript@npm:^3.9.5, typescript@npm:^3.9.7":
   version: 3.9.7
   resolution: "typescript@npm:3.9.7"
   bin:
@@ -25775,7 +25785,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^3.8.2#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.7#~builtin<compat/typescript>":
+"typescript@patch:typescript@^3.8.2#~builtin<compat/typescript>":
+  version: 3.9.10
+  resolution: "typescript@patch:typescript@npm%3A3.9.10#~builtin<compat/typescript>::version=3.9.10&hash=a1c5e5"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: dc7141ab555b23a8650a6787f98845fc11692063d02b75ff49433091b3af2fe3d773650dea18389d7c21f47d620fb3b110ea363dab4ab039417a6ccbbaf96fc2
+  languageName: node
+  linkType: hard
+
+"typescript@patch:typescript@^3.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.7#~builtin<compat/typescript>":
   version: 3.9.7
   resolution: "typescript@patch:typescript@npm%3A3.9.7#~builtin<compat/typescript>::version=3.9.7&hash=a1c5e5"
   bin:


### PR DESCRIPTION
#### What do these changes do/fix?

- Add prop to send in a url for pdf.js worker
- Use this prop in the example app and Storybook
- Adjust tests accordingly

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
Yes, any use of the `PdfViewer` component (standalone, or as part of `PdfViewerWithHighlight`, `DocumentPreview` or `PreviewDocument` will need to supply a URL string to a hosted `pdf.js` worker file (e.g. https://github.com/mozilla/pdfjs-dist/blob/master/build/pdf.worker.min.js) via the `pdfWorkerUrl` prop.
