### PR TITLE
fix: escape all search filter double quote characters

### DIFF
--- a/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
+++ b/packages/discovery-react-components/src/components/SearchFacets/utils/searchFilterTransform.tsx
@@ -83,7 +83,7 @@ export class SearchFilterTransform {
   private static unquoteString(quotedString: string): string {
     return quotedString
       .replace(new RegExp(SearchFilterTransform.STRING_IN_QUOTES), '$1')
-      .replace(/\\"/, '"');
+      .replace(/\\"/g, '"');
   }
 
   // Returns a full filter query string from the set of filterFields
@@ -112,7 +112,7 @@ export class SearchFilterTransform {
         const text = get(result, key, '');
         // Add double quotes to make the query a phrase query
         // @see https://cloud.ibm.com/docs/discovery-data?topic=discovery-data-query-operators#phrase
-        return `"${text.replace(/"/, '\\"')}"`;
+        return `"${text.replace(/"/g, '\\"')}"`;
       });
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^4.0.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^4.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2299,7 +2299,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^4.0.0, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^4.1.0, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -11114,8 +11114,8 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^4.0.2
-    "@ibm-watson/discovery-styles": ^4.0.0
+    "@ibm-watson/discovery-react-components": ^4.1.0
+    "@ibm-watson/discovery-styles": ^4.1.0
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
     body-parser: ^1.19.0


### PR DESCRIPTION
#### What do these changes do/fix?

- Escape all double quotes (rather than just the first) using a global regex

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
