### PR TITLE
feat: add unique highlighting colors to document preview text view

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
@@ -10,7 +10,7 @@ import { SkeletonText } from 'carbon-components-react';
 import Section, { OnFieldClickFn } from '../Section/Section';
 import VirtualScroll from '../VirtualScroll/VirtualScroll';
 import { defaultTheme, Theme } from 'utils/theme';
-import { SectionType, ItemMap } from 'components/CIDocument/types';
+import { SectionType, ItemMap, HighlightIdsByColor } from 'components/CIDocument/types';
 
 const baseClassName = `${settings.prefix}--ci-doc-content`;
 
@@ -29,7 +29,7 @@ export interface CIDocumentContentProps {
   theme?: Theme;
   documentId?: string;
   onItemClick?: OnFieldClickFn;
-  highlightedIdsByColor?: { color: string; highlightLocationIds: string[] }[];
+  highlightedIdsByColor?: HighlightIdsByColor;
 }
 
 const CIDocumentContent: FC<CIDocumentContentProps> = ({

--- a/packages/discovery-react-components/src/components/CIDocument/types.ts
+++ b/packages/discovery-react-components/src/components/CIDocument/types.ts
@@ -97,3 +97,5 @@ export interface Relations {
   attributes: Attributes[];
   relations?: Relations[];
 }
+
+export type HighlightIdsByColor = { color: string; highlightLocationIds: string[] }[];


### PR DESCRIPTION
#### What do these changes do/fix?
Adds a new, optional prop `highlightedIdsByColor` to the `CIDocumentContent` component, which lets us pass in specific colors for groups of highlights.
<!--
If there's a related issue, please add a link to the issue here.
-->
Related issue: https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/13111
Related PR: https://github.ibm.com/Watson-Discovery/discovery-tooling/pull/9846

#### How do you test/verify these changes?
1. For easiest testing, you'll want to link with tooling on the branch for https://github.ibm.com/Watson-Discovery/discovery-tooling/pull/9846
2. Make a query in a project with results you can view in text view (PDFs, for example)
3. Open the Advanced Preview for a result
4. Select some highlight facets. You should see:
  a. Each new highlight added gets its own unique color
  b. There is a set of default colors (from the linked issue above) that are assigned first, followed by random colors
  c. Selected colors are all light enough that you can read the black text on them
  d. Deselecting a facet that had one of the default colors opens that color to be used by the next selected facet
#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
No, since I left the original highlightedIds prop in place and made this a new, optional prop that overrides the old one
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
