### PR TITLE
fix: finish updating pdfjs

### DIFF
--- a/examples/discovery-search-app/src/App.js
+++ b/examples/discovery-search-app/src/App.js
@@ -22,6 +22,8 @@ import {
   canRenderCIDocument
 } from '@ibm-watson/discovery-react-components';
 
+const PDF_WORKER_URL = './assets/pdf.worker.min.js';
+
 const App = () => {
   const searchClient = useMemo(() => {
     // Tell SDK to send requests to our server's `/api` endpoint, where
@@ -173,7 +175,8 @@ function PreviewPage() {
   const tabs = [
     {
       name: 'Document',
-      Component: DocumentPreview
+      Component: DocumentPreview,
+      componentProps: { pdfWorkerUrl: PDF_WORKER_URL }
     }
   ];
 
@@ -207,7 +210,7 @@ function PreviewPage() {
           selected={0}
           aria-label="Document details tabs"
         >
-          {tabs.map(({ name, Component, ...restProps }) => (
+          {tabs.map(({ name, Component, componentProps, ...restProps }) => (
             <Tab
               key={name}
               label={name}
@@ -219,7 +222,7 @@ function PreviewPage() {
                     [`${settings.prefix}--search-app__content`]: true
                   })}
                 >
-                  <Component document={fullDocument} />
+                  <Component document={fullDocument} {...componentProps} />
                 </div>
               )}
             />

--- a/packages/discovery-react-components/README.md
+++ b/packages/discovery-react-components/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [@ibm-watson/discovery-react-components](#ibm-watsondiscovery-react-components)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [Setting up PdfViewer](#setting-up-pdfviewer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # @ibm-watson/discovery-react-components
 
 >
@@ -53,3 +63,10 @@ const App = () => {
   );
 };
 ```
+
+## Setting up PdfViewer
+
+To use the PdfViewer component (or the components that use it, e.g. PdfViewerWithHighlight, DocumentPreview) you will need to provide pdf.js with a PDF worker. This can be done in one of two ways:
+
+- Use the `pdfWorkerUrl` prop to send the URl of a pdf worker JS file (either self-hosted or externally hosted) to any of `PdfViewer`, `PdfViewerWithHighlight`, `DocumentPreview`, or `DocumentPreview.PreviewDocument`.
+- Set `GlobalWorkerOptions.workerSrc` globally (see `src/setupTests.ts` for an example).

--- a/packages/discovery-react-components/README.md
+++ b/packages/discovery-react-components/README.md
@@ -4,7 +4,7 @@
 - [@ibm-watson/discovery-react-components](#ibm-watsondiscovery-react-components)
   - [Install](#install)
   - [Usage](#usage)
-  - [Setting up PdfViewer](#setting-up-pdfviewer)
+  - [Rendering PDFs](#rendering-pdfs)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -64,9 +64,9 @@ const App = () => {
 };
 ```
 
-## Setting up PdfViewer
+## Rendering PDFs
 
-To use the PdfViewer component (or the components that use it, e.g. PdfViewerWithHighlight, DocumentPreview) you will need to provide pdf.js with a PDF worker. This can be done in one of two ways:
+If you want to use the Discovery Components (`DocumentPreview` or `PdfViewer`) to render PDF documents, you will need to set up the pdf.js worker script. This can be done in one of two ways:
 
-- Use the `pdfWorkerUrl` prop to send the URl of a pdf worker JS file (either self-hosted or externally hosted) to any of `PdfViewer`, `PdfViewerWithHighlight`, `DocumentPreview`, or `DocumentPreview.PreviewDocument`.
-- Set `GlobalWorkerOptions.workerSrc` globally (see `src/setupTests.ts` for an example).
+1. Set the `pdfWorkerUrl` prop to the URL of the pdf.js worker script (i.e. `pdf.worker.min.js`) to any of `DocumentPreview`, `PdfViewer`, `PdfViewerWithHighlight`, or `DocumentPreview.PreviewDocument`. (see examples/discovery-search-app/src/App.js for an example)
+2. Set `PdfjsLib.GlobalWorkerOptions.workerSrc` globally to the file path of the pdf.js worker script (see `src/setupTests.ts` for an example).

--- a/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/DocumentPreview.tsx
@@ -57,7 +57,7 @@ interface Props extends WithErrorBoundaryProps {
   /**
    * URL of hosted PDF worker
    */
-  pdfWorkerUrl: string;
+  pdfWorkerUrl?: string;
   /**
    * React component rendered as a fallback when no preview is available
    */
@@ -184,7 +184,7 @@ interface PreviewDocumentProps
   loading: boolean;
   hideToolbarControls: boolean;
   setCurrentPage?: (page: number) => void;
-  pdfWorkerUrl: string;
+  pdfWorkerUrl?: string;
 }
 
 function PreviewDocument({

--- a/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/__stories__/DocumentPreview.stories.tsx
@@ -12,6 +12,9 @@ import jsonPassages from '../__fixtures__/jsonPassages';
 import omit from 'lodash/omit';
 import pickBy from 'lodash/pickBy';
 
+// pulled from pdfjs-dist (see main.js > staticDirs)
+const PDF_WORKER_URL = 'pdf.worker.min.js';
+
 interface WrapperProps {
   style?: any;
 }
@@ -27,7 +30,12 @@ storiesOf('DocumentPreview', module)
     const [file, doc] = docSelection();
     return (
       <Wrapper>
-        <DocumentPreview document={doc} file={file} onChange={action('change')} />
+        <DocumentPreview
+          document={doc}
+          file={file}
+          onChange={action('change')}
+          pdfWorkerUrl={PDF_WORKER_URL}
+        />
       </Wrapper>
     );
   })
@@ -51,6 +59,7 @@ storiesOf('DocumentPreview', module)
           highlight={highlight}
           file={file}
           onChange={action('change')}
+          pdfWorkerUrl={PDF_WORKER_URL}
         />
       </Wrapper>
     );
@@ -73,6 +82,7 @@ storiesOf('DocumentPreview', module)
           document={docWithTable}
           highlight={highlight}
           onChange={action('change')}
+          pdfWorkerUrl={PDF_WORKER_URL}
         />
       </Wrapper>
     );
@@ -92,7 +102,11 @@ storiesOf('DocumentPreview', module)
 
     return (
       <Wrapper>
-        <DocumentPreview document={doc} fallbackComponent={fallback} />
+        <DocumentPreview
+          document={doc}
+          fallbackComponent={fallback}
+          pdfWorkerUrl={PDF_WORKER_URL}
+        />
       </Wrapper>
     );
   })
@@ -120,6 +134,7 @@ storiesOf('DocumentPreview', module)
             document={docArtEffects}
             fileFetchTimeout={fileFetchTimeout}
             onChange={action('change')}
+            pdfWorkerUrl={PDF_WORKER_URL}
           />
         </SearchContext.Provider>
       </Wrapper>

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewer.tsx
@@ -57,7 +57,7 @@ export type PdfViewerProps = PdfDisplayProps & {
   /**
    * URL of hosted PDF worker
    */
-  pdfWorkerUrl: string;
+  pdfWorkerUrl?: string;
 };
 
 const PdfViewer: FC<PdfViewerProps> = ({
@@ -227,7 +227,7 @@ let currentPdfWorkerUrl: string | null = null;
 function setupPdfjs(pdfWorkerUrl: string): void {
   // Only load the worker the first time the worker url is sent in
   // and don't load the worker in unit tests (see setupTests.ts)
-  if (typeof Worker !== 'undefined' && pdfWorkerUrl !== currentPdfWorkerUrl) {
+  if (!!pdfWorkerUrl && pdfWorkerUrl !== currentPdfWorkerUrl) {
     const pdfjsWorker = new Worker(pdfWorkerUrl);
     PdfjsLib.GlobalWorkerOptions.workerPort = pdfjsWorker;
     currentPdfWorkerUrl = pdfWorkerUrl;

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/__tests__/PdfViewer.test.tsx
@@ -7,15 +7,7 @@ import { document as doc } from 'components/DocumentPreview/__fixtures__/Art Eff
 
 describe('PdfViewer', () => {
   it('renders PDF document', async () => {
-    render(
-      <PdfViewer
-        file={atob(doc)}
-        page={1}
-        scale={1}
-        setLoading={(): void => {}}
-        pdfWorkerUrl={''}
-      />
-    );
+    render(<PdfViewer file={atob(doc)} page={1} scale={1} setLoading={(): void => {}} />);
 
     // wait for component to finish rendering (prevent "act" warning)
     await waitFor(() => expect(screen.getByText('ART EFFECTS LIMITED')).toBeVisible());

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.1.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -11093,7 +11093,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^3.1.1
+    "@ibm-watson/discovery-react-components": ^3.1.0
     "@ibm-watson/discovery-styles": ^3.0.7
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^3.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^3.1.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -11093,7 +11093,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^3.1.0
+    "@ibm-watson/discovery-react-components": ^3.1.1
     "@ibm-watson/discovery-styles": ^3.0.7
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?

BREAKING CHANGE: - PDF worker now required to be set up in order to use PdfViewer component
- Make pdfWorkerUrl prop optional (can use GlobalWorkerOptions.workerSrc instead)

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
Yes, noted above.