### PR TITLE
docs: tell jekyll to ignore the storybook dir

### DIFF
--- a/packages/discovery-react-components/package.json
+++ b/packages/discovery-react-components/package.json
@@ -30,7 +30,7 @@
     "start": "vite preview",
     "storybook": "storybook dev --ci --port=9002",
     "storybook:build": "storybook build",
-    "storybook:build:release": "cross-env STORYBOOK_BUILD_MODE=production storybook build -o ../../docs/storybook",
+    "storybook:build:release": "cross-env STORYBOOK_BUILD_MODE=production storybook build -o ../../docs/storybook && touch ../../docs/storybook/.nojekyll",
     "analyze": "yarn run g:analyze 'dist/index.js'",
     "preversion": "yarn run storybook:build:release",
     "version": "git add ../../docs"


### PR DESCRIPTION
#### What do these changes do/fix?

Our published [storybook](https://watson-developer-cloud.github.io/discovery-components/storybook/?path=/story/documentpreview--default) isn't loading currently. It gets a 404 when querying storybook files that start with an underscore.

The underlying issue is that jekyll (which is what GH pages uses) ignores files that start with an underscore. To circumvent that, this PR adds a `.nojekyll` ([info](https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/)) file in `docs/storybook`. Hopefully that fixes this issue.

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
