### PR TITLE
fix: make loading prop optional in HtmlView and fix style leaks

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -40,8 +40,8 @@ const SANITIZE_CONFIG = {
     // bbox
     'page'
   ],
-  FORBID_TAGS: ['input', 'form', 'a', 'button', 'script'],
-  FORBID_CONTENTS: ['script'],
+  FORBID_TAGS: ['input', 'form', 'a', 'button', 'script', 'style'],
+  FORBID_CONTENTS: ['script', 'style'],
   KEEP_CONTENT: true,
   WHOLE_DOCUMENT: true
 };

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -25,7 +25,7 @@ interface Props {
   /**
    * Check to disable toolbar in parent
    */
-  setLoading: (loading: boolean) => void;
+  setLoading?: (loading: boolean) => void;
   /**
    * Callback which is invoked with whether to enable/disable toolbar controls
    */

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -101,13 +101,17 @@ export const HtmlView: FC<Props> = ({
             <style>${processedDoc.styles}</style>
             ${DOMPurify.sanitize(fullHtml, SANITIZE_CONFIG)}
           `);
-          setLoading(false);
+          if (!!setLoading) {
+            setLoading(false);
+          }
         };
         process();
       } else {
         // if no highlight, then no need to "process"
         setHtml(docHtml ? DOMPurify.sanitize(docHtml, SANITIZE_CONFIG) : '');
-        setLoading(false);
+        if (!!setLoading) {
+          setLoading(false);
+        }
       }
     }
   }, [document, highlight, setLoading]);


### PR DESCRIPTION
#### What do these changes do/fix?
Makes the `setLoading` callback optional on the `HtmlView` component. Also adds `style` to the list of tags being removed by DomPurify when Html is rendered. This should prevent global styles from leaking into the rest of the application.

A future task intends to do a better job with style handling, and should make user documents retain some of their style without leakage: https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/12210

#### How do you test/verify these changes?
n/a

#### Have you documented your changes (if necessary)?
n/a

#### Are there any breaking changes included in this pull request?
no

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
