### PR TITLE
feat: add styling for overlapping highlights in text view

### DIFF
--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
@@ -30,7 +30,7 @@ export interface CIDocumentContentProps {
   theme?: Theme;
   documentId?: string;
   onItemClick?: OnFieldClickFn;
-  combinedHighlights?: HighlightWithMeta[]; //TODO: reshape this type based on tooling prop
+  combinedHighlights?: HighlightWithMeta[];
 }
 
 const CIDocumentContent: FC<CIDocumentContentProps> = ({
@@ -143,6 +143,7 @@ function createStyleRules(idList: string[], rules: string[]): string {
 function highlightColoringFullArray(combinedHighlightsWithMeta: HighlightWithMeta[]) {
   return combinedHighlightsWithMeta.map(highlightWithMeta => {
     const locationId = getHighlightLocationId(highlightWithMeta);
+    // Set z-index to -1 in order to push non-active fields back
     const rules = `.${baseClassName} .field[data-field-id="${locationId}"] > * {background-color: ${highlightWithMeta.color}; z-index: -1;}`;
     return <style>{rules}</style>;
   });

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
@@ -10,7 +10,8 @@ import { SkeletonText } from 'carbon-components-react';
 import Section, { OnFieldClickFn } from '../Section/Section';
 import VirtualScroll from '../VirtualScroll/VirtualScroll';
 import { defaultTheme, Theme } from 'utils/theme';
-import { SectionType, ItemMap, HighlightIdsByColor } from 'components/CIDocument/types';
+import { SectionType, ItemMap } from 'components/CIDocument/types';
+import { getId as getLocationId } from 'utils/document/idUtils';
 
 const baseClassName = `${settings.prefix}--ci-doc-content`;
 
@@ -29,7 +30,7 @@ export interface CIDocumentContentProps {
   theme?: Theme;
   documentId?: string;
   onItemClick?: OnFieldClickFn;
-  highlightedIdsByColor?: HighlightIdsByColor;
+  combinedHighlights?: any[]; //TODO: reshape this type based on tooling prop
 }
 
 const CIDocumentContent: FC<CIDocumentContentProps> = ({
@@ -47,7 +48,7 @@ const CIDocumentContent: FC<CIDocumentContentProps> = ({
   theme = defaultTheme,
   documentId = '',
   onItemClick = (): void => {},
-  highlightedIdsByColor
+  combinedHighlights
 }) => {
   const virtualScrollRef = useRef<any>();
 
@@ -69,11 +70,9 @@ const CIDocumentContent: FC<CIDocumentContentProps> = ({
       ) : (
         <>
           <style data-testid="style">{docStyles}</style>
-          {!!highlightedIdsByColor &&
-            highlightedIdsByColor.length > 0 &&
-            highlightStyling(highlightedIdsByColor).map(highlightStyleRules => {
-              return <style>{highlightStyleRules}</style>;
-            })}
+          {!!combinedHighlights && combinedHighlights.length > 0 && (
+            <style>{...highlightColoringFullArray(combinedHighlights)}</style>
+          )}
           {(!highlightedIdsByColor || highlightedIds.length <= 0) && (
             <style>
               {createStyleRules(highlightedIds, [
@@ -134,25 +133,21 @@ const CIDocumentContent: FC<CIDocumentContentProps> = ({
   );
 };
 
-function highlightStyling(
-  highlightedLocationIdsByColor: { color: string; highlightLocationIds: string[] }[]
-): string[] {
-  return highlightedLocationIdsByColor.map(highlightData => {
-    const { color, highlightLocationIds } = highlightData;
-
-    return createStyleRules(highlightLocationIds, [
-      backgroundColorRule(color),
-      // Set z-index to -1 in order to push non-active fields back
-      zIndexRule(-1)
-    ]);
-  });
-}
-
 function createStyleRules(idList: string[], rules: string[]): string {
   return idList
     .map(id => `.${baseClassName} .field[data-field-id="${id}"] > *`)
     .join(',')
     .concat(`{${rules.join(';')}}`);
+}
+
+function highlightColoringFullArray(combinedHighlightsWithMeta: any[]) {
+  const combinedHighlightsStyle = combinedHighlightsWithMeta.map(highlightWithMeta => {
+    const locationId = getHighlightLocationId(highlightWithMeta);
+    const rules = `.${baseClassName} .field[data-field-id="${locationId}"] > * {background-color: ${highlightWithMeta.color}; z-index: -1;}`;
+    return <style>{rules}</style>;
+  });
+  console.log('combinedHighlightStyle', combinedHighlightsStyle);
+  return combinedHighlightsStyle;
 }
 
 function backgroundColorRule(color: string): string {
@@ -180,6 +175,16 @@ function scrollToActiveItem(
     itemMap.byItem[activeId],
     `.field[data-field-id="${activeId}"]`
   );
+}
+
+//TODO: type
+function getHighlightLocationId(highlightWithMeta: any): string {
+  return getLocationId({
+    location: {
+      begin: highlightWithMeta.begin,
+      end: highlightWithMeta.end
+    }
+  });
 }
 
 export default CIDocumentContent;

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
@@ -71,7 +71,7 @@ const CIDocumentContent: FC<CIDocumentContentProps> = ({
         <>
           <style data-testid="style">{docStyles}</style>
           {!!combinedHighlights && combinedHighlights.length > 0 && (
-            <style>{...highlightColoringFullArray(combinedHighlights)}</style>
+            <style>{highlightColoringFullArray(combinedHighlights)}</style>
           )}
           {(!combinedHighlights || combinedHighlights.length <= 0) && (
             <style>

--- a/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
+++ b/packages/discovery-react-components/src/components/CIDocument/components/CIDocumentContent/CIDocumentContent.tsx
@@ -10,7 +10,7 @@ import { SkeletonText } from 'carbon-components-react';
 import Section, { OnFieldClickFn } from '../Section/Section';
 import VirtualScroll from '../VirtualScroll/VirtualScroll';
 import { defaultTheme, Theme } from 'utils/theme';
-import { SectionType, ItemMap } from 'components/CIDocument/types';
+import { SectionType, ItemMap, HighlightWithMeta } from 'components/CIDocument/types';
 import { getId as getLocationId } from 'utils/document/idUtils';
 
 const baseClassName = `${settings.prefix}--ci-doc-content`;
@@ -30,7 +30,7 @@ export interface CIDocumentContentProps {
   theme?: Theme;
   documentId?: string;
   onItemClick?: OnFieldClickFn;
-  combinedHighlights?: any[]; //TODO: reshape this type based on tooling prop
+  combinedHighlights?: HighlightWithMeta[]; //TODO: reshape this type based on tooling prop
 }
 
 const CIDocumentContent: FC<CIDocumentContentProps> = ({
@@ -73,7 +73,7 @@ const CIDocumentContent: FC<CIDocumentContentProps> = ({
           {!!combinedHighlights && combinedHighlights.length > 0 && (
             <style>{...highlightColoringFullArray(combinedHighlights)}</style>
           )}
-          {(!highlightedIdsByColor || highlightedIds.length <= 0) && (
+          {(!combinedHighlights || combinedHighlights.length <= 0) && (
             <style>
               {createStyleRules(highlightedIds, [
                 backgroundColorRule(theme.highlightBackground),
@@ -140,14 +140,12 @@ function createStyleRules(idList: string[], rules: string[]): string {
     .concat(`{${rules.join(';')}}`);
 }
 
-function highlightColoringFullArray(combinedHighlightsWithMeta: any[]) {
-  const combinedHighlightsStyle = combinedHighlightsWithMeta.map(highlightWithMeta => {
+function highlightColoringFullArray(combinedHighlightsWithMeta: HighlightWithMeta[]) {
+  return combinedHighlightsWithMeta.map(highlightWithMeta => {
     const locationId = getHighlightLocationId(highlightWithMeta);
     const rules = `.${baseClassName} .field[data-field-id="${locationId}"] > * {background-color: ${highlightWithMeta.color}; z-index: -1;}`;
     return <style>{rules}</style>;
   });
-  console.log('combinedHighlightStyle', combinedHighlightsStyle);
-  return combinedHighlightsStyle;
 }
 
 function backgroundColorRule(color: string): string {
@@ -177,8 +175,7 @@ function scrollToActiveItem(
   );
 }
 
-//TODO: type
-function getHighlightLocationId(highlightWithMeta: any): string {
+function getHighlightLocationId(highlightWithMeta: HighlightWithMeta): string {
   return getLocationId({
     location: {
       begin: highlightWithMeta.begin,

--- a/packages/discovery-react-components/src/components/CIDocument/types.ts
+++ b/packages/discovery-react-components/src/components/CIDocument/types.ts
@@ -99,3 +99,19 @@ export interface Relations {
 }
 
 export type HighlightIdsByColor = { color: string; highlightLocationIds: string[] }[];
+
+export type HighlightFacetMentions = {
+  id: string; // ${begin}_${end}
+  field: string;
+  fieldIndex: number;
+  location: Location;
+  className?: string;
+};
+
+export type HighlightWithMeta = {
+  facetIds: string[];
+  mentions: HighlightFacetMentions[];
+  begin: number;
+  end: number;
+  color: string;
+};


### PR DESCRIPTION
#### What do these changes do/fix?
Contributes to https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/13113
in combination with https://github.ibm.com/Watson-Discovery/discovery-tooling/pull/9903

Reworks the prop we use to take in highlights with unique colors, such that we can display overlapping highlights with their own designated color

<img width="958" alt="Screenshot 2023-06-22 at 2 41 53 PM" src="https://github.com/watson-developer-cloud/discovery-components/assets/11284492/458057b1-8636-4fd0-b5c2-6a947e69bcb0">

When activating a new highlight that overlaps with several of the highlights in the first screenshot:
<img width="959" alt="Screenshot 2023-06-22 at 2 41 37 PM" src="https://github.com/watson-developer-cloud/discovery-components/assets/11284492/9cca1324-92da-4e9b-89e6-e7f3ab3d765b">


<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
1. Link components to tooling, and run locally
2. Find a project and document where facets exist with overlapping highlights (sample project often works for me)
3. Search for results in the above document, and toggle overlapping highlights on and off
  a. When overlapping highlights are both activated, the entire highlights are displayed with Carbon's Purple-50 background
  b. When highlights do not overlap, they retain their original colors, and the rest of highlight styling works as normal
#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?
The prop `combinedHighlights` replaces `highlightedIdsByColor`, which was recently added. I doubt any users have had time to start using the new, optional prop, but this would technically require them to switch to the new prop during an upgrade.
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
