### PR TITLE
fix: Add position: relative to checkboxes, radio buttons, and data table

### DIFF
--- a/examples/discovery-search-app/src/app.scss
+++ b/examples/discovery-search-app/src/app.scss
@@ -148,3 +148,13 @@ h1 {
     min-height: 0;
   }
 }
+
+.#{$prefix}--checkbox-wrapper,
+.#{$prefix}--radio-button-wrapper,
+.#{$prefix}--data-table {
+  // This is to work around a Chrome quirk where focus on a Carbon checkbox or radio button will
+  // sometimes cause parts of the UI to move upwards, making it partially unusable.
+  position: relative;
+}
+
+


### PR DESCRIPTION
to work around Chromium UI issue.

#### What do these changes do/fix?

https://github.ibm.com/watson-discovery/disco-issue-tracker/issues/17308

Fixes a problem where the UI is shifted upwards after clicking checkboxes or radio buttons in the sample application.


#### How do you test/verify these changes?

**NOTE**: You may need to adjust your screen size to see the issue. I see the problem when the browser height is less than about 800 px.

- In the Discovery Tooling UI, create a Document Retrieval Contracts project.
- Add the Art Effects.pdf document located at \discovery-components\examples\discovery-search-app\public\documents\Art Effects.pdf. Wait for document processing to complete.
- Run the sample app in this repository, pointing to the project you created above.
- In the sample app, open the collection containing the Art Effects.pdf document, then click on the "view passages in document" link displayed in the center pane.  The content of the document is then displayed in the center pane with a list of filter radio buttons and checkboxes in the left pane.
- Click on the Definition radio button in the Nature section of the left pane.

The appropriate text should be selected in the content section, and the UI should not shift upwards.

