### PR TITLE
fix: keep styles from leaking in html view when highlight present

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/HtmlView/HtmlView.tsx
@@ -96,11 +96,13 @@ export const HtmlView: FC<Props> = ({
 
           setProcessedDoc(processedDoc);
 
+          // TODO: restore the styles getting added back into html as part of issue #12210, once sandboxed
           // set sanitized HTML (removing scripts, etc)
-          setHtml(`
-            <style>${processedDoc.styles}</style>
-            ${DOMPurify.sanitize(fullHtml, SANITIZE_CONFIG)}
-          `);
+          // setHtml(`
+          //   <style>${processedDoc.styles}</style>
+          //   ${DOMPurify.sanitize(fullHtml, SANITIZE_CONFIG)}
+          // `);
+          setHtml(DOMPurify.sanitize(fullHtml, SANITIZE_CONFIG));
           if (!!setLoading) {
             setLoading(false);
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2238,7 +2238,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ibm-watson/discovery-react-components@^4.1.1, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
+"@ibm-watson/discovery-react-components@^4.1.2, @ibm-watson/discovery-react-components@workspace:packages/discovery-react-components":
   version: 0.0.0-use.local
   resolution: "@ibm-watson/discovery-react-components@workspace:packages/discovery-react-components"
   dependencies:
@@ -11114,7 +11114,7 @@ __metadata:
   resolution: "discovery-search-app@workspace:examples/discovery-search-app"
   dependencies:
     "@carbon/icons": ^10.5.0
-    "@ibm-watson/discovery-react-components": ^4.1.1
+    "@ibm-watson/discovery-react-components": ^4.1.2
     "@ibm-watson/discovery-styles": ^4.1.1
     "@testing-library/cypress": ^7.0.7
     "@types/proper-url-join": ^2


### PR DESCRIPTION
#### What do these changes do/fix?
When we process an html document to render it in HtmlView -- as happens when there are highlights present -- we failed to strip all of the style elements, because they were getting manually added back outside the DOMPurify. This PR comments out that version of setting the html until we can sandbox the styling.

#### How do you test/verify these changes?
1. Link to tooling with the html view PR branch
2. Upload a pdf document and enable pre-trained sdu model
3. Query for the document, and view it in rich doc preview
4. See that the HTML View is correctly stripping style elements out of the rendered html

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
