### PR TITLE
fix: return normalized text divs/content values

### DIFF
--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/Highlighter.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/Highlighter.ts
@@ -97,7 +97,7 @@ export class Highlighter {
    * Update text content HTML elements
    * @param textContentDivs HTML elements where text content items are rendered
    */
-  setTextContentDivs(textContentDivs?: HTMLCollection) {
+  setTextContentDivs(textContentDivs?: HTMLCollection | Element[]) {
     this.pdfTextContentLayout?.setDivs(textContentDivs);
   }
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textLayout/PdfTextContentTextLayout.ts
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfHighlight/utils/textLayout/PdfTextContentTextLayout.ts
@@ -12,7 +12,7 @@ import { HtmlBboxInfo, PdfTextContentInfo, TextLayout } from './types';
 export class PdfTextContentTextLayout implements TextLayout<PdfTextContentTextLayoutCell> {
   private readonly textContentInfo: PdfTextContentInfo;
   readonly cells: PdfTextContentTextLayoutCell[];
-  private divs: HTMLCollection | undefined;
+  private divs: HTMLCollection | Element[] | undefined;
 
   constructor(textContentInfo: PdfTextContentInfo, pageNum: number, htmlBboxInfo?: HtmlBboxInfo) {
     this.textContentInfo = textContentInfo;
@@ -48,7 +48,7 @@ export class PdfTextContentTextLayout implements TextLayout<PdfTextContentTextLa
   /**
    * set PDF text content item divs
    */
-  setDivs(divs: HTMLCollection | undefined) {
+  setDivs(divs: HTMLCollection | Element[] | undefined) {
     this.divs = divs;
   }
 

--- a/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewerTextLayer.tsx
+++ b/packages/discovery-react-components/src/components/DocumentPreview/components/PdfViewer/PdfViewerTextLayer.tsx
@@ -29,7 +29,7 @@ export type PdfRenderedText = {
   /**
    * Text span DOM elements rendered on the text layer
    */
-  textDivs: HTMLCollection;
+  textDivs: HTMLCollection | Element[];
 
   /**
    * Pdf page viewport used to render text items
@@ -69,7 +69,7 @@ const PdfViewerTextLayer: FC<PdfViewerTextLayerProps> = ({
       async (signal: AbortSignal) => {
         if (textLayerWrapper && loadedText) {
           const { textContent, viewport, page } = loadedText;
-          let textDivs!: HTMLCollection;
+          let textDivs!: HTMLCollection | Element[];
 
           const builder = new TextLayerBuilder({
             pdfPage: loadedPage,
@@ -86,6 +86,10 @@ const PdfViewerTextLayer: FC<PdfViewerTextLayerProps> = ({
                   textContentItems
                 );
                 adjustTextDivs(normalizedTextDivs, normalizedTextContentItems, scale);
+
+                // update values that will be returned, to use normalized values
+                textDivs = normalizedTextDivs;
+                textContent.items = normalizedTextContentItems;
               }
             }
           });


### PR DESCRIPTION
#### What do these changes do/fix?

Return normalized `textDivs` and `textContent` values (to ensure that they match up with each other). These are passed to the `setRenderedText` callback. Fixes issue where highlights weren't properly positioned over PDF document.

#### How do you test/verify these changes?

#### Have you documented your changes (if necessary)?

#### Are there any breaking changes included in this pull request?

<!-- If there are, please ensure that you have included 'BREAKING CHANGE:' at the beginning of the optional body or footer section of the commit that introduces the breaking change. -->
