### PR TITLE
fix: fixed error in search results due to document title

### DIFF
--- a/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
+++ b/packages/discovery-react-components/src/components/SearchResults/components/Result/Result.tsx
@@ -129,10 +129,6 @@ export const Result: React.FunctionComponent<ResultProps> = ({
 
   let title = getDocumentTitle(result, resultTitleField);
 
-  if (Array.isArray(title)) {
-    title = title[0]; // only first element will be shown if title is array
-  }
-
   const searchResultClasses = [searchResultClass];
   if (isEqual(result, selectedResult.document)) {
     searchResultClasses.push(searchResultSelectedClass);

--- a/packages/discovery-react-components/src/utils/getDocumentTitle.ts
+++ b/packages/discovery-react-components/src/utils/getDocumentTitle.ts
@@ -6,12 +6,23 @@ export const getDocumentTitle = (
   titleField: string
 ): string => {
   if (document) {
-    return (
+    let title =
       get(document, titleField) ||
       get(document, 'extracted_metadata.title') ||
       get(document, 'extracted_metadata.filename') ||
-      document.document_id
-    );
+      document.document_id;
+    if (Array.isArray(title)) {
+      title = title[0]; // only first element will be shown if title is array
+    } else if (typeof title === 'object') {
+      if (title.hasOwnProperty('text') && typeof get(title, 'text') === 'string') {
+        // if title is an object return 'text' field if it exists
+        title = get(title, 'text');
+      } else {
+        // else return toString to prevent the component from crashing
+        title = title.toString();
+      }
+    }
+    return title;
   }
   return '';
 };


### PR DESCRIPTION
#### What do these changes do/fix?
When using search, regardless of user query (empty or with actual strings), the message `There was an error rendering SearchResults`, when the code doesn't find document title where it is supposed to be. With this fix, it handles the case where title is its own separate field in the document with the format `"title": { "a": 1, "text": "title text" }`. If the field title is an object and doesn't have a field `text` in string format, just returns the `toString()` so that would result in displaying [object Object]. This would prevent the component from crashing.

<!--
If there's a related issue, please add a link to the issue here.
-->
Github issue: [16447](https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/16447)

#### How do you test/verify these changes?
1. Download [test.json.zip](https://github.ibm.com/Watson-Discovery/disco-issue-tracker/files/1174563/test.json.zip)
2. Unzip the file
3. Create a collection by uploading test.json
4. Once the collection is created, go to `Improve and Customize`
5. No need to type something in the search bar, just hit enter
6. You should get the results with the `title text` as a part of the results

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
