### PR TITLE
chore: bump react peerDep to include react 18

### DIFF
--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -92,8 +92,8 @@
     "carbon-components": ">= 10.46.0 < 11",
     "carbon-components-react": ">= 7.46.0 < 8",
     "ibm-watson": "^8",
-    "react": ">= 16.8.0 < 18",
-    "react-dom": ">= 16.8.0 < 18"
+    "react": ">= 16.8.0 < 19",
+    "react-dom": ">= 16.8.0 < 19"
   },
   "jest": {
     "resetMocks": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2837,8 +2837,8 @@ __metadata:
     carbon-components: ">= 10.46.0 < 11"
     carbon-components-react: ">= 7.46.0 < 8"
     ibm-watson: ^8
-    react: ">= 16.8.0 < 18"
-    react-dom: ">= 16.8.0 < 18"
+    react: ">= 16.8.0 < 19"
+    react-dom: ">= 16.8.0 < 19"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
#### What do these changes do/fix?
Implementation for https://github.ibm.com/Watson-Discovery/disco-issue-tracker/issues/18222

Bumps the upper limit for react as a peer dependency of the components package. I think this should override the peer dependency in carbon components' 10/7 branch. React 18 shouldn't break anything functionally, but this change allows an app consuming discovery components and using react 18 to build successfully.
<!--
If there's a related issue, please add a link to the issue here.
-->

#### How do you test/verify these changes?
1. Checkout this branch locally, run `yarn` to install the latest package changes
2. Run `yarn why react` and see that the components themselves are still pulling in react 17
3. In the components package directory, run `yarn dlx yalc publish --push` to create a build and push it to a local repository that's linkable in tooling.
    1. If the build fails here, you may need to delete `node_modules` in either the root or components directory and then rerun `yarn`
4. In tooling's client directory, run `yarn dlx yalc add @ibm-watson/discovery-react-components` to link the components build locally
5.  In tooling's `client/package.json`, change `react` and `react-dom` to "^18.2.0", run `yarn`, and then verify with `yarn why react` that react 18 is the version being used
6. Run tooling locally with `yarn run start` and `yarn run api:cloud`. Verify that everything builds, and the react components haven't broken (like by running a query and checking the results)
#### Have you documented your changes (if necessary)?
N/A
#### Are there any breaking changes included in this pull request?
No
<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
