### PR TITLE
build: set absolute SASS_PATH

### DIFF
--- a/examples/discovery-search-app/.env
+++ b/examples/discovery-search-app/.env
@@ -1,2 +1,4 @@
-SASS_PATH=node_modules:src
+# SASS_PATH is set in NPM scripts in `package.json`, due to issue with
+# Webpack v5 and sass-loader.
+# @see https://github.com/facebook/create-react-app/issues/12329
 REACT_APP_PROJECT_ID=

--- a/examples/discovery-search-app/package.json
+++ b/examples/discovery-search-app/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "setup": "mkdir -p ./public/assets/ && cp ../../node_modules/pdfjs-dist/build/pdf.worker.min.js ./public/assets/pdf.worker.min.js",
     "build:app": "yarn run build",
-    "build": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true CI=false react-scripts build",
-    "start": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "build": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true CI=false SASS_PATH=${PWD}/src react-scripts build",
+    "start": "yarn setup && cross-env SKIP_PREFLIGHT_CHECK=true SASS_PATH=${PWD}/src react-scripts start",
     "lint": "yarn run g:eslint --quiet '{src,cypress}/**/*.{js,jsx,ts,tsx}' './*.{js,jsx,ts,tsx}'",
     "test:e2e": "cross-env REACT_APP_CYPRESS_MODE=true BROWSER=none CYPRESS_baseUrl=http://localhost:3000 start-server-and-test start http://localhost:3000 'cypress run'",
     "test:unit": "cross-env SKIP_PREFLIGHT_CHECK=true CI=1 react-scripts test --env=jsdom",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^4.1.0, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^4.1.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -2299,7 +2299,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ibm-watson/discovery-styles@^4.1.0, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
+"@ibm-watson/discovery-styles@^4.1.1, @ibm-watson/discovery-styles@workspace:packages/discovery-styles":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-styles@workspace:packages/discovery-styles"
   dependencies:
@@ -11114,8 +11114,8 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^4.1.0
-    "@ibm-watson/discovery-styles": ^4.1.0
+    "@ibm-watson/discovery-react-components": ^4.1.1
+    "@ibm-watson/discovery-styles": ^4.1.1
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2
     body-parser: ^1.19.0
@@ -25799,7 +25799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^3.8.2":
+"typescript@npm:^3.8.2, typescript@npm:^3.9.5, typescript@npm:^3.9.7":
   version: 3.9.10
   resolution: "typescript@npm:3.9.10"
   bin:
@@ -25809,33 +25809,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^3.9.5, typescript@npm:^3.9.7":
-  version: 3.9.7
-  resolution: "typescript@npm:3.9.7"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: d549bf1d3a93796b45be9d1dbebbef63777f8cc4d788461f4bfdb6cb07371a97d3e471c7f39dbe31107e8a25d6d8b2ef5e967af7e8e1768d9560bd95095b360b
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^3.8.2#~builtin<compat/typescript>":
+"typescript@patch:typescript@^3.8.2#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.7#~builtin<compat/typescript>":
   version: 3.9.10
   resolution: "typescript@patch:typescript@npm%3A3.9.10#~builtin<compat/typescript>::version=3.9.10&hash=a1c5e5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: dc7141ab555b23a8650a6787f98845fc11692063d02b75ff49433091b3af2fe3d773650dea18389d7c21f47d620fb3b110ea363dab4ab039417a6ccbbaf96fc2
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^3.9.5#~builtin<compat/typescript>, typescript@patch:typescript@^3.9.7#~builtin<compat/typescript>":
-  version: 3.9.7
-  resolution: "typescript@patch:typescript@npm%3A3.9.7#~builtin<compat/typescript>::version=3.9.7&hash=a1c5e5"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: be4742230d87145344866f264771c0d78fe548479694279de1d8c9b1ea0942b1016a1957f87952924b370f86107bc71d95eb7feea16ad8875c61c571aca280e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
#### What do these changes do/fix?

After upgrade to Webpack v5, we were seeing several warnings about relative import paths for SCSS/CSS files during the example app build. This PR uses an absolute path for SASS_PATH so we no longer get these warnings.

#### How do you test/verify these changes?

Run `yarn start` or `yarn build` for the example app

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
