### PR TITLE
fix: tooltip when facet available and border pdf active element

### DIFF
--- a/packages/discovery-react-components/src/components/TooltipHighlight/TooltipHighlight.tsx
+++ b/packages/discovery-react-components/src/components/TooltipHighlight/TooltipHighlight.tsx
@@ -106,7 +106,7 @@ export function calcToolTipContent(
 
   let tooltipContent = undefined;
 
-  if (enrichFacetDisplayname || enrichValue) {
+  if (tableContent.length > 0) {
     tooltipContent = (
       <div className={cx(baseTooltipCustomContent)} data-testid="tooltip_highlight_content">
         <div className={cx(baseTooltipContentHeader)}>

--- a/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
+++ b/packages/discovery-styles/scss/components/document-preview/_document-preview-pdf-viewer.scss
@@ -58,6 +58,7 @@
   position: absolute;
   opacity: 35%;
   background: darken(saturate($highlight, 50%), 50%);
+  border: 2px solid darken(saturate($highlight, 50%), 50%);
   margin: -3px;
   padding: 1px 1px 0px;
   box-sizing: content-box;


### PR DESCRIPTION
#### What do these changes do/fix?

Support feature enabled/ disabled as shown in screenshot

<img width="1704" alt="image" src="https://github.com/watson-developer-cloud/discovery-components/assets/45341518/0e8b6315-76c8-4a77-90f1-74f14868cf9f">



#### How do you test/verify these changes?

Discovery tooling, disable enhanced highlight feature

#### Have you documented your changes (if necessary)?
None

#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
